### PR TITLE
Several stuff

### DIFF
--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -67,7 +67,7 @@ namespace LuckParser.Controllers
 
             return byt;
         }
-        private int getShort()
+        private ushort getShort()
         {
             byte[] bytes = new byte[2];
             for (int b = 0; b < bytes.Length; b++)
@@ -216,7 +216,7 @@ namespace LuckParser.Controllers
             safeSkip(1);
 
             // 2 bytes: boss instance ID
-            int instid = getShort();
+            ushort instid = getShort();
 
             // 1 byte: position
             safeSkip(1);
@@ -323,7 +323,7 @@ namespace LuckParser.Controllers
             while (stream.Length - stream.Position >= 64)
             {
                 // 8 bytes: time
-                int time = (int)getLong();
+                long time = getLong();
 
                 // 8 bytes: src_agent
                 long src_agent = getLong();
@@ -338,19 +338,19 @@ namespace LuckParser.Controllers
                 int buff_dmg = getInt();
 
                 // 2 bytes: overstack_value
-                int overstack_value = getShort();
+                ushort overstack_value = getShort();
 
                 // 2 bytes: skill_id
-                int skill_id = getShort();
+                ushort skill_id = getShort();
 
                 // 2 bytes: src_instid
-                int src_instid = getShort();
+                ushort src_instid = getShort();
 
                 // 2 bytes: dst_instid
-                int dst_instid = getShort();
+                ushort dst_instid = getShort();
 
                 // 2 bytes: src_master_instid
-                int src_master_instid = getShort();
+                ushort src_master_instid = getShort();
 
                 // 9 bytes: garbage
                 safeSkip(9);
@@ -360,7 +360,7 @@ namespace LuckParser.Controllers
                IFF iff = new IFF(Convert.ToByte(stream.ReadByte())); //Convert.ToByte(stream.ReadByte());
 
                 // 1 byte: buff
-                int buff = stream.ReadByte();
+                ushort buff = (ushort)stream.ReadByte();
 
                 // 1 byte: result
                 //Result result = Result.getEnum(f.read());
@@ -375,23 +375,23 @@ namespace LuckParser.Controllers
                 BuffRemove is_buffremoved = new BuffRemove(Convert.ToByte(stream.ReadByte()));
 
                 // 1 byte: is_ninety
-                int is_ninety = stream.ReadByte();
+                ushort is_ninety = (ushort)stream.ReadByte();
 
                 // 1 byte: is_fifty
-                int is_fifty = stream.ReadByte();
+                ushort is_fifty = (ushort)stream.ReadByte();
 
                 // 1 byte: is_moving
-                int is_moving = stream.ReadByte();
+                ushort is_moving = (ushort)stream.ReadByte();
 
                 // 1 byte: is_statechange
                 //StateChange is_statechange = StateChange.getEnum(f.read());
                 StateChange is_statechange = new StateChange(Convert.ToByte(stream.ReadByte()));
 
                 // 1 byte: is_flanking
-                int is_flanking = stream.ReadByte();
+                ushort is_flanking = (ushort)stream.ReadByte();
 
                 // 1 byte: is_flanking
-                int is_shields = stream.ReadByte();
+                ushort is_shields = (ushort)stream.ReadByte();
                 // 2 bytes: garbage
                 safeSkip(2);
 
@@ -455,7 +455,7 @@ namespace LuckParser.Controllers
                     boss_data.setLastAware(NPC.getLastAware());
                 }
             }
-            List<int[]> bossHealthOverTime = new List<int[]>();
+            List<long[]> bossHealthOverTime = new List<long[]>();
 
             // Grab values threw combat data
             foreach (CombatItem c in combat_list)
@@ -479,11 +479,11 @@ namespace LuckParser.Controllers
                     }
                     else if (c.isStateChange().getID() == 9)//Log start
                     {
-                        log_data.setLogStart(c.getValue());
+                        log_data.setLogStart((long)c.getValue());
                     }
                     else if (c.isStateChange().getID() == 10)//log end
                     {
-                        log_data.setLogEnd(c.getValue());
+                        log_data.setLogEnd((long)c.getValue());
 
                     }
                     //set boss dead
@@ -495,7 +495,7 @@ namespace LuckParser.Controllers
                     //set health update
                     if (c.getSrcInstid() == boss_data.getInstid() && c.isStateChange().getID() == 8)
                     {
-                        bossHealthOverTime.Add(new int[] { c.getTime() - boss_data.getFirstAware(), (int)c.getDstAgent() });
+                        bossHealthOverTime.Add(new long[] { c.getTime() - boss_data.getFirstAware(), c.getDstAgent() });
                     }
                 
 
@@ -510,7 +510,7 @@ namespace LuckParser.Controllers
                 {
                     if (NPC.getProf().Contains("16286"))
                     {
-                        bossHealthOverTime = new List<int[]>();//reset boss health over time
+                        bossHealthOverTime = new List<long[]>();//reset boss health over time
                         xera_2_instid = NPC.getInstid();
                         boss_data.setHealth(24085950);
                         boss_data.setLastAware(NPC.getLastAware());
@@ -527,7 +527,7 @@ namespace LuckParser.Controllers
                             //set health update
                             if (c.getSrcInstid() == boss_data.getInstid() && c.isStateChange().getID() == 8)
                             {
-                                bossHealthOverTime.Add(new int[] { c.getTime() - boss_data.getFirstAware(), (int)c.getDstAgent() });
+                                bossHealthOverTime.Add(new long[] { c.getTime() - boss_data.getFirstAware(), c.getDstAgent() });
                             }
                         }
                         break;
@@ -575,7 +575,7 @@ namespace LuckParser.Controllers
                 }
             }
             // Sort
-            p_list = p_list.OrderBy(a => Int32.Parse(a.getGroup())).ToList();//p_list.Sort((a, b)=>Int32.Parse(a.getGroup()) - Int32.Parse(b.getGroup()))
+            p_list = p_list.OrderBy(a => int.Parse(a.getGroup())).ToList();//p_list.Sort((a, b)=>int.Parse(a.getGroup()) - int.Parse(b.getGroup()))
             getBossKilled();
             setMechData();
         }
@@ -659,24 +659,24 @@ namespace LuckParser.Controllers
             {
                 dps = damage / fight_duration;
             }
-            totalAll_dps = (Int32)dps;
-            totalAll_damage = (Int32)damage;
+            totalAll_dps = (int)dps;
+            totalAll_damage = (int)damage;
             //Allcondi
             damage = p.getDamageLogs(0, b_data, c_data.getCombatList(), getAgentData()).Where(x => x.isCondi() > 0).Sum(x => x.getDamage());
             if (fight_duration > 0)
             {
                 dps = damage / fight_duration;
             }
-            totalAllcondi_dps = (Int32)dps;
-            totalAllcondi_damage = (Int32)damage;
+            totalAllcondi_dps = (int)dps;
+            totalAllcondi_damage = (int)damage;
             //All Power
             damage = totalAll_damage - damage;
             if (fight_duration > 0)
             {
                 dps = damage / fight_duration;
             }
-            totalAllphys_dps = (Int32)dps;
-            totalAllphys_damage = (Int32)damage;
+            totalAllphys_dps = (int)dps;
+            totalAllphys_damage = (int)damage;
 
             // boss DPS
             damage = p.getDamageLogs(b_data.getInstid(), b_data, c_data.getCombatList(), getAgentData()).Sum(x => x.getDamage());//p.getDamageLogs(b_data, c_data.getCombatList()).stream().mapToDouble(DamageLog::getDamage).sum();
@@ -684,24 +684,24 @@ namespace LuckParser.Controllers
             {
                 dps = damage / fight_duration;
             }
-            totalboss_dps = (Int32)dps;
-            totalboss_damage = (Int32)damage;
+            totalboss_dps = (int)dps;
+            totalboss_damage = (int)damage;
             //bosscondi
             damage = p.getDamageLogs(b_data.getInstid(), b_data, c_data.getCombatList(), getAgentData()).Where(x => x.isCondi() > 0).Sum(x => x.getDamage());
             if (fight_duration > 0)
             {
                 dps = damage / fight_duration;
             }
-            totalbosscondi_dps = (Int32)dps;
-            totalbosscondi_damage = (Int32)damage;
+            totalbosscondi_dps = (int)dps;
+            totalbosscondi_damage = (int)damage;
             //boss Power
             damage = totalboss_damage - damage;
             if (fight_duration > 0)
             {
                 dps = damage / fight_duration;
             }
-            totalbossphys_dps = (Int32)dps;
-            totalbossphys_damage = (Int32)damage;
+            totalbossphys_dps = (int)dps;
+            totalbossphys_damage = (int)damage;
             //Placeholders for further calc
             return totalAll_dps.ToString() + "|" + totalAll_damage.ToString() + "|" + totalAllphys_dps.ToString() + "|" + totalAllphys_damage.ToString() + "|" + totalAllcondi_dps.ToString() + "|" + totalAllcondi_damage.ToString() + "|"
                 + totalboss_dps.ToString() + "|" + totalboss_damage.ToString() + "|" + totalbossphys_dps.ToString() + "|" + totalbossphys_damage.ToString() + "|" + totalbosscondi_dps.ToString() + "|" + totalbosscondi_damage.ToString();
@@ -864,7 +864,7 @@ namespace LuckParser.Controllers
             double died = 0.0;
             if (dead.Count() > 0)
             {
-                died = dead[0].X - b_data.getFirstAware();
+                died = (long)dead[0].X - b_data.getFirstAware();
             }
 
             statsArray = new string[] { power_loop_count.ToString(), critical_rate.ToString(), scholar_rate.ToString(), moving_rate.ToString(),
@@ -925,7 +925,7 @@ namespace LuckParser.Controllers
             double died = 0.0;
             if (dead.Count() > 0)
             {
-                died = dead[0].X - b_data.getFirstAware();
+                died = (long)dead[0].X - b_data.getFirstAware();
             }
             String[] statsArray = new string[] { damagetaken.ToString(),
                 blocked.ToString(),"0"/*dmgblocked.ToString()*/,invulned.ToString(),dmginvulned.ToString(),
@@ -1074,12 +1074,12 @@ namespace LuckParser.Controllers
 
                 List<Point> down = c_data.getStates(p.getInstid(), "CHANGE_DOWN");
                 foreach (Point pnt in down) {
-                    mech_data.AddItem(new MechanicLog((int)((pnt.X -boss_data.getFirstAware())/ 1000f), 0, "DOWN", 0, p, mech_data.GetPLoltyShape("DOWN")));
+                    mech_data.AddItem(new MechanicLog((long)(((long)pnt.X -boss_data.getFirstAware())/ 1000f), 0, "DOWN", 0, p, mech_data.GetPLoltyShape("DOWN")));
                 }
                 List<Point> dead = c_data.getStates(p.getInstid(), "CHANGE_DEAD");
                 foreach (Point pnt in dead)
                 {
-                    mech_data.AddItem(new MechanicLog((int)((pnt.X - boss_data.getFirstAware() )/ 1000f), 0, "DEAD", 0, p, mech_data.GetPLoltyShape("DEAD")));
+                    mech_data.AddItem(new MechanicLog((long)(((long)pnt.X - boss_data.getFirstAware() )/ 1000f), 0, "DEAD", 0, p, mech_data.GetPLoltyShape("DEAD")));
                 }
                 List<DamageLog> dls = p.getDamageTakenLogs(boss_data, combat_data.getCombatList(), agent_data, mech_data);
                 //damage taken 
@@ -1094,7 +1094,7 @@ namespace LuckParser.Controllers
                             //Prevent multi hit attacks form multi registering
                             if (prevMech != null)
                             {
-                                if (dLog.getID() == prevMech.GetSkill() && mech.GetName() == prevMech.GetName() && (int)(dLog.getTime() / 1000f) == prevMech.GetTime())
+                                if (dLog.getID() == prevMech.GetSkill() && mech.GetName() == prevMech.GetName() && (dLog.getTime() / 1000f) == prevMech.GetTime())
                                 {
                                     break;
                                 }
@@ -1103,7 +1103,7 @@ namespace LuckParser.Controllers
                             {
                                 
                                 
-                                 prevMech = new MechanicLog((int)(dLog.getTime() / 1000f), dLog.getID(), mech.GetName(), dLog.getDamage(), p, mech.GetPlotly());
+                                 prevMech = new MechanicLog((long)(dLog.getTime() / 1000f), dLog.getID(), mech.GetName(), dLog.getDamage(), p, mech.GetPlotly());
                                 
                                 mech_data.AddItem(prevMech);
                                 break;
@@ -1123,7 +1123,7 @@ namespace LuckParser.Controllers
                             {
                                 if (c.getSkillID() == mech.GetSkill())
                                 {
-                                    mech_data.AddItem(new MechanicLog((int)((c.getTime() - boss_data.getFirstAware())/1000f), c.getSkillID(), mech.GetName(), c.getValue(), p, mech.GetPlotly()));
+                                    mech_data.AddItem(new MechanicLog((long)((c.getTime() - boss_data.getFirstAware())/1000f), c.getSkillID(), mech.GetName(), c.getValue(), p, mech.GetPlotly()));
                                     break;
                                 }
                             }
@@ -1194,7 +1194,7 @@ namespace LuckParser.Controllers
                                 if (Math.Floor(time / 1000f) > timeGraphed)
                                 {
                                     timeGraphed = (int)Math.Floor(time / 1000f);
-                                    pointlist.Add(new Point(time / 1000, stack));
+                                    pointlist.Add(new Point(time / 1000, (int)stack));
                                 }
                                 time++;
                             }
@@ -1226,7 +1226,7 @@ namespace LuckParser.Controllers
 
                     totaldmg += log.getDamage();
 
-                    int time = log.getTime();
+                    long time = log.getTime();
                     if (time > 1000)
                     {
 
@@ -1237,7 +1237,7 @@ namespace LuckParser.Controllers
                             if ((Math.Floor(time / 1000f) - timeGraphed) < 2)
                             {
                                 timeGraphed = (int)Math.Floor(time / 1000f);
-                                bossdmgList.Add(new int[] { time / 1000, (int)(totaldmg / (float)(time / 1000f)) });
+                                bossdmgList.Add(new int[] { (int)time / 1000, (int)(totaldmg / (float)(time / 1000f)) });
                             }
                             else
                             {
@@ -1290,7 +1290,7 @@ namespace LuckParser.Controllers
             foreach (DamageLog log in damage_logs_all)
             {
                 totaldmg += log.getDamage();
-                int time = log.getTime();
+                long time = log.getTime();
                 if (time > 1000)
                 {
                     
@@ -1300,7 +1300,7 @@ namespace LuckParser.Controllers
                         if ((Math.Floor(time / 1000f) - timeGraphed) < 2)
                         {
                             timeGraphed = (int)Math.Floor(time / 1000f);
-                            totaldmgList.Add(new int[] { time / 1000, (int)(totaldmg / (float)(time / 1000f)) });
+                            totaldmgList.Add(new int[] { (int)time / 1000, (int)(totaldmg / (float)(time / 1000f)) });
                         }
                         else
                         {
@@ -1613,7 +1613,7 @@ namespace LuckParser.Controllers
                 int mechcount = 0;
                 foreach (MechanicLog ml in filterdList)
                 {
-                    int[] check = getBossDPSGraph(ml.GetPlayer()).FirstOrDefault(x => x[0] == ml.GetTime());
+                    int[] check = getBossDPSGraph(ml.GetPlayer()).FirstOrDefault(x => (long)x[0] == ml.GetTime());
                     if (mechcount == filterdList.Count - 1)
                     {
                         if (check != null)
@@ -1705,7 +1705,7 @@ namespace LuckParser.Controllers
                 sw.Write("y: [");
                 foreach (MechanicLog ml in DnDList)
                 {
-                    int[] check = getBossDPSGraph(ml.GetPlayer()).FirstOrDefault(x => x[0] == ml.GetTime());
+                    int[] check = getBossDPSGraph(ml.GetPlayer()).FirstOrDefault(x => (long)x[0] == ml.GetTime());
                     if (mcount == DnDList.Count - 1)
                     {
                         if (check != null)
@@ -1792,8 +1792,8 @@ namespace LuckParser.Controllers
 
                 float scaler = boss_data.getHealth() / maxDPS;
                 int hotCount = 0;
-                List<int[]> BossHOT = boss_data.getHealthOverTime();
-                foreach (int[] dp in BossHOT)
+                List<long[]> BossHOT = boss_data.getHealthOverTime();
+                foreach (long[] dp in BossHOT)
                 {
                     if (hotCount == BossHOT.Count - 1)
                     {
@@ -1813,7 +1813,7 @@ namespace LuckParser.Controllers
 
                 float scaler2 = boss_data.getHealth() / 100;
                 hotCount = 0;
-                foreach (int[] dp in BossHOT)
+                foreach (long[] dp in BossHOT)
                 {
                     if (hotCount == BossHOT.Count - 1)
                     {
@@ -1831,7 +1831,7 @@ namespace LuckParser.Controllers
                 //add time axis
                 sw.Write("x: [");
                 hotCount = 0;
-                foreach (int[] dp in BossHOT)
+                foreach (long[] dp in BossHOT)
                 {
                     if (hotCount == BossHOT.Count - 1)
                     {
@@ -1880,7 +1880,7 @@ namespace LuckParser.Controllers
             int firstGroup = 11;
             foreach (Player play in p_list)
             {
-                int playerGroup = Int32.Parse(play.getGroup());
+                int playerGroup = int.Parse(play.getGroup());
                 if (playerGroup > groupCount)
                 {
                     groupCount = playerGroup;
@@ -1897,7 +1897,7 @@ namespace LuckParser.Controllers
                 for (int n = firstGroup; n <= groupCount; n++)
                 {
                     sw.Write("<tr>");
-                    List<Player> sortedList = p_list.Where(x => Int32.Parse(x.getGroup()) == n).ToList();
+                    List<Player> sortedList = p_list.Where(x => int.Parse(x.getGroup()) == n).ToList();
                     if (sortedList.Count > 0)
                     {
                         foreach (Player gPlay in sortedList)
@@ -2013,12 +2013,12 @@ namespace LuckParser.Controllers
                             sw.Write("<td></td>");
                             sw.Write("<td>Group " + groupNum + "</td>");
                             sw.Write("<td></td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Int32.Parse(c[8])) + " dmg \">" + groupList.Sum(c => Int32.Parse(c[7])) + "</span>" + "</td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Int32.Parse(c[10])) + " dmg \">" + groupList.Sum(c => Int32.Parse(c[9])) + "</span>" + "</td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Int32.Parse(c[12])) + " dmg \">" + groupList.Sum(c => Int32.Parse(c[11])) + "</span>" + "</td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Int32.Parse(c[2])) + " dmg \">" + groupList.Sum(c => Int32.Parse(c[1])) + "</span>" + "</td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Int32.Parse(c[4])) + " dmg \">" + groupList.Sum(c => Int32.Parse(c[3])) + "</span>" + "</td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Int32.Parse(c[6])) + " dmg \">" + groupList.Sum(c => Int32.Parse(c[5])) + "</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => int.Parse(c[8])) + " dmg \">" + groupList.Sum(c => int.Parse(c[7])) + "</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => int.Parse(c[10])) + " dmg \">" + groupList.Sum(c => int.Parse(c[9])) + "</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => int.Parse(c[12])) + " dmg \">" + groupList.Sum(c => int.Parse(c[11])) + "</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => int.Parse(c[2])) + " dmg \">" + groupList.Sum(c => int.Parse(c[1])) + "</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => int.Parse(c[4])) + " dmg \">" + groupList.Sum(c => int.Parse(c[3])) + "</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => int.Parse(c[6])) + " dmg \">" + groupList.Sum(c => int.Parse(c[5])) + "</span>" + "</td>");
                             sw.Write("<td></td>");
                             sw.Write("<td></td>");
                         }
@@ -2030,12 +2030,12 @@ namespace LuckParser.Controllers
                         sw.Write("<td></td>");
                         sw.Write("<td>Total</td>");
                         sw.Write("<td></td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Int32.Parse(c[8])) + " dmg \">" + footerList.Sum(c => Int32.Parse(c[7])) + "</span>" + "</td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Int32.Parse(c[10])) + " dmg \">" + footerList.Sum(c => Int32.Parse(c[9])) + "</span>" + "</td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Int32.Parse(c[12])) + " dmg \">" + footerList.Sum(c => Int32.Parse(c[11])) + "</span>" + "</td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Int32.Parse(c[2])) + " dmg \">" + footerList.Sum(c => Int32.Parse(c[1])) + "</span>" + "</td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Int32.Parse(c[4])) + " dmg \">" + footerList.Sum(c => Int32.Parse(c[3])) + "</span>" + "</td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Int32.Parse(c[6])) + " dmg \">" + footerList.Sum(c => Int32.Parse(c[5])) + "</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => int.Parse(c[8])) + " dmg \">" + footerList.Sum(c => int.Parse(c[7])) + "</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => int.Parse(c[10])) + " dmg \">" + footerList.Sum(c => int.Parse(c[9])) + "</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => int.Parse(c[12])) + " dmg \">" + footerList.Sum(c => int.Parse(c[11])) + "</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => int.Parse(c[2])) + " dmg \">" + footerList.Sum(c => int.Parse(c[1])) + "</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => int.Parse(c[4])) + " dmg \">" + footerList.Sum(c => int.Parse(c[3])) + "</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => int.Parse(c[6])) + " dmg \">" + footerList.Sum(c => int.Parse(c[5])) + "</span>" + "</td>");
                         sw.Write("<td></td>");
                         sw.Write("<td></td>");
                     }
@@ -2130,13 +2130,13 @@ namespace LuckParser.Controllers
                             sw.Write("<td>" + (int)(100 * groupList.Sum(c => Double.Parse(c[4]) / Double.Parse(c[1])) / groupList.Count) + "%</td>");
                             sw.Write("<td>" + (int)(100 * groupList.Sum(c => Double.Parse(c[5]) / Double.Parse(c[1])) / groupList.Count) + "%</td>");
                             sw.Write("<td>" + (int)(100 * groupList.Sum(c => Double.Parse(c[6]) / Double.Parse(c[1])) / groupList.Count) + "%</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[7])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[8])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[9])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[7])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[8])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[9])) + "</td>");
                             sw.Write("<td></td>");
                             sw.Write("<td></td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[10])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[11])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[10])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[11])) + "</td>");
                             sw.Write("<td></td>");
                         }
                         sw.Write("</tr>");
@@ -2151,13 +2151,13 @@ namespace LuckParser.Controllers
                         sw.Write("<td>" + (int)(100 * footerList.Sum(c => Double.Parse(c[4]) / Double.Parse(c[1])) / footerList.Count) + "%</td>");
                         sw.Write("<td>" + (int)(100 * footerList.Sum(c => Double.Parse(c[5]) / Double.Parse(c[1])) / footerList.Count) + "%</td>");
                         sw.Write("<td>" + (int)(100 * footerList.Sum(c => Double.Parse(c[6]) / Double.Parse(c[1])) / footerList.Count) + "%</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[7])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[8])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[9])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[7])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[8])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[9])) + "</td>");
                         sw.Write("<td></td>");
                         sw.Write("<td></td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[10])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[11])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[10])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[11])) + "</td>");
                         sw.Write("<td></td>");
                     }
                     sw.Write("</tr>");
@@ -2236,13 +2236,13 @@ namespace LuckParser.Controllers
                             sw.Write("<td></td>");
                             sw.Write("<td></td>");
                             sw.Write("<td>Group " + groupNum + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[1])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[2])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[3])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[4])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[5])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[6])) + "</td>");
-                            sw.Write("<td>" + groupList.Sum(c => Int32.Parse(c[7])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[1])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[2])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[3])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[4])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[5])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[6])) + "</td>");
+                            sw.Write("<td>" + groupList.Sum(c => int.Parse(c[7])) + "</td>");
                             sw.Write("<td></td>");
                         }
                         sw.Write("</tr>");
@@ -2252,13 +2252,13 @@ namespace LuckParser.Controllers
                         sw.Write("<td></td>");
                         sw.Write("<td></td>");
                         sw.Write("<td>Total</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[1])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[2])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[3])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[4])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[5])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[6])) + "</td>");
-                        sw.Write("<td>" + footerList.Sum(c => Int32.Parse(c[7])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[1])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[2])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[3])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[4])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[5])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[6])) + "</td>");
+                        sw.Write("<td>" + footerList.Sum(c => int.Parse(c[7])) + "</td>");
                         sw.Write("<td></td>");
                     }
                     sw.Write("</tr>");
@@ -2318,8 +2318,8 @@ namespace LuckParser.Controllers
                             sw.Write("<td></td>");
                             sw.Write("<td></td>");
                             sw.Write("<td>Group " + groupNum + "</td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Double.Parse(c[1])).ToString() + " seconds \">" + groupList.Sum(c => Int32.Parse(c[2])).ToString() + " condis</span>" + "</td>");
-                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Double.Parse(c[3])).ToString() + " seconds \">" + groupList.Sum(c => Int32.Parse(c[4])) + "</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Double.Parse(c[1])).ToString() + " seconds \">" + groupList.Sum(c => int.Parse(c[2])).ToString() + " condis</span>" + "</td>");
+                            sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + groupList.Sum(c => Double.Parse(c[3])).ToString() + " seconds \">" + groupList.Sum(c => int.Parse(c[4])) + "</span>" + "</td>");
                         }
                         sw.Write("</tr>");
                     }
