### PR TITLE
Maintenance

### DIFF
--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -2325,6 +2325,7 @@ namespace LuckParser.Controllers
                 }           
                 sw.Write("</thead>");
                 HashSet<int> intensityBoon = new HashSet<int>();
+                bool boonTable = list_to_use.Select(x => x.getID()).Contains(740);
                 sw.Write("<tbody>");
                 {
                     foreach (Player player in p_list)
@@ -2338,7 +2339,21 @@ namespace LuckParser.Controllers
                         {
                             sw.Write("<td>" + player.getGroup().ToString() + "</td>");
                             sw.Write("<td>" + "<img src=\"" + GetLink(player.getProf().ToString()) + " \" alt=\"" + player.getProf().ToString() + "\" height=\"18\" width=\"18\" >" + "</td>");
-                            sw.Write("<td>" + player.getCharacter().ToString() + "</td>");
+                            if (boonTable)
+                            {
+                                long fight_duration = getBossData().getLastAware() - getBossData().getFirstAware();
+                                Dictionary<int, long> boonPresence = player.getBoonPresence(getBossData(), getSkillData(), getCombatData().getCombatList());
+                                double avg_boons = 0.0;
+                                foreach(Boon boon in list_to_use)
+                                {
+                                    avg_boons += boonPresence[boon.getID()];
+                                }
+                                avg_boons /= fight_duration;
+                                sw.Write("<td data-toggle=\"tooltip\" title=\"Average number of boons: " + Math.Round(avg_boons,1) + "\">" + player.getCharacter().ToString() + " </td>");
+                            } else
+                            {
+                                sw.Write("<td>" + player.getCharacter().ToString() + "</td>");
+                            }
                             foreach (Boon boon in list_to_use)
                             {
                                 if (boon.getType() == "intensity")
@@ -2908,7 +2923,7 @@ namespace LuckParser.Controllers
                                         Dictionary<int, BoonsGraphModel> boonGraphData = p.getBoonGraphs(getBossData(), getSkillData(), getCombatData().getCombatList());
                                         foreach (int boonid in boonGraphData.Keys.Reverse())
                                         {
-                                            if (parseBoonsList.FirstOrDefault(x => x.getID() == boonid) != null)
+                                            if (parseBoonsList.FirstOrDefault(x => x.getID() == boonid) != null || boonid == -2)
                                             {
                                                 sw.Write("{");
                                                 {

--- a/LuckParser/Models/ParseModels/Boons/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boons/Boon.cs
@@ -10,7 +10,7 @@ namespace LuckParser.Models.ParseModels
         // Boon
         public enum BoonEnum { Condition, Boon, OffensiveBuffTable, DefensiveBuffTable, GraphOnlyBuff, Food, Utility};
         public enum BoonSource { Mixed, Necromancer, Elementalist, Mesmer, Warrior, Revenant, Guardian, Thief, Ranger, Engineer, Item  };
-        public enum RemoveType { Cleanse, Manual, None};
+        public enum RemoveType { Cleanse, Manual, None, All};
 
         private static BoonSource ProfToEnum(string prof)
         {
@@ -113,8 +113,8 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Protection", 717, BoonSource.Mixed, "duration", 5, BoonEnum.Boon, "https://wiki.guildwars2.com/images/6/6c/Protection.png", RemoveType.Cleanse),
                 new Boon("Regeneration", 718, BoonSource.Mixed, "duration", 5, BoonEnum.Boon, "https://wiki.guildwars2.com/images/5/53/Regeneration.png", RemoveType.Cleanse),
                 new Boon("Vigor", 726, BoonSource.Mixed, "duration", 5, BoonEnum.Boon, "https://wiki.guildwars2.com/images/f/f4/Vigor.png", RemoveType.Cleanse),
-                new Boon("Aegis", 743, BoonSource.Mixed, "duration", 5, BoonEnum.Boon, "https://wiki.guildwars2.com/images/e/e5/Aegis.png", RemoveType.Cleanse),
-                new Boon("Stability", 1122, BoonSource.Mixed, "intensity", 25, BoonEnum.Boon, "https://wiki.guildwars2.com/images/a/ae/Stability.png", RemoveType.Cleanse),
+                new Boon("Aegis", 743, BoonSource.Mixed, "duration", 5, BoonEnum.Boon, "https://wiki.guildwars2.com/images/e/e5/Aegis.png", RemoveType.All),
+                new Boon("Stability", 1122, BoonSource.Mixed, "intensity", 25, BoonEnum.Boon, "https://wiki.guildwars2.com/images/a/ae/Stability.png", RemoveType.All),
                 new Boon("Swiftness", 719, BoonSource.Mixed, "duration", 9, BoonEnum.Boon, "https://wiki.guildwars2.com/images/a/af/Swiftness.png", RemoveType.Cleanse),
                 new Boon("Retaliation", 873, BoonSource.Mixed, "duration", 5, BoonEnum.Boon, "https://wiki.guildwars2.com/images/5/53/Retaliation.png", RemoveType.Cleanse),
                 new Boon("Resistance", 26980, BoonSource.Mixed, "duration", 5, BoonEnum.Boon, "https://wiki.guildwars2.com/images/thumb/e/e9/Resistance_40px.png/20px-Resistance_40px.png", RemoveType.Cleanse),
@@ -505,6 +505,8 @@ namespace LuckParser.Models.ParseModels
                         return buffremove == 1 || buffremove == 2;
                     case RemoveType.Manual:
                         return buffremove == 3;
+                    case RemoveType.All:
+                        return buffremove == 1 || buffremove == 2 || buffremove == 3;
                     default:
                         return false;
                 }

--- a/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
+++ b/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
@@ -9,10 +9,14 @@ namespace LuckParser.Models.ParseModels
 {
     public class BoonsGraphModel
     {
-        protected string boonname = null;
-        protected List<Point> boonChart = new List<Point>();
+        private string boonname = null;
+        private List<Point> boonChart = new List<Point>();
 
         // Constructor
+        public BoonsGraphModel(string boonname)
+        {
+            this.boonname = boonname;
+        }
         public BoonsGraphModel(string boonname, List<Point> boonChart)
         {
             this.boonname = boonname;

--- a/LuckParser/Models/ParseModels/Player.cs
+++ b/LuckParser/Models/ParseModels/Player.cs
@@ -411,7 +411,7 @@ namespace LuckParser.Models.ParseModels
             long dur = bossData.getLastAware() - bossData.getFirstAware();
             int fight_duration = (int)(dur) / 1000;
             // Init boon presence points
-            BoonsGraphModel boon_presence_points = new BoonsGraphModel("Average Boons");
+            BoonsGraphModel boon_presence_points = new BoonsGraphModel("Number of Boons");
             for (int i = 0; i < fight_duration; i++)
             {
                 boon_presence_points.getBoonChart().Add(new Point(i, 0));

--- a/LuckParser/Models/ParseModels/Player.cs
+++ b/LuckParser/Models/ParseModels/Player.cs
@@ -548,6 +548,8 @@ namespace LuckParser.Models.ParseModels
                                 {
                                     long subtract = (curBL.getTime() + curBL.getValue()) - time;
                                     loglist[cnt].addValue(-subtract);
+                                    // add removed as overstack
+                                    loglist[cnt].addOverstack((ushort)subtract);
                                 }
                             }
 
@@ -561,6 +563,8 @@ namespace LuckParser.Models.ParseModels
                             {
                                 long subtract = (curBL.getTime() + curBL.getValue()) - time;
                                 loglist[cnt].addValue(-subtract);
+                                // add removed as overstack
+                                loglist[cnt].addOverstack((ushort)subtract);
                             }
                         }
                         else if (c.isBuffremove().getID() == 3)//Manuel
@@ -574,6 +578,8 @@ namespace LuckParser.Models.ParseModels
                                 {
                                     long subtract = (curBL.getTime() + curBL.getValue()) - time;
                                     loglist[cnt].addValue(-subtract);
+                                    // add removed as overstack
+                                    loglist[cnt].addOverstack((ushort)subtract);
                                     break;
                                 }
                             }

--- a/LuckParser/Models/ParseModels/Player.cs
+++ b/LuckParser/Models/ParseModels/Player.cs
@@ -523,11 +523,7 @@ namespace LuckParser.Models.ParseModels
             
             foreach (CombatItem c in combatList)
             {
-                if (c.getValue() == 0 || c.isBuff() != 1  || c.getBuffDmg() > 0)
-                {
-                    continue;
-                }
-                if (!boon_map.ContainsKey(c.getSkillID()))
+                if (c.isBuff() != 1 || !boon_map.ContainsKey(c.getSkillID()))
                 {
                     continue;
                 }

--- a/LuckParser/Models/ParseModels/Player.cs
+++ b/LuckParser/Models/ParseModels/Player.cs
@@ -534,7 +534,7 @@ namespace LuckParser.Models.ParseModels
                     ushort src = c.getSrcMasterInstid() > 0 ? c.getSrcMasterInstid() : c.getSrcInstid();
                     if (c.isBuffremove().getID() == 0)
                     {
-                        boon_map[c.getSkillID()].Add(new BoonLog(time, src, c.getValue(), c.getOverstackValue()));
+                        boon_map[c.getSkillID()].Add(new BoonLog(time, src, c.getValue(), 0));
                     }
                     else if (Boon.removePermission(c.getSkillID(), c.isBuffremove().getID()))
                     {

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
@@ -40,6 +40,11 @@ namespace LuckParser.Models.ParseModels
 
         public abstract long getOverstack(ushort src);
 
+        public long getItemDuration()
+        {
+            return duration;
+        }
+
         public abstract void setEnd(long end);
 
         public abstract int getStack(long end);

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
@@ -38,6 +38,8 @@ namespace LuckParser.Models.ParseModels
             return start + duration;
         }
 
+        public abstract bool addOverstack(ushort src, long overstack);
+
         public abstract long getOverstack(ushort src);
 
         public long getItemDuration()

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemDuration.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemDuration.cs
@@ -51,5 +51,15 @@ namespace LuckParser.Models.ParseModels
         {
             return overstack;
         }
+
+        public override bool addOverstack(ushort src, long overstack)
+        {
+            if (this.src != src || duration == 0)
+            {
+                return false;
+            }
+            this.overstack += overstack;
+            return true;
+        }
     }
 }

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemIntensity.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemIntensity.cs
@@ -60,5 +60,21 @@ namespace LuckParser.Models.ParseModels
             }
             return total;
         }
+
+        public override bool addOverstack(ushort src, long overstack)
+        {
+            if (duration == 0)
+            {
+                return false;
+            }
+            foreach(BoonSimulationItemDuration stack in stacks)
+            {
+                if (stack.addOverstack(src,overstack))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
@@ -100,6 +100,15 @@ namespace LuckParser.Models.ParseModels
                 int index = boon_stack.Count() - 1;
                 if (boon_stack[index].boon_duration < boon_duration)
                 {
+                    long overstackValue = boon_stack[index].overstack + boon_stack[index].boon_duration;
+                    ushort srcValue = boon_stack[index].src;
+                    for (int i = simulation.Count -1; i >= 0; i--)
+                    {
+                        if (simulation[i].addOverstack(srcValue,overstackValue))
+                        {
+                            break;
+                        }
+                    }
                     boon_stack[index] = toAdd;
                     sort();
                 }

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
@@ -100,6 +100,7 @@ namespace LuckParser.Models.ParseModels
                 int index = boon_stack.Count() - 1;
                 if (boon_stack[index].boon_duration < boon_duration)
                 {
+                    // added overwritten value as a overstack
                     long overstackValue = boon_stack[index].overstack + boon_stack[index].boon_duration;
                     ushort srcValue = boon_stack[index].src;
                     for (int i = simulation.Count -1; i >= 0; i--)


### PR DESCRIPTION
Feature:
- Avg number of boons when hovering the name of the player on boon uptime table
- Number of boons on a given time on the player tab (as Number of Boons)

Bugfix:
- Fixed a bug where Aegis and Stability were not properly removed after a hit/cc
- Fixed a bug where the filtering in get boon map was too agressive
- Fixed a bug where the overstack values were too high and associated to incorrect players


You can also close Derpy Moa's issue as Enhancement