@@ -2328,8 +2328,8 @@ namespace LuckParser.Controllers
                         sw.Write("<td></td>");
                         sw.Write("<td></td>");
                         sw.Write("<td>Total</td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Double.Parse(c[1])).ToString() + " seconds \">" + footerList.Sum(c => Int32.Parse(c[2])).ToString() + " condis</span>" + "</td>");
-                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Double.Parse(c[3])).ToString() + " seconds \">" + footerList.Sum(c => Int32.Parse(c[4])).ToString() + "</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Double.Parse(c[1])).ToString() + " seconds \">" + footerList.Sum(c => int.Parse(c[2])).ToString() + " condis</span>" + "</td>");
+                        sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + footerList.Sum(c => Double.Parse(c[3])).ToString() + " seconds \">" + footerList.Sum(c => int.Parse(c[4])).ToString() + "</span>" + "</td>");
                     }
                     sw.Write("</tr>");
                 }
@@ -3297,8 +3297,8 @@ namespace LuckParser.Controllers
             List<DamageLog> damageToKill = new List<DamageLog>(); ;
             if (down.Count > 0)
             {//went to down state before death
-                damageToDown = damageLogs.Where(x => x.getTime() < down.Last().X-b_data.getFirstAware()).ToList();
-                damageToKill = damageLogs.Where(x => x.getTime() > down.Last().X - b_data.getFirstAware() && x.getTime() < dead.Last().X - b_data.getFirstAware()).ToList();
+                damageToDown = damageLogs.Where(x => x.getTime() < (long)down.Last().X-b_data.getFirstAware()).ToList();
+                damageToKill = damageLogs.Where(x => x.getTime() > (long)down.Last().X - b_data.getFirstAware() && x.getTime() < (long)dead.Last().X - b_data.getFirstAware()).ToList();
                 //Filter last 30k dmg taken
                 int totaldmg = 0;
                 for (int i = damageToDown.Count() - 1; i > 0; i--)
@@ -3325,7 +3325,7 @@ namespace LuckParser.Controllers
             }
             else
             {
-                damageToKill = damageLogs.Where(x =>  x.getTime() < dead.Last().X).ToList();
+                damageToKill = damageLogs.Where(x =>  x.getTime() < (long)dead.Last().X).ToList();
                 //Filter last 30k dmg taken
                 int totaldmg = 0;
                 for (int i = damageToKill.Count() - 1; i > 0; i--)
@@ -3813,7 +3813,7 @@ namespace LuckParser.Controllers
             BossData b_data = getBossData();
             // List<CastLog> casting = p.getCastLogs(b_data, c_data.getCombatList(), getAgentData());
 
-            List<DamageLog> damageLogs = p.getMinionDamageLogs((int)agent.getAgent(), b_data, c_data.getCombatList(), getAgentData());
+            List<DamageLog> damageLogs = p.getMinionDamageLogs(agent.getAgent(), b_data, c_data.getCombatList(), getAgentData());
             SkillData s_data = getSkillData();
             List<SkillItem> s_list = s_data.getSkillList();
             int finalTotalDamage = damageLogs.Sum(x => x.getDamage());

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -465,39 +465,38 @@ namespace LuckParser.Controllers
                     boss_data.setHealth((int)c.getDstAgent());
 
                 }
-                    if (c.isStateChange().getID() == 13 && log_data.getPOV() == "N/A")//Point of View
+                if (c.isStateChange().getID() == 13 && log_data.getPOV() == "N/A")//Point of View
+                {
+                    long pov_agent = c.getSrcAgent();
+                    foreach (AgentItem p in player_list)
                     {
-                        long pov_agent = c.getSrcAgent();
-                        foreach (AgentItem p in player_list)
+                        if (pov_agent == p.getAgent())
                         {
-                            if (pov_agent == p.getAgent())
-                            {
-                                log_data.setPOV(p.getName());
-                            }
+                            log_data.setPOV(p.getName());
                         }
+                    }
 
-                    }
-                    else if (c.isStateChange().getID() == 9)//Log start
-                    {
-                        log_data.setLogStart((long)c.getValue());
-                    }
-                    else if (c.isStateChange().getID() == 10)//log end
-                    {
-                        log_data.setLogEnd((long)c.getValue());
+                }
+                else if (c.isStateChange().getID() == 9)//Log start
+                {
+                    log_data.setLogStart((long)c.getValue());
+                }
+                else if (c.isStateChange().getID() == 10)//log end
+                {
+                    log_data.setLogEnd((long)c.getValue());
 
-                    }
-                    //set boss dead
-                    if (c.getSrcInstid() == boss_data.getInstid() && c.isStateChange().getID() == 4)//change dead
-                    {
-                        log_data.setBossKill(true);
+                }
+                //set boss dead
+                if (c.isStateChange().getEnum() == "REWARD")//change dead
+                {
+                    log_data.setBossKill(true);
 
-                    }
-                    //set health update
-                    if (c.getSrcInstid() == boss_data.getInstid() && c.isStateChange().getID() == 8)
-                    {
-                        bossHealthOverTime.Add(new long[] { c.getTime() - boss_data.getFirstAware(), c.getDstAgent() });
-                    }
-                
+                }
+                //set health update
+                if (c.getSrcInstid() == boss_data.getInstid() && c.isStateChange().getID() == 8)
+                {
+                    bossHealthOverTime.Add(new long[] { c.getTime() - boss_data.getFirstAware(), c.getDstAgent() });
+                }
 
             }
 
@@ -543,6 +542,11 @@ namespace LuckParser.Controllers
                     if (NPC.getProf().Contains("57069"))
                     {
                         deimos_2_instid = NPC.getInstid();
+                        if (NPC.getLastAware() < boss_data.getLastAware())
+                        {
+                            // No split
+                            break;
+                        }
                         boss_data.setLastAware(NPC.getLastAware());
                         //List<CombatItem> fuckyou = combat_list.Where(x => x.getDstInstid() == deimos_2_instid ).ToList().Sum(x);
                         //int stop = 0;
@@ -1692,14 +1696,12 @@ namespace LuckParser.Controllers
             }
             //Downs and deaths
 
-
-            int mcount = 0;
-
             List<String> DnDStringList = new List<string>();
             DnDStringList.Add("DOWN");
             DnDStringList.Add("DEAD");
             foreach (string state in DnDStringList)
             {
+                int mcount = 0;
                 List<MechanicLog> DnDList = mech_data.GetMDataLogs().Where(x => x.GetName() == state).ToList();
                 sw.Write("{");
                 sw.Write("y: [");
@@ -4768,7 +4770,7 @@ namespace LuckParser.Controllers
                                                             }
                                                             sw.Write("<div class=\"progress-bar bg-danger\" role=\"progressbar\" style=\"width:" + finalPercent + "%; ;display: inline-block;\" aria-valuenow=\"100\" aria-valuemin=\"0\" aria-valuemax=\"100\">");
                                                             {
-                                                                sw.Write("<p style=\"text-align:center; color: #FFF;\">" + getBossData().getHealth().ToString() + " Health</p>");
+                                                                sw.Write("<p style=\"text-align:center; color: #FFF;\">" + (getBossData().getHealth() * finalPercent/100.0).ToString() + " Health</p>");
                                                             }
                                                             sw.Write("</div>");
                                                         }
@@ -4777,10 +4779,6 @@ namespace LuckParser.Controllers
                                                     if (log_data.getBosskill())
                                                     {
                                                         sw.Write("<p class='text text-success'> Result: Success</p>");
-                                                    }
-                                                    else if (boss_data.getID() == 17154)//Deimos is fucked
-                                                    {
-                                                        sw.Write("<p class='text'> Result: N/A</p>");
                                                     }
                                                     else
                                                     {

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -585,41 +585,50 @@ namespace LuckParser.Controllers
         public List<Boon> present_offbuffs = new List<Boon>();//Used only for Off Buff tables
         public List<Boon> present_defbuffs = new List<Boon>();//Used only for Def Buff tables
         public Dictionary<int, List<Boon>> present_personnal = new Dictionary<int, List<Boon>>();//Used only for personnal
-        public void setPresentBoons() {
+        public void setPresentBoons(bool[] SnapSettings) {
             List<SkillItem> s_list = getSkillData().getSkillList();
-            foreach (Boon boon in Boon.getBoonList())
-            {
-                if (s_list.Exists(x => x.getID() == boon.getID()))
+            if (SnapSettings[3])
+            {//Main boons
+                foreach (Boon boon in Boon.getBoonList())
                 {
-                    present_boons.Add(boon);
-                }
-            }
-            foreach (Boon boon in Boon.getOffensiveList())
-            {
-                if (s_list.Exists(x => x.getID() == boon.getID()))
-                {
-                    present_offbuffs.Add(boon);
-                }
-            }
-            foreach (Boon boon in Boon.getDefensiveList())
-            {
-                if (s_list.Exists(x => x.getID() == boon.getID()))
-                {
-                    present_defbuffs.Add(boon);
-                }
-            }
-            List<CombatItem> c_data = getCombatData().getCombatList();
-            foreach (Player p in p_list)
-            {
-                present_personnal[p.getInstid()] = new List<Boon>();
-                foreach (Boon boon in Boon.getRemainingBuffsList(Boon.ProfToEnum(p.getProf())))
-                {
-                    if (c_data.Exists(x => x.getSkillID() == boon.getID() && x.getDstInstid() == p.getInstid()))
+                    if (s_list.Exists(x => x.getID() == boon.getID()))
                     {
-                        present_personnal[p.getInstid()].Add(boon);
+                        present_boons.Add(boon);
                     }
                 }
             }
+            if (SnapSettings[4])
+            {//Important Class specefic boons
+                foreach (Boon boon in Boon.getOffensiveList())
+                {
+                    if (s_list.Exists(x => x.getID() == boon.getID()))
+                    {
+                        present_offbuffs.Add(boon);
+                    }
+                }
+                foreach (Boon boon in Boon.getDefensiveList())
+                {
+                    if (s_list.Exists(x => x.getID() == boon.getID()))
+                    {
+                        present_defbuffs.Add(boon);
+                    }
+                }
+            }
+            if (SnapSettings[5])
+            {//All class specefic boons
+                List<CombatItem> c_data = getCombatData().getCombatList();
+                foreach (Player p in p_list)
+                {
+                    present_personnal[p.getInstid()] = new List<Boon>();
+                    foreach (Boon boon in Boon.getRemainingBuffsList(Boon.ProfToEnum(p.getProf())))
+                    {
+                        if (c_data.Exists(x => x.getSkillID() == boon.getID() && x.getDstInstid() == p.getInstid()))
+                        {
+                            present_personnal[p.getInstid()].Add(boon);
+                        }
+                    }
+                }
+            }        
         }
         public String getFinalDPS(Player p)
         {
@@ -2840,21 +2849,9 @@ namespace LuckParser.Controllers
                                             sw.Write(" },");
                                         }
                                     }
-                                    if (SnapSettings[3] || SnapSettings[4] || SnapSettings[5])
+                                    if (present_boons.Count() > 0)
                                     {
-                                        List<Boon> parseBoonsList = new List<Boon>();
-                                        /*if (SnapSettings[3])
-                                        {//Main boons
-                                            parseBoonsList.AddRange(Boon.getBoonList());
-                                        }
-                                        if (SnapSettings[4] || SnapSettings[5])
-                                        {//Important Class specefic boons
-                                            parseBoonsList.AddRange(Boon.getSharableProfList());
-                                        }
-                                        if (SnapSettings[5])
-                                        {//All class specefic boons
-                                            parseBoonsList.AddRange(Boon.getRemainingBuffsList());
-                                        }*/
+                                        List<Boon> parseBoonsList = new List<Boon>();                                       
                                         parseBoonsList.AddRange(present_boons);
                                         parseBoonsList.AddRange(present_offbuffs);
                                         parseBoonsList.AddRange(present_defbuffs);
@@ -4420,7 +4417,7 @@ namespace LuckParser.Controllers
                         //Condis
                         parseBoonsList.AddRange(Boon.getCondiBoonList());
                         //Every boon and buffs
-                        parseBoonsList.AddRange(Boon.getAllProfList());
+                        parseBoonsList.AddRange(Boon.getSharableProfList());
                         List<BoonsGraphModel> boonGraphData = getBossBoonGraph(p);
                         boonGraphData.Reverse();
                         foreach (BoonsGraphModel bgm in boonGraphData)
@@ -4685,7 +4682,7 @@ namespace LuckParser.Controllers
             TimeSpan duration = TimeSpan.FromSeconds(fight_duration);
             String durationString = duration.ToString("mm") + "m " + duration.ToString("ss") + "s";
             string bossname = FilterStringChars(b_data.getName());
-            setPresentBoons();
+            setPresentBoons(settingsSnap);
             string Html_playerDropdown = "";
             foreach (Player p in p_list)
             {

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -1186,10 +1186,10 @@ namespace LuckParser.Controllers
                         }
                         else if (boon.getType().Equals("intensity"))
                         {
-                            List<int> stackslist = Statistics.getBoonStacksList(boon_object, logs, b_data);
+                            List<long> stackslist = Statistics.getBoonStacksList(boon_object, logs, b_data);
                             int time = 0;
                             int timeGraphed = 0;
-                            foreach (int stack in stackslist)
+                            foreach (long stack in stackslist)
                             {
                                 if (Math.Floor(time / 1000f) > timeGraphed)
                                 {
@@ -1386,15 +1386,15 @@ namespace LuckParser.Controllers
                         }
                         else if (boon.getType().Equals("intensity"))
                         {
-                            List<int> stackslist = Statistics.getBoonStacksList(boon_object, logs, b_data);
+                            List<long> stackslist = Statistics.getBoonStacksList(boon_object, logs, b_data);
                             int time = 0;
                             int timeGraphed = 0;
-                            foreach (int stack in stackslist)
+                            foreach (long stack in stackslist)
                             {
                                 if (Math.Floor(time / 1000f) > timeGraphed)
                                 {
                                     timeGraphed = (int)Math.Floor(time / 1000f);
-                                    pointlist.Add(new Point(time / 1000, stack));
+                                    pointlist.Add(new Point(time / 1000, (int)stack));
                                 }
                                 time++;
                             }

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -584,6 +584,7 @@ namespace LuckParser.Controllers
         public List<Boon> present_boons =  new List<Boon>();//Used only for Boon tables
         public List<Boon> present_offbuffs = new List<Boon>();//Used only for Off Buff tables
         public List<Boon> present_defbuffs = new List<Boon>();//Used only for Def Buff tables
+        public Dictionary<int, List<Boon>> present_personnal = new Dictionary<int, List<Boon>>();//Used only for personnal
         public void setPresentBoons() {
             List<SkillItem> s_list = getSkillData().getSkillList();
             foreach (Boon boon in Boon.getBoonList())
@@ -605,6 +606,18 @@ namespace LuckParser.Controllers
                 if (s_list.Exists(x => x.getID() == boon.getID()))
                 {
                     present_defbuffs.Add(boon);
+                }
+            }
+            List<CombatItem> c_data = getCombatData().getCombatList();
+            foreach (Player p in p_list)
+            {
+                present_personnal[p.getInstid()] = new List<Boon>();
+                foreach (Boon boon in Boon.getRemainingBuffsList(Boon.ProfToEnum(p.getProf())))
+                {
+                    if (c_data.Exists(x => x.getSkillID() == boon.getID() && x.getDstInstid() == p.getInstid()))
+                    {
+                        present_personnal[p.getInstid()].Add(boon);
+                    }
                 }
             }
         }
@@ -1116,31 +1129,13 @@ namespace LuckParser.Controllers
         }
         //Generate HTML---------------------------------------------------------------------------------------------------------------------------------------------------------
         //Methods that make it easier to create Javascript graphs
-        private List<BoonsGraphModel> getBoonGraph(Player p ) {
+        private List<BoonsGraphModel> getBoonGraph(Player p , List<Boon> boon_list) {
             List<BoonsGraphModel> uptime = new List<BoonsGraphModel>();
             BossData b_data = getBossData();
             CombatData c_data = getCombatData();
             SkillData s_data = getSkillData();
             List<BoonMap> boon_logs = p.getBoonMap(b_data, s_data, c_data.getCombatList());
-            List<Boon> boon_list = new List<Boon>();
-            if (SnapSettings[3] || SnapSettings[4] || SnapSettings[5])
-            {
-                if (SnapSettings[3])
-                {//Main boons
-                    boon_list.AddRange(Boon.getBoonList());
-
-                }
-                if (SnapSettings[4] || SnapSettings[5])
-                {//Important Class specefic boons
-                    boon_list.AddRange(Boon.getSharableProfList());
-                }
-                if (SnapSettings[5])
-                {//All class specefic boons
-                    boon_list.AddRange(Boon.getRemainingBuffsList());
-
-                }
-            }
-                int n = boon_list.Count();//# of diff boons
+            int n = boon_list.Count();//# of diff boons
 
             for (int i = 0; i < n; i++)//foreach boon
             {
@@ -2848,7 +2843,7 @@ namespace LuckParser.Controllers
                                     if (SnapSettings[3] || SnapSettings[4] || SnapSettings[5])
                                     {
                                         List<Boon> parseBoonsList = new List<Boon>();
-                                        if (SnapSettings[3])
+                                        /*if (SnapSettings[3])
                                         {//Main boons
                                             parseBoonsList.AddRange(Boon.getBoonList());
                                         }
@@ -2859,8 +2854,12 @@ namespace LuckParser.Controllers
                                         if (SnapSettings[5])
                                         {//All class specefic boons
                                             parseBoonsList.AddRange(Boon.getRemainingBuffsList());
-                                        }
-                                        List<BoonsGraphModel> boonGraphData = getBoonGraph(p);
+                                        }*/
+                                        parseBoonsList.AddRange(present_boons);
+                                        parseBoonsList.AddRange(present_offbuffs);
+                                        parseBoonsList.AddRange(present_defbuffs);
+                                        parseBoonsList.AddRange(present_personnal[p.getInstid()]);
+                                        List<BoonsGraphModel> boonGraphData = getBoonGraph(p, parseBoonsList);
                                         boonGraphData.Reverse();
                                         foreach (BoonsGraphModel bgm in boonGraphData)
                                         {

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -542,6 +542,7 @@ namespace LuckParser.Controllers
                     if (NPC.getProf().Contains("57069"))
                     {
                         deimos_2_instid = NPC.getInstid();
+                        long oldAware = boss_data.getLastAware();
                         if (NPC.getLastAware() < boss_data.getLastAware())
                         {
                             // No split
@@ -552,16 +553,20 @@ namespace LuckParser.Controllers
                         //int stop = 0;
                         foreach (CombatItem c in combat_list)
                         {
-                            if (c.getSrcInstid() == deimos_2_instid)
+                            if (c.getTime() > oldAware)
                             {
-                                c.setSrcInstid(boss_data.getInstid());
-                                
+                                int lol = c.isStateChange().getID();
+                                if (c.getSrcInstid() == deimos_2_instid)
+                                {
+                                    c.setSrcInstid(boss_data.getInstid());
+
+                                }
+                                if (c.getDstInstid() == deimos_2_instid)
+                                {
+                                    c.setDstInstid(boss_data.getInstid());
+                                }
                             }
-                            if (c.getDstInstid() == deimos_2_instid)
-                            {
-                                c.setDstInstid(boss_data.getInstid());
-                            }
-                           
+
                         }
                         break;
                     }
@@ -580,7 +585,6 @@ namespace LuckParser.Controllers
             }
             // Sort
             p_list = p_list.OrderBy(a => int.Parse(a.getGroup())).ToList();//p_list.Sort((a, b)=>int.Parse(a.getGroup()) - int.Parse(b.getGroup()))
-            getBossKilled();
             setMechData();
         }
 
@@ -709,57 +713,7 @@ namespace LuckParser.Controllers
             //Placeholders for further calc
             return totalAll_dps.ToString() + "|" + totalAll_damage.ToString() + "|" + totalAllphys_dps.ToString() + "|" + totalAllphys_damage.ToString() + "|" + totalAllcondi_dps.ToString() + "|" + totalAllcondi_damage.ToString() + "|"
                 + totalboss_dps.ToString() + "|" + totalboss_damage.ToString() + "|" + totalbossphys_dps.ToString() + "|" + totalbossphys_damage.ToString() + "|" + totalbosscondi_dps.ToString() + "|" + totalbosscondi_damage.ToString();
-        }
-        public bool getBossKilled() {
-            //if deimos
-            if (boss_data.getID() == 17154) {
-                //BossData b_data = getBossData();
-                //CombatData c_data = getCombatData();
-                //int totaldmg = 0;
-                
-                //int[] lasttick = boss_data.getHealthOverTime()[boss_data.getHealthOverTime().Count - 1];
-                //if (lasttick[1] < 1100) {
-                //    foreach (Player p in p_list)
-                //    {
-                //        totaldmg += p.getDamageLogs(b_data.getInstid(), b_data, c_data.getCombatList(), getAgentData()).Where(x=>x.getTime() -boss_data.getFirstAware() > lasttick[0]).ToList().Sum(x => x.getDamage());
-                //    }
-                //    int stop = 0;
-                //}
-                
-            }
-            //fix kill for Horrer
-            if (boss_data.getID() == 19767)
-            {
-                if (boss_data.getHealthOverTime()[boss_data.getHealthOverTime().Count - 1][1] < 200)
-                {
-                    log_data.setBossKill(true);
-                    return true;
-                }
-            }
-            if (log_data.getBosskill() == false)
-            {
-                BossData b_data = getBossData();
-                CombatData c_data = getCombatData();
-                int totaldmg = 0;
-
-                foreach (Player p in p_list)
-                {
-                    totaldmg += p.getDamageLogs(b_data.getInstid(), b_data, c_data.getCombatList(), getAgentData()).Sum(x => x.getDamage());
-                }
-                int healthremaining = b_data.getHealth() - totaldmg;
-                if (healthremaining > 0)
-                {
-                    log_data.setBossKill(false);
-                    return false;
-                }
-                else if (healthremaining <= 0)
-                {
-                    log_data.setBossKill(true);
-                    return true;
-                }
-            }
-            return false;
-        }
+        }      
         public String[] getFinalStats(Player p)
         {
             BossData b_data = getBossData();
@@ -4755,27 +4709,25 @@ namespace LuckParser.Controllers
                                                     {
                                                         if (log_data.getBosskill())
                                                         {
-                                                            sw.Write("<div class=\"progress-bar bg-danger\" role=\"progressbar\" style=\"width:100%; ;display: inline-block;\" aria-valuenow=\"100\" aria-valuemin=\"0\" aria-valuemax=\"100\">");
-                                                            {
-                                                                sw.Write("<p style=\"text-align:center; color: #FFF;\">" + getBossData().getHealth().ToString() + " Health</p>");
-                                                            }
-                                                            sw.Write("</div>");
+                                                            string tp = getBossData().getHealth().ToString() + " Health";
+                                                            sw.Write("<div class=\"progress-bar bg-success\" data-toggle=\"tooltip\" title=\"" + tp + "\" role=\"progressbar\" style=\"width:100%; ;\" aria-valuenow=\"100\" aria-valuemin=\"0\" aria-valuemax=\"100\"></div>");
                                                         }
                                                         else
                                                         {
-                                                            double finalPercent = 100;
+                                                            double finalPercent = 0;
                                                             if (boss_data.getHealthOverTime().Count > 0)
                                                             {
-                                                                finalPercent = boss_data.getHealthOverTime()[boss_data.getHealthOverTime().Count - 1][1] * 0.01;
+                                                                finalPercent = 100.0 - boss_data.getHealthOverTime()[boss_data.getHealthOverTime().Count - 1][1] * 0.01;
                                                             }
-                                                            sw.Write("<div class=\"progress-bar bg-danger\" role=\"progressbar\" style=\"width:" + finalPercent + "%; ;display: inline-block;\" aria-valuenow=\"100\" aria-valuemin=\"0\" aria-valuemax=\"100\">");
-                                                            {
-                                                                sw.Write("<p style=\"text-align:center; color: #FFF;\">" + (getBossData().getHealth() * finalPercent/100.0).ToString() + " Health</p>");
-                                                            }
-                                                            sw.Write("</div>");
+                                                            string tp = getBossData().getHealth() * finalPercent / 100.0 + " Health";
+                                                            sw.Write("<div class=\"progress-bar bg-success\" data-toggle=\"tooltip\" title=\"" + tp + "\" role=\"progressbar\" style=\"width:" + finalPercent + "%;\" aria-valuenow=\""+ finalPercent+"\" aria-valuemin=\"0\" aria-valuemax=\"100\"></div>");
+                                                            tp = getBossData().getHealth() * (100.0-finalPercent) / 100.0 + " Health";
+                                                            sw.Write("<div class=\"progress-bar bg-danger\" data-toggle=\"tooltip\" title=\"" + tp + "\" role=\"progressbar\" style=\"width:" + (100.0 - finalPercent) + "%;\" aria-valuenow=\""+ (100.0 - finalPercent )+ "\" aria-valuemin=\"0\" aria-valuemax=\"100\"></div>");
+                                                            
                                                         }
                                                     }
                                                     sw.Write("</div>");
+                                                    sw.Write("<p class=\"small\" style=\"text-align:center; color: #FFF;\">" + getBossData().getHealth().ToString() + " Health</p>");
                                                     if (log_data.getBosskill())
                                                     {
                                                         sw.Write("<p class='text text-success'> Result: Success</p>");

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -2855,7 +2855,10 @@ namespace LuckParser.Controllers
                                         parseBoonsList.AddRange(present_boons);
                                         parseBoonsList.AddRange(present_offbuffs);
                                         parseBoonsList.AddRange(present_defbuffs);
-                                        parseBoonsList.AddRange(present_personnal[p.getInstid()]);
+                                        if (present_personnal.ContainsKey(p.getInstid()))
+                                        {
+                                            parseBoonsList.AddRange(present_personnal[p.getInstid()]);
+                                        }
                                         List<BoonsGraphModel> boonGraphData = getBoonGraph(p, parseBoonsList);
                                         boonGraphData.Reverse();
                                         foreach (BoonsGraphModel bgm in boonGraphData)

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -1196,7 +1196,7 @@ namespace LuckParser.Controllers
                             }
 
                         }
-                        BoonsGraphModel bgm = new BoonsGraphModel(boon.getName(), pointlist);
+                        BoonsGraphModel bgm = new BoonsGraphModel(boon.getName(), pointlist, boon.getID());
                         uptime.Add(bgm);
                     }
                 }
@@ -1396,7 +1396,7 @@ namespace LuckParser.Controllers
                             }
 
                         }
-                        BoonsGraphModel bgm = new BoonsGraphModel(boon.getName(), pointlist);
+                        BoonsGraphModel bgm = new BoonsGraphModel(boon.getName(), pointlist, boon.getID());
                         uptime.Add(bgm);
                     }
                 }
@@ -2350,7 +2350,7 @@ namespace LuckParser.Controllers
                         sw.Write("<th>Name</th>");
                         foreach (Boon boon in list_to_use)
                         {
-                            sw.Write("<th width=\"50px\">" + "<img src=\"" + GetLink(boon.getName()) + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
+                            sw.Write("<th width=\"50px\">" + "<img src=\"" + boon.getLink() + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
                         }
                     }                 
                     sw.Write("</tr> ");
@@ -2459,7 +2459,7 @@ namespace LuckParser.Controllers
                         sw.Write("<th>Name</th>");
                         foreach (Boon boon in list_to_use)
                         {
-                            sw.Write("<th width=\"50px\">" + "<img src=\"" + GetLink(boon.getName()) + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
+                            sw.Write("<th width=\"50px\">" + "<img src=\"" + boon.getLink() + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
                         }
                     }
                     
@@ -2513,7 +2513,7 @@ namespace LuckParser.Controllers
                         sw.Write("<th>Name</th>");
                         foreach (Boon boon in list_to_use)
                         {
-                            sw.Write("<th width=\"50px\">" + "<img src=\"" + GetLink(boon.getName()) + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
+                            sw.Write("<th width=\"50px\">" + "<img src=\"" + boon.getLink() + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
                         }
                     }
                     
@@ -2566,7 +2566,7 @@ namespace LuckParser.Controllers
                 sw.Write(" <thead> <tr> <th width=\"50px\">Sub</th><th width=\"50px\"></th><th>Name</th>");
                 foreach (Boon boon in list_to_use)
                 {
-                    sw.Write("<th width=\"50px\">" + "<img src=\"" + GetLink(boon.getName()) + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
+                    sw.Write("<th width=\"50px\">" + "<img src=\"" + boon.getLink() + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
                 }
                 sw.Write(" </tr> </thead>");
                 sw.Write("<tbody>");
@@ -2619,7 +2619,7 @@ namespace LuckParser.Controllers
                         sw.Write("<th>Name</th>");
                         foreach (Boon boon in list_to_use)
                         {
-                            sw.Write("<th width=\"50px\">" + "<img src=\"" + GetLink(boon.getName()) + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
+                            sw.Write("<th width=\"50px\">" + "<img src=\"" + boon.getLink() + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
                         }
                     }            
                     sw.Write("</tr>");
@@ -2864,7 +2864,7 @@ namespace LuckParser.Controllers
                                         boonGraphData.Reverse();
                                         foreach (BoonsGraphModel bgm in boonGraphData)
                                         {
-                                            if (parseBoonsList.FirstOrDefault(x => x.getName() == bgm.getBoonName()) != null)
+                                            if (parseBoonsList.FirstOrDefault(x => x.getID() == bgm.getBoonId()) != null)
                                             {
                                                 sw.Write("{");
                                                 {
@@ -3398,13 +3398,13 @@ namespace LuckParser.Controllers
                 {
                     for (int d = 0; d < damageToDown.Count(); d++)
                     {
-                        sw.Write("'" + a_data.GetAgentWInst(damageToDown[d].getInstidt()).getName().Replace("\0", "") + "<br>"+
+                        sw.Write("'" + a_data.GetAgentWInst(damageToDown[d].getInstidt()).getName().Replace("\0", "").Replace("\'", "\\'") + "<br>"+
                             s_data.getName( damageToDown[d].getID()) +" hit you for "+damageToDown[d].getDamage() + "',");
                     }
                 }
                 for (int d = 0; d < damageToKill.Count(); d++)
                 {
-                    sw.Write("'" + a_data.GetAgentWInst(damageToKill[d].getInstidt()).getName().Replace("\0","") + "<br>" +
+                    sw.Write("'" + a_data.GetAgentWInst(damageToKill[d].getInstidt()).getName().Replace("\0","").Replace("\'", "\\'") + "<br>" +
                            "hit you with <b>"+ s_data.getName(damageToKill[d].getID()) + "</b> for " + damageToKill[d].getDamage() + "'");
 
                     if (d != damageToKill.Count() - 1)
@@ -3599,7 +3599,8 @@ namespace LuckParser.Controllers
 
                     foreach (int condiID in damageLogs.Where(x => x.isCondi() == 1).Select(x => x.getID()).Distinct())
                     {//condis
-                        string condiName = condiList.FirstOrDefault(x => x.getID() == condiID).getName();// Boon.getCondiName(condiID);
+                        Boon condi = condiList.FirstOrDefault(x => x.getID() == condiID);
+                        string condiName = condi.getName();// Boon.getCondiName(condiID);
                         int totaldamage = 0;
                         int mindamage = 0;
                         int avgdamage = 0;
@@ -3623,7 +3624,7 @@ namespace LuckParser.Controllers
                         {
                             sw.Write("<tr class=\"condi\">");
                             {
-                                sw.Write("<td align=\"left\"><img src=" + GetLink(condiName) + " alt=\"" + condiName + "\" title=\"" + condiID + "\" height=\"18\" width=\"18\">" + condiName + "</td>");
+                                sw.Write("<td align=\"left\"><img src=" + condi.getLink() + " alt=\"" + condiName + "\" title=\"" + condiID + "\" height=\"18\" width=\"18\">" + condiName + "</td>");
                                 sw.Write("<td>" + (int)(100 * (double)totaldamage / (double)finalTotalDamage) + "%</td>");
                                 sw.Write("<td>" + totaldamage + "</td>");
                                 sw.Write("<td>" + mindamage + "</td>");
@@ -3919,7 +3920,8 @@ namespace LuckParser.Controllers
                     List<Boon> condiList = Boon.getCondiBoonList();
                     foreach (int condiID in damageLogs.Where(x => x.isCondi() == 1).Select(x => x.getID()).Distinct())
                     {
-                        string condiName = condiList.FirstOrDefault(x => x.getID() == condiID).getName();// Boon.getCondiName(condiID);
+                        Boon condi = condiList.FirstOrDefault(x => x.getID() == condiID);
+                        string condiName = condi.getName();// Boon.getCondiName(condiID);
 
                         int totaldamage = 0;
                         int mindamage = 0;
@@ -3941,7 +3943,7 @@ namespace LuckParser.Controllers
                         {
                             sw.Write("<tr class=\"condi\">");
                             {
-                                sw.Write("<td align=\"left\"><img src=" + GetLink(condiName) + " alt=\"" + condiName + "\" title=\"" + condiID + "\" height=\"18\" width=\"18\">" + condiName + "</td>");
+                                sw.Write("<td align=\"left\"><img src=" + condi.getLink() + " alt=\"" + condiName + "\" title=\"" + condiID + "\" height=\"18\" width=\"18\">" + condiName + "</td>");
                                 sw.Write("<td>" + totaldamage + "</td>");
                                 sw.Write("<td>" + (int)(100 * (double)totaldamage / (double)finalTotalDamage) + "%</td>");
                                 sw.Write("<td>" + hits + "</td>");
@@ -4092,7 +4094,8 @@ namespace LuckParser.Controllers
                     List<Boon> condiList = Boon.getCondiBoonList();
                     foreach (int condiID in damageLogs.Where(x => x.isCondi() == 1).Select(x => x.getID()).Distinct())
                     {
-                        string condiName = condiList.FirstOrDefault(x => x.getID() == condiID).getName();// Boon.getCondiName(condiID);
+                        Boon condi = condiList.FirstOrDefault(x => x.getID() == condiID);
+                        string condiName = condi.getName();// Boon.getCondiName(condiID);
                         int totaldamage = 0;
                         int mindamage = 0;
                         int avgdamage = 0;
@@ -4116,7 +4119,7 @@ namespace LuckParser.Controllers
                         {
                             sw.Write("<tr>");
                             {
-                                sw.Write("<td align=\"left\"><img src=" + GetLink(condiName) + " alt=\"" + condiName + "\" title=\"" + condiID + "\" height=\"18\" width=\"18\">" + condiName + "</td>");
+                                sw.Write("<td align=\"left\"><img src=" + condi.getLink() + " alt=\"" + condiName + "\" title=\"" + condiID + "\" height=\"18\" width=\"18\">" + condiName + "</td>");
                                 sw.Write("<td>" + totaldamage + "</td>");
                                 sw.Write("<td>" + (int)(100 * (double)totaldamage / (double)finalTotalDamage) + "%</td>");
                                 sw.Write("<td>" + hits + "</td>");
@@ -4314,7 +4317,7 @@ namespace LuckParser.Controllers
                         sw.Write("<th>Name</th>");
                         foreach (Boon boon in Boon.getCondiBoonList())
                         {
-                            sw.Write("<th>" + "<img src=\"" + GetLink(boon.getName()) + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
+                            sw.Write("<th>" + "<img src=\"" + boon.getLink() + " \" alt=\"" + boon.getName() + "\" title =\" " + boon.getName() + "\" height=\"18\" width=\"18\" >" + "</th>");
                         }
                     }                 
                     sw.Write("</tr>");
@@ -4402,7 +4405,7 @@ namespace LuckParser.Controllers
                         boonGraphData.Reverse();
                         foreach (BoonsGraphModel bgm in boonGraphData)
                         {
-                            if (parseBoonsList.FirstOrDefault(x => x.getName() == bgm.getBoonName()) != null)
+                            if (parseBoonsList.FirstOrDefault(x => x.getID() == bgm.getBoonId()) != null)
                             {
                                 sw.Write("{");
                                 {
@@ -5284,6 +5287,8 @@ namespace LuckParser.Controllers
                     return "https://wiki.guildwars2.com/images/thumb/7/79/Daze.png/20px-Daze.png";
                 case "Invuln":
                     return "https://wiki.guildwars2.com/images/e/eb/Determined.png";
+                case "Blinded":
+                    return "https://wiki.guildwars2.com/images/thumb/3/33/Blinded.png/20px-Blinded.png";
                 case "Wasted":
                     return "https://wiki.guildwars2.com/images/b/b3/Out_Of_Health_Potions.png";
                 case "Saved":
@@ -5296,99 +5301,7 @@ namespace LuckParser.Controllers
                     return "https://wiki.guildwars2.com/images/c/cc/Dodge_Instructor.png";
                 case "Bandage":
                     return "https://render.guildwars2.com/file/D2D7D11874060D68760BFD519CFC77B6DF14981F/102928.png";
-
-                case "Bleeding":
-                    return "https://wiki.guildwars2.com/images/thumb/3/33/Bleeding.png/20px-Bleeding.png";
-                case "Burning":
-                    return "https://wiki.guildwars2.com/images/thumb/4/45/Burning.png/20px-Burning.png";
-                case "Confusion":
-                    return "https://wiki.guildwars2.com/images/thumb/e/e6/Confusion.png/20px-Confusion.png";
-                case "Poison":
-                    return "https://wiki.guildwars2.com/images/thumb/0/05/Poison.png/20px-Poison.png";
-                case "Torment":
-                    return "https://wiki.guildwars2.com/images/thumb/0/08/Torment.png/20px-Torment.png";
-                case "Blinded":
-                    return "https://wiki.guildwars2.com/images/thumb/3/33/Blinded.png/20px-Blinded.png";
-                case "Chilled":
-                    return "https://wiki.guildwars2.com/images/thumb/a/a6/Chilled.png/20px-Chilled.png";
-                case "Crippled":
-                    return "https://wiki.guildwars2.com/images/thumb/f/fb/Crippled.png/20px-Crippled.png";
-                case "Fear":
-                    return "https://wiki.guildwars2.com/images/thumb/e/e6/Fear.png/20px-Fear.png";
-                case "Immobile":
-                    return "https://wiki.guildwars2.com/images/thumb/3/32/Immobile.png/20px-Immobile.png";
-                case "Slow":
-                    return "https://wiki.guildwars2.com/images/thumb/f/fb/Slow_40px.png/20px-Slow_40px.png";
-                case "Taunt":
-                    return "https://wiki.guildwars2.com/images/thumb/c/cc/Taunt.png/20px-Taunt.png";
-                case "Weakness":
-                    return "https://wiki.guildwars2.com/images/thumb/f/f9/Weakness.png/20px-Weakness.png";
-                case "Vulnerability":
-                    return "https://wiki.guildwars2.com/images/thumb/a/af/Vulnerability.png/20px-Vulnerability.png";
-                case "Aegis": return "https://wiki.guildwars2.com/images/e/e5/Aegis.png";
-                case "Fury": return "https://wiki.guildwars2.com/images/4/46/Fury.png";
-                case "Might": return "https://wiki.guildwars2.com/images/7/7c/Might.png";
-                case "Protection": return "https://wiki.guildwars2.com/images/6/6c/Protection.png";
-                case "Quickness": return "https://wiki.guildwars2.com/images/b/b4/Quickness.png";
-                case "Regeneration": return "https://wiki.guildwars2.com/images/5/53/Regeneration.png";
-                case "Resistance": return "https://wiki.guildwars2.com/images/thumb/e/e9/Resistance_40px.png/20px-Resistance_40px.png";
-                case "Retaliation": return "https://wiki.guildwars2.com/images/5/53/Retaliation.png";
-                case "Stability": return "https://wiki.guildwars2.com/images/a/ae/Stability.png";
-                case "Swiftness": return "https://wiki.guildwars2.com/images/a/af/Swiftness.png";
-                case "Vigor": return "https://wiki.guildwars2.com/images/f/f4/Vigor.png";
-
-                case "Alacrity": return "https://wiki.guildwars2.com/images/thumb/4/4c/Alacrity.png/20px-Alacrity.png";
-                case "Glyph of Empowerment": return "https://wiki.guildwars2.com/images/thumb/f/f0/Glyph_of_Empowerment.png/33px-Glyph_of_Empowerment.png";
-                case "Grace of the Land": return "https://wiki.guildwars2.com/images/thumb/4/45/Grace_of_the_Land.png/25px-Grace_of_the_Land.png";
-                case "Sun Spirit": return "https://wiki.guildwars2.com/images/thumb/d/dd/Sun_Spirit.png/33px-Sun_Spirit.png";
-                case "Water Spirit": return "https://wiki.guildwars2.com/images/thumb/0/06/Water_Spirit.png/33px-Water_Spirit.png";
-                case "Frost Spirit": return "https://wiki.guildwars2.com/images/thumb/c/c6/Frost_Spirit.png/33px-Frost_Spirit.png";
-                case "Banner of Strength": return "https://wiki.guildwars2.com/images/thumb/e/e1/Banner_of_Strength.png/33px-Banner_of_Strength.png";
-                case "Banner of Discipline": return "https://wiki.guildwars2.com/images/thumb/5/5f/Banner_of_Discipline.png/33px-Banner_of_Discipline.png";
-                case "Banner of Tactics": return "https://wiki.guildwars2.com/images/thumb/3/3f/Banner_of_Tactics.png/33px-Banner_of_Tactics.png";
-                case "Banner of Defense": return "https://wiki.guildwars2.com/images/thumb/f/f1/Banner_of_Defense.png/33px-Banner_of_Defense.png";
-                case "Spotter": return "https://wiki.guildwars2.com/images/b/b0/Spotter.png";
-                case "Stone Spirit": return "https://wiki.guildwars2.com/images/thumb/3/35/Stone_Spirit.png/20px-Stone_Spirit.png";
-                case "Storm Spirit": return "https://wiki.guildwars2.com/images/thumb/2/25/Storm_Spirit.png/30px-Storm_Spirit.png";
-                case "Empower Allies": return "https://wiki.guildwars2.com/images/thumb/4/4c/Empower_Allies.png/20px-Empower_Allies.png";
-                case "Soothing Mist": return "https://wiki.guildwars2.com/images/f/f7/Soothing_Mist.png";
-                case "Pinpoint Distribution": return "https://wiki.guildwars2.com/images/b/bf/Pinpoint_Distribution.png";
-                case "Vampiric Aura": return "https://wiki.guildwars2.com/images/d/da/Vampiric_Presence.png";
-                case "Assassin's Presence": return "https://wiki.guildwars2.com/images/5/54/Assassin%27s_Presence.png";
-                case "Battle Presence": return "https://wiki.guildwars2.com/images/2/27/Battle_Presence.png";
-                case "Razorclaw's Rage": return "https://wiki.guildwars2.com/images/7/73/Razorclaw%27s_Rage.png";
-                case "Soulcleave's Summit": return "https://wiki.guildwars2.com/images/7/78/Soulcleave%27s_Summit.png";
-                case "Ashes of the Just": return "https://wiki.guildwars2.com/images/6/6d/Epilogue-_Ashes_of_the_Just.png";
-                case "Vulture Stance": return "https://wiki.guildwars2.com/images/8/8f/Vulture_Stance.png";
-                case "One Wolf Pack": return "https://wiki.guildwars2.com/images/3/3b/One_Wolf_Pack.png";
-                case "Skale Venom": return "https://wiki.guildwars2.com/images/1/14/Skale_Venom.png";
-                case "Spider Venom": return "https://wiki.guildwars2.com/images/3/39/Spider_Venom.png";
-                case "Basilisk Venom": return "https://wiki.guildwars2.com/images/3/3a/Basilisk_Venom.png";
-                case "Conjure Flame Axe": return "https://wiki.guildwars2.com/images/a/a1/Conjure_Flame_Axe.png";
-                case "Conjure Frost Bow": return "https://wiki.guildwars2.com/images/c/c3/Conjure_Frost_Bow.png";
-                case "Conjure Lightning Hammer": return "https://wiki.guildwars2.com/images/1/1f/Conjure_Lightning_Hammer.png";
-                case "Conjure Fiery Greatsword": return "https://wiki.guildwars2.com/images/e/e2/Conjure_Fiery_Greatsword.png";
-                case "Arcane Power": return "https://wiki.guildwars2.com/images/7/72/Arcane_Power.png";
-                case "Rite of the Great Dwarf": return "https://wiki.guildwars2.com/images/6/69/Rite_of_the_Great_Dwarf.png";
-                case "Infuse Light": return "https://wiki.guildwars2.com/images/6/60/Infuse_Light.png";
-                case "Naturalistic Resonance": return "https://wiki.guildwars2.com/images/e/e9/Facet_of_Nature.png";
-                case "Breakrazor's Bastion": return "https://wiki.guildwars2.com/images/a/a7/Breakrazor%27s_Bastion.png";
-                case "Purging Flames": return "https://wiki.guildwars2.com/images/2/28/Purging_Flames.png";
-                case "Eternal Oasis": return "https://wiki.guildwars2.com/images/5/5f/Epilogue-_Eternal_Oasis.png";
-                case "Unbroken Lines": return "https://wiki.guildwars2.com/images/d/d8/Epilogue-_Unbroken_Lines.png";
-                case "Strength in Numbers": return "https://wiki.guildwars2.com/images/7/7b/Strength_in_Numbers.png";
-                case "Dolyak Stance": return "https://wiki.guildwars2.com/images/7/71/Dolyak_Stance.png";
-                case "Griffon Stance": return "https://wiki.guildwars2.com/images/9/98/Griffon_Stance.png";
-                case "Moa Stance": return "https://wiki.guildwars2.com/images/6/66/Moa_Stance.png";
-                case "Bear Stance": return "https://wiki.guildwars2.com/images/f/f0/Bear_Stance.png";
-                case "Ice Drake Venom": return "https://wiki.guildwars2.com/images/7/7b/Ice_Drake_Venom.png";
-                case "Skelk Venom": return "https://wiki.guildwars2.com/images/7/75/Skelk_Venom.png";
-                case "Devourer Venom": return "https://wiki.guildwars2.com/images/4/4d/Devourer_Venom.png";
-                case "Last Rites": return "https://wiki.guildwars2.com/images/1/1a/Last_Rites_%28effect%29.png";
-                case "Conjure Earth Shield": return "https://wiki.guildwars2.com/images/7/7a/Conjure_Earth_Shield.png";
-                case "Rebound": return "https://wiki.guildwars2.com/images/0/03/%22Rebound%21%22.png";
-
-
+                    
                 case "Color-Aegis": return "rgb(102,255,255)";
                 case "Color-Fury": return "rgb(255,153,0)";
                 case "Color-Might": return "rgb(153,0,0)";

--- a/LuckParser/Models/ParseEnums/StateChange.cs
+++ b/LuckParser/Models/ParseEnums/StateChange.cs
@@ -82,6 +82,14 @@ namespace LuckParser.Models.ParseEnums
                     return "POINT_OF_VIEW";
                 case 14:
                     return "CBTS_LANGUAGE";
+                case 15:
+                    return "GWBUILD";
+                case 16:
+                    return "SHARDID";
+                case 17:
+                    return "REWARD";
+                case 18:
+                    return "BUFFINITIAL";
                 default:
                     return "UNKNOWN";
             }

--- a/LuckParser/Models/ParseModels/AbstractBoon.cs
+++ b/LuckParser/Models/ParseModels/AbstractBoon.cs
@@ -9,7 +9,7 @@ namespace LuckParser.Models.ParseModels
     {
 
         // Fields
-        protected List<int> boon_stack = new List<int>();
+        protected List<long> boon_stack = new List<long>();
         protected int capacity;
 
         // Constructor
@@ -19,14 +19,14 @@ namespace LuckParser.Models.ParseModels
         }
 
         // Abstract Methods
-        public abstract int getStackValue();
+        public abstract long getStackValue();
 
         public abstract void update(long time_passed);
 
-        public abstract void addStacksBetween(List<int> boon_stacks, long time_between);
+        public abstract void addStacksBetween(List<long> boon_stacks, long time_between);
 
         // Public Methods
-        public void add(int boon_duration)
+        public void add(long boon_duration)
         {
             // Find empty slot
             if (!isFull())

--- a/LuckParser/Models/ParseModels/AbstractBoon.cs
+++ b/LuckParser/Models/ParseModels/AbstractBoon.cs
@@ -21,9 +21,9 @@ namespace LuckParser.Models.ParseModels
         // Abstract Methods
         public abstract int getStackValue();
 
-        public abstract void update(int time_passed);
+        public abstract void update(long time_passed);
 
-        public abstract void addStacksBetween(List<int> boon_stacks, int time_between);
+        public abstract void addStacksBetween(List<int> boon_stacks, long time_between);
 
         // Public Methods
         public void add(int boon_duration)

--- a/LuckParser/Models/ParseModels/Agent.cs
+++ b/LuckParser/Models/ParseModels/Agent.cs
@@ -41,7 +41,7 @@ namespace LuckParser.Models.ParseModels
         private int prof;
 
         // Constructor
-       public Agent(long ID, String name,int prof,int elite)
+       public Agent(long ID, String name, int prof, int elite)
         {
             this.name = name;
             this.ID = ID;

--- a/LuckParser/Models/ParseModels/AgentData.cs
+++ b/LuckParser/Models/ParseModels/AgentData.cs
@@ -70,7 +70,7 @@ namespace LuckParser.Models.ParseModels
             return new AgentItem(0,"UNKOWN","UNKNOWN");
             
         }
-        public AgentItem GetAgentWInst(int instid)
+        public AgentItem GetAgentWInst(ushort instid)
         {
             return all_agents_list.FirstOrDefault(x => x.getInstid() == instid);
         }

--- a/LuckParser/Models/ParseModels/AgentItem.cs
+++ b/LuckParser/Models/ParseModels/AgentItem.cs
@@ -9,9 +9,9 @@ namespace LuckParser.Models.ParseModels
     {
         // Fields
         private long agent;
-        private int instid = 0;
-        private int first_aware = 0;
-        private int last_aware = Int16.MaxValue;
+        private ushort instid = 0;
+        private long first_aware = 0;
+        private long last_aware = long.MaxValue;
         private String name;
         private String prof;
         private int toughness = 0;
@@ -58,17 +58,17 @@ namespace LuckParser.Models.ParseModels
             return agent;
         }
 
-        public int getInstid()
+        public ushort getInstid()
         {
             return instid;
         }
 
-        public int getFirstAware()
+        public long getFirstAware()
         {
             return first_aware;
         }
 
-        public int getLastAware()
+        public long getLastAware()
         {
             return last_aware;
         }
@@ -101,17 +101,17 @@ namespace LuckParser.Models.ParseModels
         }
 
         // Setters
-        public void setInstid(int instid)
+        public void setInstid(ushort instid)
         {
             this.instid = instid;
         }
 
-        public void setFirstAware(int first_aware)
+        public void setFirstAware(long first_aware)
         {
             this.first_aware = first_aware;
         }
 
-        public void setLastAware(int last_aware)
+        public void setLastAware(long last_aware)
         {
             this.last_aware = last_aware;
         }

--- a/LuckParser/Models/ParseModels/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boon.cs
@@ -8,8 +8,8 @@ namespace LuckParser.Models.ParseModels
     public class Boon
     {
         // Boon
-        public enum BoonEnum { Condition, Boon, OffensiveBuff, DefensiveBuff, NonShareableBuff}
-        public enum BoonSource { Mixed, Necromancer, Elementalist, Mesmer, Warrior, Revenant, Guardian, Thief, Ranger, Engineer  }
+        public enum BoonEnum { Condition, Boon, OffensiveBuff, DefensiveBuff, NonShareableBuff, Food, Utility}
+        public enum BoonSource { Mixed, Necromancer, Elementalist, Mesmer, Warrior, Revenant, Guardian, Thief, Ranger, Engineer, Item  }
 
         // Fields
         private String name;
@@ -406,6 +406,29 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Lesser Arcane Shield",25579, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Weaver's Prowess",42061, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Elements of Rage",42416, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                /// FOODS
+                new Boon("Plate of Truffle Steak",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/4/4c/Plate_of_Truffle_Steak.png"),
+                new Boon("Bowl of Sweet and Spicy Butternut Squash Soup",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/d/df/Bowl_of_Sweet_and_Spicy_Butternut_Squash_Soup.png"),
+                new Boon("Red-Lentil Saobosa",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/a/a8/Red-Lentil_Saobosa.png"),
+                new Boon("Rare Veggie Pizza",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/a/a0/Rare_Veggie_Pizza.png"),
+                new Boon("Bowl of Garlic Kale Sautee",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/0/04/Bowl_of_Garlic_Kale_Sautee.png"),
+                new Boon("Koi Cake",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/1/14/Koi_Cake.png"),
+                new Boon("Prickly Pear Pie",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/0/0a/Prickly_Pear_Pie.png"),
+                new Boon("Bowl of Nopalitos Sauté",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/f/f1/Bowl_of_Nopalitos_Saut%C3%A9.png"),
+                new Boon("Delicious Rice Ball",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/5/5d/Delicious_Rice_Ball.png"),
+                new Boon("Slice of Allspice Cake",-1, BoonSource.Item, "duration", 1, BoonEnum.Food, "https://wiki.guildwars2.com/images/1/13/Slice_of_Allspice_Cake.png"),
+                /// UTILITIES
+                new Boon("Superior Sharpening Stone",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/7/78/Superior_Sharpening_Stone.png"),
+                new Boon("Master Maintenance Oil",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/5/5b/Master_Maintenance_Oil.png"),
+                new Boon("Master Tuning Crystal",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/5/58/Master_Tuning_Crystal.png"),
+                new Boon("Toxic Sharpening Stone",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/d/db/Toxic_Sharpening_Stone.png"),
+                new Boon("Potent Superior Sharpening Stone",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/7/78/Superior_Sharpening_Stone.png"),
+                new Boon("Toxic Maintenance Oil",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/a/a6/Toxic_Maintenance_Oil.png"),
+                new Boon("Magnanimous Maintenance Oil",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/5/53/Magnanimous_Maintenance_Oil.png"),
+                new Boon("Potent Master Maintenance Oil",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/5/5b/Master_Maintenance_Oil.png"),
+                new Boon("Furious Maintenance Oil",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/5/5b/Master_Maintenance_Oil.png"),
+                new Boon("Bountiful Maintenance Oil",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/5/5b/Master_Maintenance_Oil.png"),
+                new Boon("Toxic Focusing Crystal",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/d/de/Toxic_Focusing_Crystal.png"),
             };
 
         public static List<Boon> getCondiBoonList()
@@ -423,7 +446,7 @@ namespace LuckParser.Models.ParseModels
         }
         public static List<Boon> getOffensiveList(BoonSource source)
         {
-            return allBoons.Where(x => x.priority == BoonEnum.OffensiveBuff && x.plotlyGroup == source).ToList();
+            return getOffensiveList().Where(x => x.plotlyGroup == source).ToList();
         }
 
         public static List<Boon> getDefensiveList()
@@ -432,7 +455,7 @@ namespace LuckParser.Models.ParseModels
         }
         public static List<Boon> getDefensiveList(BoonSource source)
         {
-            return allBoons.Where(x => x.priority == BoonEnum.DefensiveBuff && x.plotlyGroup == source).ToList();
+            return getDefensiveList().Where(x => x.plotlyGroup == source).ToList();
         }
 
         public static List<Boon> getBoonList()
@@ -446,12 +469,22 @@ namespace LuckParser.Models.ParseModels
         }
         public static List<Boon> getSharableProfList(BoonSource source)
         {
-            return allBoons.Where(x => (x.priority == BoonEnum.OffensiveBuff || x.priority == BoonEnum.DefensiveBuff) && x.plotlyGroup == source).ToList();
+            return getSharableProfList().Where(x => x.plotlyGroup == source).ToList();
+        }
+
+        public static List<Boon> getFoodList()
+        {
+            return allBoons.Where(x => x.priority != BoonEnum.Food).ToList();
+        }
+
+        public static List<Boon> getUtilityList()
+        {
+            return allBoons.Where(x => x.priority != BoonEnum.Utility).ToList();
         }
 
         public static List<Boon> getAllProfList()
         {
-            return allBoons.Where(x => x.priority != BoonEnum.Condition).ToList();
+            return allBoons.Where(x => x.priority != BoonEnum.Condition && x.priority != BoonEnum.Food && x.priority != BoonEnum.Utility).ToList();
         }
 
         public static List<Boon> getRemainingBuffsList()

--- a/LuckParser/Models/ParseModels/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boon.cs
@@ -8,8 +8,52 @@ namespace LuckParser.Models.ParseModels
     public class Boon
     {
         // Boon
-        public enum BoonEnum { Condition, Boon, OffensiveBuff, DefensiveBuff, NonShareableBuff, Food, Utility}
-        public enum BoonSource { Mixed, Necromancer, Elementalist, Mesmer, Warrior, Revenant, Guardian, Thief, Ranger, Engineer, Item  }
+        public enum BoonEnum { Condition, Boon, OffensiveBuff, DefensiveBuff, NonShareableBuff, Food, Utility, DontTrackForNow};
+        public enum BoonSource { Mixed, Necromancer, Elementalist, Mesmer, Warrior, Revenant, Guardian, Thief, Ranger, Engineer, Item  };
+
+        public static BoonSource ProfToEnum(string prof)
+        {
+            switch(prof)
+            {
+                case "Druid":
+                case "Ranger":
+                case "Soulbeast":
+                    return BoonSource.Ranger;
+                case "Scrapper":
+                case "Holosmith":
+                case "Engineer":
+                    return BoonSource.Engineer;
+                case "Daredevil":
+                case "Deadeye":
+                case "Thief":
+                    return BoonSource.Thief;
+                case "Weaver":
+                case "Tempest":
+                case "Elementalist":
+                    return BoonSource.Elementalist;
+                case "Mirage":
+                case "Chronomancer":
+                case "Mesmer":
+                    return BoonSource.Mesmer;
+                case "Scourge":
+                case "Reaper":
+                case "Necromancer":
+                    return BoonSource.Necromancer;
+                case "Spellbreaker":
+                case "Berserker":
+                case "Warrior":
+                    return BoonSource.Warrior;
+                case "Firebrand":
+                case "Dragonhunter":
+                case "Guardian":
+                    return BoonSource.Guardian;
+                case "Renegade":
+                case "Herald":
+                case "Revenant":
+                    return BoonSource.Revenant;
+            }
+            return BoonSource.Mixed;
+        }
 
         // Fields
         private String name;
@@ -88,8 +132,8 @@ namespace LuckParser.Models.ParseModels
                 // Generic
                 new Boon("Stealth", 13017, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Revealed", 890, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Superspeed", 5974, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Invulnerability", 801, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff, "https://wiki.guildwars2.com/images/e/eb/Determined.png"),
+                new Boon("Superspeed", 5974, BoonSource.Mixed, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/1/1a/Super_Speed.png"),
+                //new Boon("Invulnerability", 801, BoonSource.Mixed, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/e/eb/Determined.png"),
                 new Boon("Unblockable", BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
                 //Auras
                 new Boon("Chaos Armor", 10332, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
@@ -113,25 +157,25 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Crystal Hibernation", 28262, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Vengeful Hammers", 27273, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Rite of the Great Dwarf", 26596, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/6/69/Rite_of_the_Great_Dwarf.png"),
-                new Boon("Embrace the Darkness", 28001, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Embrace the Darkness", 28001, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),// incorrect id?
                 new Boon("Enchanted Daggers", 28557, BoonSource.Revenant, "intensity", 6, BoonEnum.NonShareableBuff),
                 new Boon("Impossible Odds", 27581, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 //facets
-                new Boon("Facet of Light",27336, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff),
+                new Boon("Facet of Light",27336, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Infuse Light",27737, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/6/60/Infuse_Light.png"),
-                new Boon("Facet of Darkness",28036, BoonSource.Revenant, "duration", 1, BoonEnum.OffensiveBuff),
-                new Boon("Facet of Elements",28243, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff),
-                new Boon("Facet of Strength",27376, BoonSource.Revenant, "duration", 1, BoonEnum.OffensiveBuff),
-                new Boon("Facet of Chaos",27983, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff),
-                new Boon("Facet of Nature",29275, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Facet of Darkness",28036, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Facet of Elements",28243, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Facet of Strength",27376, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Facet of Chaos",27983, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Facet of Nature",29275, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Naturalistic Resonance", 29379, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/e/e9/Facet_of_Nature.png"),
                 //legends
-                new Boon("Legendary Centaur Stance",27972, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Legendary Dragon Stance",27732, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Legendary Dwarf Stance",27205, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Legendary Demon Stance",27928, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Legendary Assassin Stance",27890, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Legendary Renegade Stance",44272, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Legendary Centaur Stance",27972, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Legendary Dragon Stance",27732, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Legendary Dwarf Stance",27205, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Legendary Demon Stance",27928, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Legendary Assassin Stance",27890, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Legendary Renegade Stance",44272, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
                 //summons
                 new Boon("Breakrazor's Bastion",44682, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/a/a7/Breakrazor%27s_Bastion.png"),
                 new Boon("Razorclaw's Rage",41016, BoonSource.Revenant, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/7/73/Razorclaw%27s_Rage.png"),
@@ -139,13 +183,13 @@ namespace LuckParser.Models.ParseModels
                 //traits
                 new Boon("Vicious Lacerations",29395, BoonSource.Revenant, "intensity", 5, BoonEnum.NonShareableBuff),
                 new Boon("Assassin's Presence", 26854, BoonSource.Revenant, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/5/54/Assassin%27s_Presence.png"),
-                new Boon("Expose Defenses", 48894, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                //new Boon("Expose Defenses", 48894, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Invoking Harmony",29025, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Selfless Amplification",30509, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Hardening Persistence",28957, BoonSource.Revenant, "intensity", 8, BoonEnum.NonShareableBuff),
                 new Boon("Soothing Bastion",34136, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Kalla's Fervor",42883, BoonSource.Revenant, "duration", 5, BoonEnum.NonShareableBuff),
-                new Boon("Improved Kalla's Fervor",45614, BoonSource.Revenant, "duration", 5, BoonEnum.NonShareableBuff),
+                new Boon("Kalla's Fervor",42883, BoonSource.Revenant, "intensity", 5, BoonEnum.NonShareableBuff),
+                new Boon("Improved Kalla's Fervor",45614, BoonSource.Revenant, "intensity", 5, BoonEnum.NonShareableBuff),
                 ///WARRIOR
                 //skills
                 new Boon("Riposte",14434, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
@@ -155,12 +199,12 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Rock Guard", 34256 , BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Sight beyond Sight",40616, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
                 //signets
-                new Boon("Healing Signet",786, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Dolyak Signet",14458, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Fury",14459, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Might",14444, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Stamina",14478, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Rage",14496, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Healing Signet",786, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Dolyak Signet",14458, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Fury",14459, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Might",14444, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Stamina",14478, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Rage",14496, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
                 //banners
                 new Boon("Banner of Strength", 14417, BoonSource.Warrior, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/thumb/e/e1/Banner_of_Strength.png/33px-Banner_of_Strength.png"),
                 new Boon("Banner of Discipline", 14449, BoonSource.Warrior, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/thumb/5/5f/Banner_of_Discipline.png/33px-Banner_of_Discipline.png"),
@@ -187,27 +231,27 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Zealot's Flame", 9103, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Purging Flames",21672, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/2/28/Purging_Flames.png"),
                 new Boon("Litany of Wrath",21665, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Renewed Focus",9255, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Renewed Focus",9255, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Ashes of the Just",41957, BoonSource.Guardian, "intensity", 25, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/6/6d/Epilogue-_Ashes_of_the_Just.png"),
                 new Boon("Eternal Oasis",44871, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/5/5f/Epilogue-_Eternal_Oasis.png"),
                 new Boon("Unbroken Lines",43194, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/d/d8/Epilogue-_Unbroken_Lines.png"),
                 //signets
-                new Boon("Signet of Resolve",9220, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Bane Signet",9092, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Judgment",9156, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Mercy",9162, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Wrath",9100, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Courage",29633, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Resolve",9220, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Bane Signet",9092, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Judgment",9156, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Mercy",9162, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Wrath",9100, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Courage",29633, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
                 //virtues
-                new Boon("Virtue of Justice", 9114, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Spears of Justice", 29632, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Virtue of Courage", 9113, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Shield of Courage", 29523, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Virtue of Resolve", 9119, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Wings of Resolve", 30308, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Tome of Justice",40530, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Tome of Courage",43508,BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Tome of Resolve",46298, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Virtue of Justice", 9114, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Spears of Justice", 29632, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Virtue of Courage", 9113, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Shield of Courage", 29523, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Virtue of Resolve", 9119, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Wings of Resolve", 30308, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Tome of Justice",40530, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Tome of Courage",43508,BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Tome of Resolve",46298, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
                 //traits
                 new Boon("Strength in Numbers",13796, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/7b/Strength_in_Numbers.png"),
                 new Boon("Invigorated Bulwark",30207, BoonSource.Guardian, "intensity", 5, BoonEnum.NonShareableBuff),
@@ -230,15 +274,15 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Gear Shield",5997, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 //Transforms
                 new Boon("Rampage", BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Photon Forge",43708, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Photon Forge",43708, BoonSource.Engineer, "duration", 1, BoonEnum.DontTrackForNow),
                 //Traits
-                new Boon("Laser's Edge",44414, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Laser's Edge",44414, BoonSource.Engineer, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Afterburner",42210, BoonSource.Engineer, "intensity", 5, BoonEnum.NonShareableBuff),
                 new Boon("Iron Blooded",49065, BoonSource.Engineer, "intensity", 25, BoonEnum.NonShareableBuff),
                 new Boon("Streamlined Kits",18687, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Kinetic Charge",45781, BoonSource.Engineer, "intensity", 5, BoonEnum.NonShareableBuff),
                 new Boon("Pinpoint Distribution", 38333, BoonSource.Engineer, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/b/bf/Pinpoint_Distribution.png"),
-                new Boon("Heat Therapy",40694, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Heat Therapy",40694, BoonSource.Engineer, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Overheat", 40397, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 ///RANGER
                 new Boon("Celestial Avatar", 31508, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
@@ -265,8 +309,8 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Call of the Wild",36781, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Strength of the pack!",12554, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Sick 'Em!",33902, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Sharpening Stones",12536, BoonSource.Ranger, "intenstiy", 10, BoonEnum.NonShareableBuff),
-                new Boon("Ancestral Grace", 31584, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Sharpening Stones",12536, BoonSource.Ranger, "intenstiy", 10, BoonEnum.DontTrackForNow),
+                new Boon("Ancestral Grace", 31584, BoonSource.Ranger, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Glyph of Empowerment", 31803, BoonSource.Ranger, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/thumb/f/f0/Glyph_of_Empowerment.png/33px-Glyph_of_Empowerment.png"),
                 new Boon("Dolyak Stance",41815, BoonSource.Ranger, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/71/Dolyak_Stance.png"),
                 new Boon("Griffon Stance",46280, BoonSource.Ranger, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/9/98/Griffon_Stance.png"),
@@ -277,10 +321,10 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Sharpen Spines",43266, BoonSource.Ranger, "intensity", 5, BoonEnum.NonShareableBuff),
                 //traits
                 new Boon("Spotter", 14055, BoonSource.Ranger, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/b/b0/Spotter.png"),
-                new Boon("Opening Strike",13988, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Opening Strike",13988, BoonSource.Ranger, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Quick Draw",29703, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Light on your feet",30673, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Natural Mender",30449, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Natural Mender",30449, BoonSource.Ranger, "intensity", 10, BoonEnum.NonShareableBuff),
                 new Boon("Lingering Light",32248, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Deadly",44932, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Ferocious",41720, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
@@ -291,12 +335,12 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Twice as Vicious",45600, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 ///THIEF
                 //signets
-                new Boon("Signet of Malice",13049, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Assassin's Signet (Passive)",13047, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Assassin's Signet (Active)",44597, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Infiltrator's Signet",13063, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Agility",13061, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Shadows",13059, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Malice",13049, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Assassin's Signet (Passive)",13047, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Assassin's Signet (Active)",44597, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Infiltrator's Signet",13063, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Agility",13061, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Shadows",13059, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
                 //venoms
                 new Boon("Skelk Venom",-1, BoonSource.Thief, "intensity", 4, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/75/Skelk_Venom.png"),
                 new Boon("Ice Drake Venom",13095, BoonSource.Thief, "intensity", 4, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/7b/Ice_Drake_Venom.png"),
@@ -323,19 +367,19 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Bounding Dodger", 33162, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
                 ///MESMER
                 //signets
-                new Boon("Signet of the Ether", 21751, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Domination",10231, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Illusions",10246, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Inspiration",10235, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Midnight",10233, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Humility",30739, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of the Ether", 21751, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Domination",10231, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Illusions",10246, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Inspiration",10235, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Midnight",10233, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Humility",30739, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
                 //skills
                 new Boon("Distortion",10243, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Blur", 10335 , BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Blur", 10335 , BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Mirror",10357, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Echo",29664, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Illusion of Life", BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Time Block",30134, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                //new Boon("Time Block",30134, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff), What is this?
                 new Boon("Time Echo",29582, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Time Anchored",30136, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 //traits
@@ -347,14 +391,14 @@ namespace LuckParser.Models.ParseModels
                 ///NECROMANCER
                 //forms
                 new Boon("Lich Form",10631, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Death Shroud", 790, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Reaper's Shroud", 29446, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Death Shroud", 790, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Reaper's Shroud", 29446, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
                 //signets
-                new Boon("Signet of Vampirism",21761, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Plague Signet",10630, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Spite",10621, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of the Locust",10614, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Signet of Undeath",10610, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Vampirism",21761, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Plague Signet",10630, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Spite",10621, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of the Locust",10614, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Undeath",10610, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
                 //skills
                 new Boon("Spectral Walk",15083, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Infusing Terror", 30129, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
@@ -371,10 +415,10 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Signet of Fire",5544, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Signet of Water",5591, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 //attunments
-                new Boon("Fire Attunement", 5585, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Water Attunement", 5586, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Air Attunement", 5575, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Earth Attunement", 5580, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Fire Attunement", 5585, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Water Attunement", 5586, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Air Attunement", 5575, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Earth Attunement", 5580, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
                 //forms
                 new Boon("Mist Form",5543, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Ride the Lightning",5588, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
@@ -391,10 +435,10 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Arcane Power",5582, BoonSource.Elementalist, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/7/72/Arcane_Power.png"),
                 new Boon("Arcane Shield",5640, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Renewal of Fire",5764, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Glyph of Elemental Power (Fire)",5739, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Glyph of Elemental Power (Water)",5741, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Glyph of Elemental Power (Air)",5740, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Glyph of Elemental Power (Earth)",5742, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Glyph of Elemental Power (Fire)",5739, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Glyph of Elemental Power (Water)",5741, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Glyph of Elemental Power (Air)",5740, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Glyph of Elemental Power (Earth)",5742, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Rebound",31337, BoonSource.Elementalist, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/0/03/%22Rebound%21%22.png"),
                 new Boon("Rock Barrier",34633, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),//750?
                 new Boon("Magnetic Wave",15794, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
@@ -476,7 +520,6 @@ namespace LuckParser.Models.ParseModels
         {
             return allBoons.Where(x => x.priority != BoonEnum.Food).ToList();
         }
-
         public static List<Boon> getUtilityList()
         {
             return allBoons.Where(x => x.priority != BoonEnum.Utility).ToList();
@@ -490,6 +533,10 @@ namespace LuckParser.Models.ParseModels
         public static List<Boon> getRemainingBuffsList()
         {
             return allBoons.Where(x => x.priority == BoonEnum.NonShareableBuff).ToList();
+        }
+        public static List<Boon> getRemainingBuffsList(BoonSource source)
+        {
+            return getRemainingBuffsList().Where(x => x.plotlyGroup == source || x.plotlyGroup == BoonSource.Mixed).ToList();
         }
 
 

--- a/LuckParser/Models/ParseModels/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boon.cs
@@ -8,7 +8,7 @@ namespace LuckParser.Models.ParseModels
     public class Boon
     {
         // Boon
-        public enum BoonEnum { Condition, Boon, OffensiveBuff, DefensiveBuff, NonShareableBuff, Food, Utility, DontTrackForNow};
+        public enum BoonEnum { Condition, Boon, OffensiveBuff, DefensiveBuff, NonShareableBuff, Food, Utility};
         public enum BoonSource { Mixed, Necromancer, Elementalist, Mesmer, Warrior, Revenant, Guardian, Thief, Ranger, Engineer, Item  };
 
         public static BoonSource ProfToEnum(string prof)
@@ -132,7 +132,7 @@ namespace LuckParser.Models.ParseModels
                 // Generic
                 new Boon("Stealth", 13017, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Revealed", 890, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Superspeed", 5974, BoonSource.Mixed, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/1/1a/Super_Speed.png"),
+                new Boon("Superspeed", 5974, BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff, "https://wiki.guildwars2.com/images/1/1a/Super_Speed.png"),
                 //new Boon("Invulnerability", 801, BoonSource.Mixed, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/e/eb/Determined.png"),
                 new Boon("Unblockable", BoonSource.Mixed, "duration", 1, BoonEnum.NonShareableBuff),
                 //Auras
@@ -161,13 +161,13 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Enchanted Daggers", 28557, BoonSource.Revenant, "intensity", 6, BoonEnum.NonShareableBuff),
                 new Boon("Impossible Odds", 27581, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 //facets
-                new Boon("Facet of Light",27336, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Facet of Light",27336, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Infuse Light",27737, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/6/60/Infuse_Light.png"),
-                new Boon("Facet of Darkness",28036, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Facet of Elements",28243, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Facet of Strength",27376, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Facet of Chaos",27983, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Facet of Nature",29275, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Facet of Darkness",28036, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Facet of Elements",28243, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Facet of Strength",27376, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Facet of Chaos",27983, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Facet of Nature",29275, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Naturalistic Resonance", 29379, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/e/e9/Facet_of_Nature.png"),
                 //legends
                 new Boon("Legendary Centaur Stance",27972, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
@@ -243,15 +243,15 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Signet of Wrath",9100, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Signet of Courage",29633, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
                 //virtues
-                new Boon("Virtue of Justice", 9114, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Spears of Justice", 29632, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Virtue of Courage", 9113, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Shield of Courage", 29523, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Virtue of Resolve", 9119, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Wings of Resolve", 30308, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Tome of Justice",40530, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Tome of Courage",43508,BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Tome of Resolve",46298, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Virtue of Justice", 9114, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Spears of Justice", 29632, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Virtue of Courage", 9113, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Shield of Courage", 29523, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Virtue of Resolve", 9119, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Wings of Resolve", 30308, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Tome of Justice",40530, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Tome of Courage",43508,BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Tome of Resolve",46298, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
                 //traits
                 new Boon("Strength in Numbers",13796, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/7b/Strength_in_Numbers.png"),
                 new Boon("Invigorated Bulwark",30207, BoonSource.Guardian, "intensity", 5, BoonEnum.NonShareableBuff),
@@ -415,10 +415,10 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Signet of Fire",5544, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Signet of Water",5591, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 //attunments
-                new Boon("Fire Attunement", 5585, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Water Attunement", 5586, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Air Attunement", 5575, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Earth Attunement", 5580, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Fire Attunement", 5585, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Water Attunement", 5586, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Air Attunement", 5575, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Earth Attunement", 5580, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 //forms
                 new Boon("Mist Form",5543, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Ride the Lightning",5588, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
@@ -435,10 +435,10 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Arcane Power",5582, BoonSource.Elementalist, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/7/72/Arcane_Power.png"),
                 new Boon("Arcane Shield",5640, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Renewal of Fire",5764, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Glyph of Elemental Power (Fire)",5739, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Glyph of Elemental Power (Water)",5741, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Glyph of Elemental Power (Air)",5740, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Glyph of Elemental Power (Earth)",5742, BoonSource.Elementalist, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Glyph of Elemental Power (Fire)",5739, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Glyph of Elemental Power (Water)",5741, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Glyph of Elemental Power (Air)",5740, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Glyph of Elemental Power (Earth)",5742, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Rebound",31337, BoonSource.Elementalist, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/0/03/%22Rebound%21%22.png"),
                 new Boon("Rock Barrier",34633, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),//750?
                 new Boon("Magnetic Wave",15794, BoonSource.Elementalist, "duration", 1, BoonEnum.NonShareableBuff),
@@ -512,12 +512,12 @@ namespace LuckParser.Models.ParseModels
         // Foods
         public static List<Boon> getFoodList()
         {
-            return allBoons.Where(x => x.priority != BoonEnum.Food).ToList();
+            return allBoons.Where(x => x.priority == BoonEnum.Food).ToList();
         }
         // Utilities
         public static List<Boon> getUtilityList()
         {
-            return allBoons.Where(x => x.priority != BoonEnum.Utility).ToList();
+            return allBoons.Where(x => x.priority == BoonEnum.Utility).ToList();
         }
         // All buffs
         public static List<Boon> getAllProfList()

--- a/LuckParser/Models/ParseModels/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boon.cs
@@ -157,7 +157,7 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Crystal Hibernation", 28262, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Vengeful Hammers", 27273, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Rite of the Great Dwarf", 26596, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/6/69/Rite_of_the_Great_Dwarf.png"),
-                new Boon("Embrace the Darkness", 28001, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),// incorrect id?
+                new Boon("Embrace the Darkness", 28001, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),// incorrect id?
                 new Boon("Enchanted Daggers", 28557, BoonSource.Revenant, "intensity", 6, BoonEnum.NonShareableBuff),
                 new Boon("Impossible Odds", 27581, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 //facets
@@ -170,12 +170,12 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Facet of Nature",29275, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Naturalistic Resonance", 29379, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/e/e9/Facet_of_Nature.png"),
                 //legends
-                new Boon("Legendary Centaur Stance",27972, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Legendary Dragon Stance",27732, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Legendary Dwarf Stance",27205, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Legendary Demon Stance",27928, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Legendary Assassin Stance",27890, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Legendary Renegade Stance",44272, BoonSource.Revenant, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Legendary Centaur Stance",27972, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Legendary Dragon Stance",27732, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Legendary Dwarf Stance",27205, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Legendary Demon Stance",27928, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Legendary Assassin Stance",27890, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Legendary Renegade Stance",44272, BoonSource.Revenant, "duration", 1, BoonEnum.NonShareableBuff),
                 //summons
                 new Boon("Breakrazor's Bastion",44682, BoonSource.Revenant, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/a/a7/Breakrazor%27s_Bastion.png"),
                 new Boon("Razorclaw's Rage",41016, BoonSource.Revenant, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/7/73/Razorclaw%27s_Rage.png"),
@@ -199,12 +199,12 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Rock Guard", 34256 , BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Sight beyond Sight",40616, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
                 //signets
-                new Boon("Healing Signet",786, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Dolyak Signet",14458, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Fury",14459, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Might",14444, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Stamina",14478, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Rage",14496, BoonSource.Warrior, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Healing Signet",786, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Dolyak Signet",14458, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Fury",14459, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Might",14444, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Stamina",14478, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Rage",14496, BoonSource.Warrior, "duration", 1, BoonEnum.NonShareableBuff),
                 //banners
                 new Boon("Banner of Strength", 14417, BoonSource.Warrior, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/thumb/e/e1/Banner_of_Strength.png/33px-Banner_of_Strength.png"),
                 new Boon("Banner of Discipline", 14449, BoonSource.Warrior, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/thumb/5/5f/Banner_of_Discipline.png/33px-Banner_of_Discipline.png"),
@@ -231,17 +231,17 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Zealot's Flame", 9103, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Purging Flames",21672, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/2/28/Purging_Flames.png"),
                 new Boon("Litany of Wrath",21665, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Renewed Focus",9255, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Renewed Focus",9255, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Ashes of the Just",41957, BoonSource.Guardian, "intensity", 25, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/6/6d/Epilogue-_Ashes_of_the_Just.png"),
                 new Boon("Eternal Oasis",44871, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/5/5f/Epilogue-_Eternal_Oasis.png"),
                 new Boon("Unbroken Lines",43194, BoonSource.Guardian, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/d/d8/Epilogue-_Unbroken_Lines.png"),
                 //signets
-                new Boon("Signet of Resolve",9220, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Bane Signet",9092, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Judgment",9156, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Mercy",9162, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Wrath",9100, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Courage",29633, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Resolve",9220, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Bane Signet",9092, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Judgment",9156, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Mercy",9162, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Wrath",9100, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Courage",29633, BoonSource.Guardian, "duration", 1, BoonEnum.NonShareableBuff),
                 //virtues
                 new Boon("Virtue of Justice", 9114, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
                 new Boon("Spears of Justice", 29632, BoonSource.Guardian, "duration", 1, BoonEnum.DontTrackForNow),
@@ -274,15 +274,15 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Gear Shield",5997, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 //Transforms
                 new Boon("Rampage", BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Photon Forge",43708, BoonSource.Engineer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Photon Forge",43708, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 //Traits
-                new Boon("Laser's Edge",44414, BoonSource.Engineer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Laser's Edge",44414, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Afterburner",42210, BoonSource.Engineer, "intensity", 5, BoonEnum.NonShareableBuff),
                 new Boon("Iron Blooded",49065, BoonSource.Engineer, "intensity", 25, BoonEnum.NonShareableBuff),
                 new Boon("Streamlined Kits",18687, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Kinetic Charge",45781, BoonSource.Engineer, "intensity", 5, BoonEnum.NonShareableBuff),
                 new Boon("Pinpoint Distribution", 38333, BoonSource.Engineer, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/b/bf/Pinpoint_Distribution.png"),
-                new Boon("Heat Therapy",40694, BoonSource.Engineer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Heat Therapy",40694, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Overheat", 40397, BoonSource.Engineer, "duration", 1, BoonEnum.NonShareableBuff),
                 ///RANGER
                 new Boon("Celestial Avatar", 31508, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
@@ -309,8 +309,8 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Call of the Wild",36781, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Strength of the pack!",12554, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Sick 'Em!",33902, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Sharpening Stones",12536, BoonSource.Ranger, "intenstiy", 10, BoonEnum.DontTrackForNow),
-                new Boon("Ancestral Grace", 31584, BoonSource.Ranger, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Sharpening Stones",12536, BoonSource.Ranger, "intenstiy", 10, BoonEnum.NonShareableBuff),
+                new Boon("Ancestral Grace", 31584, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Glyph of Empowerment", 31803, BoonSource.Ranger, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/thumb/f/f0/Glyph_of_Empowerment.png/33px-Glyph_of_Empowerment.png"),
                 new Boon("Dolyak Stance",41815, BoonSource.Ranger, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/71/Dolyak_Stance.png"),
                 new Boon("Griffon Stance",46280, BoonSource.Ranger, "duration", 1, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/9/98/Griffon_Stance.png"),
@@ -321,7 +321,7 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Sharpen Spines",43266, BoonSource.Ranger, "intensity", 5, BoonEnum.NonShareableBuff),
                 //traits
                 new Boon("Spotter", 14055, BoonSource.Ranger, "duration", 1, BoonEnum.OffensiveBuff, "https://wiki.guildwars2.com/images/b/b0/Spotter.png"),
-                new Boon("Opening Strike",13988, BoonSource.Ranger, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Opening Strike",13988, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Quick Draw",29703, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Light on your feet",30673, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Natural Mender",30449, BoonSource.Ranger, "intensity", 10, BoonEnum.NonShareableBuff),
@@ -335,12 +335,12 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Twice as Vicious",45600, BoonSource.Ranger, "duration", 1, BoonEnum.NonShareableBuff),
                 ///THIEF
                 //signets
-                new Boon("Signet of Malice",13049, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Assassin's Signet (Passive)",13047, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Assassin's Signet (Active)",44597, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Infiltrator's Signet",13063, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Agility",13061, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Shadows",13059, BoonSource.Thief, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Malice",13049, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Assassin's Signet (Passive)",13047, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Assassin's Signet (Active)",44597, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Infiltrator's Signet",13063, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Agility",13061, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Shadows",13059, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
                 //venoms
                 new Boon("Skelk Venom",-1, BoonSource.Thief, "intensity", 4, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/75/Skelk_Venom.png"),
                 new Boon("Ice Drake Venom",13095, BoonSource.Thief, "intensity", 4, BoonEnum.DefensiveBuff, "https://wiki.guildwars2.com/images/7/7b/Ice_Drake_Venom.png"),
@@ -367,15 +367,15 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Bounding Dodger", 33162, BoonSource.Thief, "duration", 1, BoonEnum.NonShareableBuff),
                 ///MESMER
                 //signets
-                new Boon("Signet of the Ether", 21751, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Domination",10231, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Illusions",10246, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Inspiration",10235, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Midnight",10233, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Humility",30739, BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of the Ether", 21751, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Domination",10231, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Illusions",10246, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Inspiration",10235, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Midnight",10233, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Humility",30739, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 //skills
                 new Boon("Distortion",10243, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Blur", 10335 , BoonSource.Mesmer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Blur", 10335 , BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Mirror",10357, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Echo",29664, BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Illusion of Life", BoonSource.Mesmer, "duration", 1, BoonEnum.NonShareableBuff),
@@ -391,14 +391,14 @@ namespace LuckParser.Models.ParseModels
                 ///NECROMANCER
                 //forms
                 new Boon("Lich Form",10631, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
-                new Boon("Death Shroud", 790, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Reaper's Shroud", 29446, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Death Shroud", 790, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Reaper's Shroud", 29446, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
                 //signets
-                new Boon("Signet of Vampirism",21761, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Plague Signet",10630, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Spite",10621, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of the Locust",10614, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
-                new Boon("Signet of Undeath",10610, BoonSource.Necromancer, "duration", 1, BoonEnum.DontTrackForNow),
+                new Boon("Signet of Vampirism",21761, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Plague Signet",10630, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Spite",10621, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of the Locust",10614, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
+                new Boon("Signet of Undeath",10610, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
                 //skills
                 new Boon("Spectral Walk",15083, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
                 new Boon("Infusing Terror", 30129, BoonSource.Necromancer, "duration", 1, BoonEnum.NonShareableBuff),
@@ -474,16 +474,17 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Bountiful Maintenance Oil",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/5/5b/Master_Maintenance_Oil.png"),
                 new Boon("Toxic Focusing Crystal",-1, BoonSource.Item, "duration", 1, BoonEnum.Utility, "https://wiki.guildwars2.com/images/d/de/Toxic_Focusing_Crystal.png"),
             };
-
+        // Conditions
         public static List<Boon> getCondiBoonList()
         {
             return allBoons.Where(x => x.priority == BoonEnum.Condition).ToList();
         }
-        public static List<Boon> getList()
+        // Boons
+        public static List<Boon> getBoonList()
         {
-            return allBoons.Where(x => x.priority == BoonEnum.Boon || x.priority == BoonEnum.OffensiveBuff || x.priority == BoonEnum.DefensiveBuff).ToList();
+            return allBoons.Where(x => x.priority == BoonEnum.Boon).ToList();
         }
-
+        // Shareable buffs
         public static List<Boon> getOffensiveList()
         {
             return allBoons.Where(x => x.priority == BoonEnum.OffensiveBuff).ToList();
@@ -492,7 +493,6 @@ namespace LuckParser.Models.ParseModels
         {
             return getOffensiveList().Where(x => x.plotlyGroup == source).ToList();
         }
-
         public static List<Boon> getDefensiveList()
         {
             return allBoons.Where(x => x.priority == BoonEnum.DefensiveBuff).ToList();
@@ -501,12 +501,6 @@ namespace LuckParser.Models.ParseModels
         {
             return getDefensiveList().Where(x => x.plotlyGroup == source).ToList();
         }
-
-        public static List<Boon> getBoonList()
-        {
-            return allBoons.Where(x => x.priority == BoonEnum.Boon).ToList();
-        }
-
         public static List<Boon> getSharableProfList()
         {
             return allBoons.Where(x => x.priority == BoonEnum.OffensiveBuff || x.priority == BoonEnum.DefensiveBuff).ToList();   
@@ -515,28 +509,29 @@ namespace LuckParser.Models.ParseModels
         {
             return getSharableProfList().Where(x => x.plotlyGroup == source).ToList();
         }
-
+        // Foods
         public static List<Boon> getFoodList()
         {
             return allBoons.Where(x => x.priority != BoonEnum.Food).ToList();
         }
+        // Utilities
         public static List<Boon> getUtilityList()
         {
             return allBoons.Where(x => x.priority != BoonEnum.Utility).ToList();
         }
-
+        // All buffs
         public static List<Boon> getAllProfList()
         {
             return allBoons.Where(x => x.priority != BoonEnum.Condition && x.priority != BoonEnum.Food && x.priority != BoonEnum.Utility).ToList();
         }
-
+        // Non shareable buffs
         public static List<Boon> getRemainingBuffsList()
         {
             return allBoons.Where(x => x.priority == BoonEnum.NonShareableBuff).ToList();
         }
         public static List<Boon> getRemainingBuffsList(BoonSource source)
         {
-            return getRemainingBuffsList().Where(x => x.plotlyGroup == source || x.plotlyGroup == BoonSource.Mixed).ToList();
+            return getRemainingBuffsList().Where(x => x.plotlyGroup == source).ToList();
         }
 
 

--- a/LuckParser/Models/ParseModels/BoonLog.cs
+++ b/LuckParser/Models/ParseModels/BoonLog.cs
@@ -8,17 +8,17 @@ namespace LuckParser.Models.ParseModels
     public class BoonLog
     {
         // Fields
-        private int time = 0;
-        private int value = 0;
-        private int overstack = 0;
+        private long time = 0;
+        private long value = 0;
+        private long overstack = 0;
 
         // Constructor
-        public BoonLog(int time, int value)
+        public BoonLog(long time, long value)
         {
             this.time = time;
             this.value = value;
         }
-        public BoonLog(int time, int value,int overstack)
+        public BoonLog(long time, long value, long overstack)
         {
             this.time = time;
             this.value = value;
@@ -26,16 +26,16 @@ namespace LuckParser.Models.ParseModels
         }
 
         // Getters
-        public int getTime()
+        public long getTime()
         {
             return time;
         }
 
-        public int getValue()
+        public long getValue()
         {
             return value;
         }
-        public int getOverstack() {
+        public long getOverstack() {
             return overstack;
         }
     }

--- a/LuckParser/Models/ParseModels/BoonsGraphModel.cs
+++ b/LuckParser/Models/ParseModels/BoonsGraphModel.cs
@@ -10,17 +10,23 @@ namespace LuckParser.Models.ParseModels
     public class BoonsGraphModel
     {
         protected string boonname = null;
+        protected int boonid = -1;
         protected List<Point> boonChart = new List<Point>();
 
         // Constructor
-        public BoonsGraphModel(String boonname, List<Point> boonChart)
+        public BoonsGraphModel(string boonname, List<Point> boonChart, int boonid)
         {
             this.boonname = boonname;
             this.boonChart = boonChart;
+            this.boonid = boonid;
         }
         //getters
         public string getBoonName() {
             return this.boonname;
+        }
+        public int getBoonId()
+        {
+            return this.boonid;
         }
         public List<Point> getBoonChart()
         {

--- a/LuckParser/Models/ParseModels/BossData.cs
+++ b/LuckParser/Models/ParseModels/BossData.cs
@@ -9,16 +9,16 @@ namespace LuckParser.Models.ParseModels
     {
         // Fields
         private long agent = 0;
-        private int instid = 0;
-        private int first_aware = 0;
-        private int last_aware = Int16.MaxValue;
-        private int id;
+        private ushort instid = 0;
+        private long first_aware = 0;
+        private long last_aware = long.MaxValue;
+        private ushort id;
         private String name = "UNKNOWN";
         private int health = -1;
         private int toughness = -1;
-        private List<int[]> healthOverTime = new List<int[]>();
+        private List<long[]> healthOverTime = new List<long[]>();
         // Constructors
-        public BossData(int id)
+        public BossData(ushort id)
         {
             this.id = id;
         }
@@ -92,22 +92,22 @@ namespace LuckParser.Models.ParseModels
             return agent;
         }
 
-        public int getInstid()
+        public ushort getInstid()
         {
             return instid;
         }
 
-        public int getFirstAware()
+        public long getFirstAware()
         {
             return first_aware;
         }
 
-        public int getLastAware()
+        public long getLastAware()
         {
             return last_aware;
         }
 
-        public int getID()
+        public ushort getID()
         {
             return id;
         }
@@ -127,7 +127,7 @@ namespace LuckParser.Models.ParseModels
             return toughness;
         }
 
-        public List<int[]> getHealthOverTime() {
+        public List<long[]> getHealthOverTime() {
             return healthOverTime;
         }
         // Setters
@@ -136,17 +136,17 @@ namespace LuckParser.Models.ParseModels
             this.agent = agent;
         }
 
-        public void setInstid(int instid)
+        public void setInstid(ushort instid)
         {
             this.instid = instid;
         }
 
-        public void setFirstAware(int first_aware)
+        public void setFirstAware(long first_aware)
         {
             this.first_aware = first_aware;
         }
 
-        public void setLastAware(int last_aware)
+        public void setLastAware(long last_aware)
         {
             this.last_aware = last_aware;
         }
@@ -165,7 +165,7 @@ namespace LuckParser.Models.ParseModels
         {
             this.toughness = tough;
         }
-        public void setHealthOverTime(List<int[]> hot) {
+        public void setHealthOverTime(List<long[]> hot) {
             this.healthOverTime = hot;
         }
     }

--- a/LuckParser/Models/ParseModels/CastLog.cs
+++ b/LuckParser/Models/ParseModels/CastLog.cs
@@ -10,7 +10,7 @@ namespace LuckParser.Models.ParseModels
    public  class CastLog
     {
         // Fields
-        private int time;
+        private long time;
         private int skill_id;
         private int exp_dur;
         private int act_dur;
@@ -19,7 +19,7 @@ namespace LuckParser.Models.ParseModels
 
 
         // Constructor
-        public CastLog(int time, int skill_id, int exp_dur, Activation start_activation,int act_dur,Activation end_activation)
+        public CastLog(long time, int skill_id, int exp_dur, Activation start_activation,int act_dur,Activation end_activation)
         {
             this.time = time;
             this.skill_id = skill_id;
@@ -29,7 +29,7 @@ namespace LuckParser.Models.ParseModels
             this.end_activation = end_activation;
         }
         //start cast log
-        public CastLog(int time, int skill_id, int exp_dur, Activation start_activation)
+        public CastLog(long time, int skill_id, int exp_dur, Activation start_activation)
         {
             this.time = time;
             this.skill_id = skill_id;
@@ -39,7 +39,7 @@ namespace LuckParser.Models.ParseModels
         }
 
         // Getters
-        public int getTime()
+        public long getTime()
         {
             return time;
         }

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -30,7 +30,7 @@ namespace LuckParser.Models.ParseModels
             {
                 if (c.getSrcInstid() == src_instid && c.isStateChange().getEnum() == change)
                 {
-                    states.Add(new Point(c.getTime(), (int)c.getDstAgent()));
+                    states.Add(new Point((int)c.getTime(), (int)c.getDstAgent()));
                 }
             }
             return states;

--- a/LuckParser/Models/ParseModels/CombatItem.cs
+++ b/LuckParser/Models/ParseModels/CombatItem.cs
@@ -10,32 +10,32 @@ namespace LuckParser.Models.ParseModels
     {
 
         // Fields
-        private int time;
+        private long time;
         private long src_agent;
         private long dst_agent;
         private int value;
         private int buff_dmg;
-        private int overstack_value;
+        private ushort overstack_value;
         private int skill_id;
-        private int src_instid;
-        private int dst_instid;
-        private int src_master_instid;
+        private ushort src_instid;
+        private ushort dst_instid;
+        private ushort src_master_instid;
         private IFF iff;
-        private int is_buff;
+        private ushort is_buff;
         private Result result;
         private Activation is_activation;
         private BuffRemove is_buffremove;
-        private int is_ninety;
-        private int is_fifty;
-        private int is_moving;
+        private ushort is_ninety;
+        private ushort is_fifty;
+        private ushort is_moving;
         private StateChange is_statechange;
-        private int is_flanking;
-        private int is_shields;
+        private ushort is_flanking;
+        private ushort is_shields;
         // Constructor
-        public CombatItem(int time, long src_agent, long dst_agent, int value, int buff_dmg, int overstack_value,
-                int skill_id, int src_instid, int dst_instid, int src_master_instid, IFF iff, int buff, Result result,
-                Activation is_activation,BuffRemove is_buffremove, int is_ninety, int is_fifty, int is_moving,
-                StateChange is_statechange, int is_flanking)
+        public CombatItem(long time, long src_agent, long dst_agent, int value, int buff_dmg, ushort overstack_value,
+                int skill_id, ushort src_instid, ushort dst_instid, ushort src_master_instid, IFF iff, ushort buff, Result result,
+                Activation is_activation,BuffRemove is_buffremove, ushort is_ninety, ushort is_fifty, ushort is_moving,
+                StateChange is_statechange, ushort is_flanking)
         {
             this.time = time;
             this.src_agent = src_agent;
@@ -58,10 +58,10 @@ namespace LuckParser.Models.ParseModels
            this.is_statechange = is_statechange;
             this.is_flanking = is_flanking;
         }
-        public CombatItem(int time, long src_agent, long dst_agent, int value, int buff_dmg, int overstack_value,
-               int skill_id, int src_instid, int dst_instid, int src_master_instid, IFF iff, int buff, Result result,
-               Activation is_activation, BuffRemove is_buffremove, int is_ninety, int is_fifty, int is_moving,
-               StateChange is_statechange, int is_flanking,int is_shields)
+        public CombatItem(long time, long src_agent, long dst_agent, int value, int buff_dmg, ushort overstack_value,
+               int skill_id, ushort src_instid, ushort dst_instid, ushort src_master_instid, IFF iff, ushort buff, Result result,
+               Activation is_activation, BuffRemove is_buffremove, ushort is_ninety, ushort is_fifty, ushort is_moving,
+               StateChange is_statechange, ushort is_flanking, ushort is_shields)
         {
             this.time = time;
             this.src_agent = src_agent;
@@ -114,7 +114,7 @@ namespace LuckParser.Models.ParseModels
         }
 
         // Getters
-        public int getTime()
+        public long getTime()
         {
             return time;
         }
@@ -139,7 +139,7 @@ namespace LuckParser.Models.ParseModels
             return buff_dmg;
         }
 
-        public int getOverstackValue()
+        public ushort getOverstackValue()
         {
             return overstack_value;
         }
@@ -149,17 +149,17 @@ namespace LuckParser.Models.ParseModels
             return skill_id;
         }
 
-        public int getSrcInstid()
+        public ushort getSrcInstid()
         {
             return src_instid;
         }
 
-        public int getDstInstid()
+        public ushort getDstInstid()
         {
             return dst_instid;
         }
 
-        public int getSrcMasterInstid()
+        public ushort getSrcMasterInstid()
         {
             return src_master_instid;
         }
@@ -169,7 +169,7 @@ namespace LuckParser.Models.ParseModels
             return iff;
         }
 
-        public int isBuff()
+        public ushort isBuff()
         {
             return is_buff;
         }
@@ -189,22 +189,22 @@ namespace LuckParser.Models.ParseModels
             return is_buffremove;
         }
 
-        public int isNinety()
+        public ushort isNinety()
         {
             return is_ninety;
         }
 
-        public int isFifty()
+        public ushort isFifty()
         {
             return is_fifty;
         }
 
-        public int isMoving()
+        public ushort isMoving()
         {
             return is_moving;
         }
 
-        public int isFlanking()
+        public ushort isFlanking()
         {
             return is_flanking;
         }
@@ -213,7 +213,7 @@ namespace LuckParser.Models.ParseModels
         {
             return is_statechange;
         }
-        public int isShields() {
+        public ushort isShields() {
             return is_shields;
         }
         // Setters
@@ -227,12 +227,12 @@ namespace LuckParser.Models.ParseModels
             this.dst_agent = dst_agent;
         }
 
-        public void setSrcInstid(int src_instid)
+        public void setSrcInstid(ushort src_instid)
         {
             this.src_instid = src_instid;
         }
 
-        public void setDstInstid(int dst_instid)
+        public void setDstInstid(ushort dst_instid)
         {
             this.dst_instid = dst_instid;
         }

--- a/LuckParser/Models/ParseModels/DamageLog.cs
+++ b/LuckParser/Models/ParseModels/DamageLog.cs
@@ -9,22 +9,22 @@ namespace LuckParser.Models.ParseModels
     public class DamageLog
     {
         // Fields
-        private int time;
+        private long time;
         private int damage;
         private int skill_id;
         private int buff;
         private Result result;
-        private int is_ninety;
-        private int is_moving;
-        private int is_flanking;
+        private ushort is_ninety;
+        private ushort is_moving;
+        private ushort is_flanking;
         private Activation is_activation;
-        private int is_shields;
+        private ushort is_shields;
         private long src_agent;
-        private int src_instid;
+        private ushort src_instid;
 
         // Constructor
-        public DamageLog(int time, int damage, int skill_id, int buff, Result result, int is_ninety, int is_moving,
-                int is_flanking,Activation is_activation)
+        public DamageLog(long time, int damage, int skill_id, int buff, Result result, ushort is_ninety, ushort is_moving,
+                ushort is_flanking,Activation is_activation)
         {
             this.time = time;
             this.damage = damage;
@@ -36,8 +36,8 @@ namespace LuckParser.Models.ParseModels
             this.is_flanking = is_flanking;
             this.is_activation = is_activation;
         }
-        public DamageLog(int time, long srcagent,int instid, int damage, int skill_id, int buff, Result result, int is_ninety, int is_moving,
-               int is_flanking, Activation is_activation)
+        public DamageLog(long time, long srcagent, ushort instid, int damage, int skill_id, int buff, Result result, ushort is_ninety, ushort is_moving,
+               ushort is_flanking, Activation is_activation)
         {
             this.time = time;
             this.damage = damage;
@@ -52,8 +52,8 @@ namespace LuckParser.Models.ParseModels
             this.src_instid = instid;
 
         }
-        public DamageLog(int time, int damage, int skill_id, int buff, Result result, int is_ninety, int is_moving,
-               int is_flanking, Activation is_activation,int is_shields)
+        public DamageLog(long time, int damage, int skill_id, int buff, Result result, ushort is_ninety, ushort is_moving,
+               ushort is_flanking, Activation is_activation, ushort is_shields)
         {
             this.time = time;
             this.damage = damage;
@@ -66,8 +66,8 @@ namespace LuckParser.Models.ParseModels
             this.is_activation = is_activation;
             this.is_shields = is_shields;
         }
-        public DamageLog(int time, long srcagent, int instid, int damage, int skill_id, int buff, Result result, int is_ninety, int is_moving,
-              int is_flanking, Activation is_activation,int is_shields)
+        public DamageLog(long time, long srcagent, ushort instid, int damage, int skill_id, int buff, Result result, ushort is_ninety, ushort is_moving,
+              ushort is_flanking, Activation is_activation, ushort is_shields)
         {
             this.time = time;
             this.damage = damage;
@@ -84,7 +84,7 @@ namespace LuckParser.Models.ParseModels
 
         }
         // Getters
-        public int getTime()
+        public long getTime()
         {
             return time;
         }
@@ -109,17 +109,17 @@ namespace LuckParser.Models.ParseModels
             return result;
         }
 
-        public int isNinety()
+        public ushort isNinety()
         {
             return is_ninety;
         }
 
-        public int isMoving()
+        public ushort isMoving()
         {
             return is_moving;
         }
 
-        public int isFlanking()
+        public ushort isFlanking()
         {
             return is_flanking;
         }
@@ -127,14 +127,14 @@ namespace LuckParser.Models.ParseModels
         {
             return is_activation;
         }
-        public int isShields() {
+        public ushort isShields() {
             return is_shields;
         }
         public long getSrcAgent()
         {
             return src_agent;
         }
-        public int getInstidt()
+        public ushort getInstidt()
         {
             return src_instid;
         }

--- a/LuckParser/Models/ParseModels/Duration.cs
+++ b/LuckParser/Models/ParseModels/Duration.cs
@@ -21,7 +21,7 @@ namespace LuckParser.Models.ParseModels
             //check for overflow
             int total = boon_stack[0];
             for (int i =0;i<boon_stack.Count-1;i++) {
-                if (total > 0 && boon_stack[i + 1] > int.MaxValue - total)
+                if (total > 0 && boon_stack[i + 1] > uint.MaxValue - total)
                 {
                     //Overflow
                     return int.MaxValue;
@@ -35,13 +35,13 @@ namespace LuckParser.Models.ParseModels
         }
 
         
-    public override void update(int time_passed)
+    public override void update(long time_passed)
         {
 
             if (boon_stack.Count() > 0)
             {
                 // Clear stack
-                if (time_passed >= getStackValue())
+                if (time_passed >= (long)getStackValue())
                 {
                     boon_stack.Clear();
                     return;
@@ -49,11 +49,11 @@ namespace LuckParser.Models.ParseModels
                 // Remove from the longest duration
                 else
                 {
-                    boon_stack[0] = (boon_stack[0] - time_passed);
+                    boon_stack[0] = (int)((long)boon_stack[0] - time_passed);
                     if (boon_stack[0] <= 0)
                     {
                         // Spend leftover time
-                        time_passed = Math.Abs(boon_stack[0]);
+                        time_passed = (long)Math.Abs(boon_stack[0]);
                         boon_stack.RemoveAt(0);
                         update(time_passed);
                     }
@@ -62,7 +62,7 @@ namespace LuckParser.Models.ParseModels
         }
 
         
-    public override void addStacksBetween(List<int> boon_stacks, int time_between)
+    public override void addStacksBetween(List<int> boon_stacks, long time_between)
         {
         }
     }

--- a/LuckParser/Models/ParseModels/Duration.cs
+++ b/LuckParser/Models/ParseModels/Duration.cs
@@ -15,13 +15,13 @@ namespace LuckParser.Models.ParseModels
 
         // Public Methods
         
-    public override int getStackValue()
+    public override long getStackValue()
         {
             // return boon_stack.stream().mapToInt(Integer::intValue).sum();
             //check for overflow
-            int total = boon_stack[0];
+            long total = boon_stack[0];
             for (int i =0;i<boon_stack.Count-1;i++) {
-                if (total > 0 && boon_stack[i + 1] > uint.MaxValue - total)
+                if (total > 0 && boon_stack[i + 1] > long.MaxValue - total)
                 {
                     //Overflow
                     return int.MaxValue;
@@ -62,7 +62,7 @@ namespace LuckParser.Models.ParseModels
         }
 
         
-    public override void addStacksBetween(List<int> boon_stacks, long time_between)
+    public override void addStacksBetween(List<long> boon_stacks, long time_between)
         {
         }
     }

--- a/LuckParser/Models/ParseModels/Intensity.cs
+++ b/LuckParser/Models/ParseModels/Intensity.cs
@@ -21,13 +21,13 @@ namespace LuckParser.Models.ParseModels
         }
 
         
-    public override void update(int time_passed)
+    public override void update(long time_passed)
         {
 
             // Subtract from each
             for (int i = 0; i < boon_stack.Count(); i++)
             {
-                boon_stack[i] =( boon_stack[i] - time_passed);
+                boon_stack[i] = (int)( (long)boon_stack[i] - time_passed);
             }
             // Remove negatives
             int indexcount = 0;
@@ -50,7 +50,7 @@ namespace LuckParser.Models.ParseModels
         }
 
        
-    public override void addStacksBetween(List<int> boon_stacks, int time_between)
+    public override void addStacksBetween(List<int> boon_stacks, long time_between)
         {
 
             // Create copy of the boon
@@ -62,13 +62,13 @@ namespace LuckParser.Models.ParseModels
             if (stacks.Count() > 0)
             {
 
-                int time_passed = 0;
+                long time_passed = 0;
                 int min_duration = stacks.Min();
 
                 // Remove minimum duration from stack
-                for (int i = 1; i < time_between; i++)
+                for (long i = 1; i < time_between; i++)
                 {
-                    if ((i - time_passed) >= min_duration)
+                    if ((i - time_passed) >= (long)min_duration)
                     {
                         boon_copy.update(i - time_passed);
                         if (stacks.Count() > 0)
@@ -83,7 +83,7 @@ namespace LuckParser.Models.ParseModels
             // Fill in remaining time with 0 values
             else
             {
-                for (int i = 1; i < time_between; i++)
+                for (long i = 1; i < time_between; i++)
                 {
                     boon_stacks.Add(0);
                 }

--- a/LuckParser/Models/ParseModels/Intensity.cs
+++ b/LuckParser/Models/ParseModels/Intensity.cs
@@ -15,7 +15,7 @@ namespace LuckParser.Models.ParseModels
 
         // Public Methods
         
-    public override int getStackValue()
+    public override long getStackValue()
         {
             return boon_stack.Count();
         }
@@ -27,7 +27,7 @@ namespace LuckParser.Models.ParseModels
             // Subtract from each
             for (int i = 0; i < boon_stack.Count(); i++)
             {
-                boon_stack[i] = (int)( (long)boon_stack[i] - time_passed);
+                boon_stack[i] = boon_stack[i] - time_passed;
             }
             // Remove negatives
             int indexcount = 0;
@@ -50,20 +50,20 @@ namespace LuckParser.Models.ParseModels
         }
 
        
-    public override void addStacksBetween(List<int> boon_stacks, long time_between)
+    public override void addStacksBetween(List<long> boon_stacks, long time_between)
         {
 
             // Create copy of the boon
             Intensity boon_copy = new Intensity(this.capacity);
-            boon_copy.boon_stack = new List<int>(this.boon_stack);
-            List<int> stacks = boon_copy.boon_stack;
+            boon_copy.boon_stack = new List<long>(this.boon_stack);
+            List<long> stacks = boon_copy.boon_stack;
 
             // Simulate the boon stack decreasing
             if (stacks.Count() > 0)
             {
 
                 long time_passed = 0;
-                int min_duration = stacks.Min();
+                long min_duration = stacks.Min();
 
                 // Remove minimum duration from stack
                 for (long i = 1; i < time_between; i++)

--- a/LuckParser/Models/ParseModels/LogData.cs
+++ b/LuckParser/Models/ParseModels/LogData.cs
@@ -62,14 +62,14 @@ namespace LuckParser.Models.ParseModels
             this.pov = pov.Substring(0, pov.LastIndexOf('\0'));
         }
 
-        public void setLogStart(int unix_seconds)
+        public void setLogStart(long unix_seconds)
         {
             System.DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
             dtDateTime = dtDateTime.AddSeconds(unix_seconds).ToLocalTime();
             this.log_start = dtDateTime.ToString("yyyy-MM-dd HH:mm:ss z");//sdf.format(new Date(unix_seconds * 1000L));
         }
 
-        public void setLogEnd(int unix_seconds)
+        public void setLogEnd(long unix_seconds)
         {
             System.DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
             dtDateTime = dtDateTime.AddSeconds(unix_seconds).ToLocalTime();

--- a/LuckParser/Models/ParseModels/Mechanic.cs
+++ b/LuckParser/Models/ParseModels/Mechanic.cs
@@ -21,10 +21,10 @@ namespace LuckParser.Models.ParseModels
         //4 enemy boon stripped
         //5 spawn check
         //6 boss cast (check finished)
-        private int bossid;
+        private ushort bossid;
         private string plotlyShape;
 
-        public Mechanic( int skill_id, string name, int mechtype,int bossid, string plotlyShape,string friendlyName)
+        public Mechanic( int skill_id, string name, int mechtype, ushort bossid, string plotlyShape,string friendlyName)
         {
             this.skill_id = skill_id;
             this.name = name;
@@ -47,7 +47,7 @@ namespace LuckParser.Models.ParseModels
         {
             return mechType;
         }
-        public int GetBossID() {
+        public ushort GetBossID() {
             return bossid;
         }
 

--- a/LuckParser/Models/ParseModels/MechanicLog.cs
+++ b/LuckParser/Models/ParseModels/MechanicLog.cs
@@ -9,14 +9,14 @@ namespace LuckParser.Models.ParseModels
     public class MechanicLog
     {
         // Fields
-        private int time;
+        private long time;
         private int skill_id;
         private string name;
         private int damage;
         private Player player;
         private string plotlyShape;
 
-        public MechanicLog(int time, int skill_id,string name, int damage, Player p,string plotlyShape) {
+        public MechanicLog(long time, int skill_id,string name, int damage, Player p,string plotlyShape) {
             this.time = time;
             this.skill_id = skill_id;
             this.name = name;
@@ -25,7 +25,7 @@ namespace LuckParser.Models.ParseModels
             this.plotlyShape = plotlyShape;
         }
         //getters
-        public int GetTime() {
+        public long GetTime() {
             return time;
         }
         public int GetSkill()

--- a/LuckParser/Models/ParseModels/Player.cs
+++ b/LuckParser/Models/ParseModels/Player.cs
@@ -403,24 +403,22 @@ namespace LuckParser.Models.ParseModels
                 }
             }
         }
-        private void setBoonMap(BossData bossData, SkillData skillData, List<CombatItem> combatList, bool only_condi)
+        private void setBoonMap(BossData bossData, SkillData skillData, List<CombatItem> combatList, bool add_condi)
         {
             // Initialize Boon Map with every Boon
-            if (only_condi)
+            foreach (Boon boon in Boon.getAllProfList())
+            {
+                BoonMap map = new BoonMap(boon.getName(), boon.getID(), new List<BoonLog>());
+                boon_map[boon.getID()] = map;
+            }
+            // This only happens for bosses
+            if (add_condi)
             {
                 foreach (Boon boon in Boon.getCondiBoonList())
                 {
                     BoonMap map = new BoonMap(boon.getName(), boon.getID(), new List<BoonLog>());
                     boon_map[boon.getID()] = map;
                 }
-            } else
-            {
-                foreach (Boon boon in Boon.getAllProfList())
-                {
-                    BoonMap map = new BoonMap(boon.getName(), boon.getID(), new List<BoonLog>());
-                    boon_map[boon.getID()] = map;
-                }
-
             }
             // Fill in Boon Map
             int time_start = bossData.getFirstAware();

--- a/LuckParser/Models/ParseModels/Player.cs
+++ b/LuckParser/Models/ParseModels/Player.cs
@@ -403,21 +403,24 @@ namespace LuckParser.Models.ParseModels
                 }
             }
         }
-        private void setBoonMap(BossData bossData, SkillData skillData, List<CombatItem> combatList, bool add_condi)
+        private void setBoonMap(BossData bossData, SkillData skillData, List<CombatItem> combatList, bool only_condi)
         {
             // Initialize Boon Map with every Boon
-            foreach (Boon boon in Boon.getAllProfList())
-            {
-                BoonMap map = new BoonMap(boon.getName(), boon.getID(), new List<BoonLog>());
-                boon_map[boon.getID()] = map;
-            }
-            if (add_condi)
+            if (only_condi)
             {
                 foreach (Boon boon in Boon.getCondiBoonList())
                 {
                     BoonMap map = new BoonMap(boon.getName(), boon.getID(), new List<BoonLog>());
                     boon_map[boon.getID()] = map;
                 }
+            } else
+            {
+                foreach (Boon boon in Boon.getAllProfList())
+                {
+                    BoonMap map = new BoonMap(boon.getName(), boon.getID(), new List<BoonLog>());
+                    boon_map[boon.getID()] = map;
+                }
+
             }
             // Fill in Boon Map
             int time_start = bossData.getFirstAware();

--- a/LuckParser/Models/ParseModels/Player.cs
+++ b/LuckParser/Models/ParseModels/Player.cs
@@ -408,7 +408,7 @@ namespace LuckParser.Models.ParseModels
         private void setBoonMap(BossData bossData, SkillData skillData, List<CombatItem> combatList, bool add_condi)
         {
             // Initialize Boon Map with every Boon
-            foreach (Boon boon in Boon.getRemainingBuffsList(Boon.ProfToEnum(this.getProf())))
+            foreach (Boon boon in Boon.getAllProfList())
             {
                 BoonMap map = new BoonMap(boon.getName(), boon.getID(), new List<BoonLog>());
                 boon_map[boon.getID()] = map;
@@ -436,11 +436,8 @@ namespace LuckParser.Models.ParseModels
                     continue;
                 }
                 long time = c.getTime() - time_start;
-                string name = boon_map[c.getSkillID()].getName();
                 if (instid == c.getDstInstid() && time > 0 && time < fight_duration)
                 {
-                    int isBuff = c.isBuff();
-                    int isRemove = c.isBuffremove().getID();
                     if (c.isBuff() == 1 && c.isBuffremove().getID() == 0)
                     {
                         boon_map[c.getSkillID()].getBoonLog().Add(new BoonLog(time, (long)c.getValue(), c.getOverstackValue()));

--- a/LuckParser/Models/ParseModels/Statistics.cs
+++ b/LuckParser/Models/ParseModels/Statistics.cs
@@ -20,7 +20,7 @@ namespace LuckParser.Models.ParseModels
             }
             foreach (BoonLog bl in boon_logs)
             {
-                if (bl.getValue() + bl.getTime() > fight_duration)
+                if ((long)bl.getValue() + bl.getTime() > fight_duration)
                 {
                     os = os + (bl.getValue() - (fight_duration - bl.getTime())) + bl.getOverstack();
                 }
@@ -52,8 +52,8 @@ namespace LuckParser.Models.ParseModels
         public static List<Point> getBoonIntervalsList(AbstractBoon boon, List<BoonLog> boon_logs,BossData b_data)
         {
             // Initialise variables
-            int t_prev = 0;
-            int t_curr = 0;
+            long t_prev = 0;
+            long t_curr = 0;
             List<Point> boon_intervals = new List<Point>();
 
             // Loop: update then add durations
@@ -61,25 +61,25 @@ namespace LuckParser.Models.ParseModels
             {
                 t_curr = log.getTime();
                 boon.update(t_curr - t_prev);
-                boon.add(log.getValue());
-                int duration = t_curr + boon.getStackValue();//this may overload
+                boon.add((int)log.getValue());
+                long duration = t_curr + (long)boon.getStackValue();
                 if (duration < 0) {
-                    duration = Int32.MaxValue;
+                    duration = int.MaxValue;
                 }
                 t_prev = t_curr;
-                boon_intervals.Add(new Point(t_curr, duration));
+                boon_intervals.Add(new Point((int)t_curr, (int)duration));
             }
 
             // Merge intervals
             boon_intervals = Utility.mergeIntervals(boon_intervals);
 
             // Trim duration overflow
-            int fight_duration = b_data.getLastAware() - b_data.getFirstAware();
+            long fight_duration = b_data.getLastAware() - b_data.getFirstAware();
             int last = boon_intervals.Count() - 1;
-            if (boon_intervals[last].Y > fight_duration)
+            if ((long)boon_intervals[last].Y > fight_duration)
             {
                 Point mod = boon_intervals[last];
-                mod.Y = fight_duration;
+                mod.Y = (int)fight_duration;
                 boon_intervals[last] = mod;
             }
 
@@ -106,8 +106,8 @@ namespace LuckParser.Models.ParseModels
         public static List<int> getBoonStacksList(AbstractBoon boon, List<BoonLog> boon_logs,BossData b_data)
         {
             // Initialise variables
-            int t_prev = 0;
-            int t_curr = 0;
+            long t_prev = 0;
+            long t_curr = 0;
             List<int> boon_stacks = new List<int>();
             boon_stacks.Add(0);
 
@@ -117,7 +117,7 @@ namespace LuckParser.Models.ParseModels
                 t_curr = log.getTime();
                 boon.addStacksBetween(boon_stacks, t_curr - t_prev);
                 boon.update(t_curr - t_prev);
-                boon.add(log.getValue());
+                boon.add((int)log.getValue());
                 if (t_curr != t_prev)
                 {
                     boon_stacks.Add(boon.getStackValue());

--- a/LuckParser/Models/ParseModels/Statistics.cs
+++ b/LuckParser/Models/ParseModels/Statistics.cs
@@ -103,12 +103,12 @@ namespace LuckParser.Models.ParseModels
 
       
 
-        public static List<int> getBoonStacksList(AbstractBoon boon, List<BoonLog> boon_logs,BossData b_data)
+        public static List<long> getBoonStacksList(AbstractBoon boon, List<BoonLog> boon_logs,BossData b_data)
         {
             // Initialise variables
             long t_prev = 0;
             long t_curr = 0;
-            List<int> boon_stacks = new List<int>();
+            List<long> boon_stacks = new List<long>();
             boon_stacks.Add(0);
 
             // Loop: fill, update, and add to stacks
@@ -136,7 +136,7 @@ namespace LuckParser.Models.ParseModels
             return boon_stacks;
         }
 
-        public static String getAverageStacks(List<int> boon_stacks)
+        public static String getAverageStacks(List<long> boon_stacks)
         {
             // Calculate average stacks
             double average_stacks = boon_stacks.Sum();


### PR DESCRIPTION
- Some bug fixes here and there
- Put down baseground for foods/utilities
- Changed the progress bar on the header a little. Full health displayed below, damage done in green progress bar and failed in red bar (multi progress bar). Damage done and remaining health on hover
- Huge type rework in order to manage overflows (changed to ulong, long, short or ushort where applicable). Seems to have fixed overflow issues (at least on my test database) but could use more testing
- Nonshareable buffs are tracked per player when the 'all buff' option is enabled. They are displayed on the player tab, on the graph. Don't know if they should be put on a table, lots of them are more interesting to see on a time bar than plain uptime %
- Fixed a bug on Deimos CM, where the structure boss seems to appear long before the last 10% (before disapearing again, seems to happen at the start of the fight) thus if the pull is a fail, lastAware of the boss becomes nearly identical to firstAware, causing dps explosion and inevitable overflows
- Extended StateChange with more ids and migrated the successfull kill checking to "bouncy chest" method. Removed getBossKill() in Controller.cs as a result. Tested on several bosses, including SH. Seems to be working fine