### PR TITLE
Maintenance

### DIFF
--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -453,7 +453,7 @@ namespace LuckParser.Controllers
                             // No split
                             break;
                         }
-                        boss.addPhaseData(boss_data.getLastAware());
+                        boss.addPhaseData(NPC.getFirstAware() >= oldAware ? NPC.getFirstAware() : oldAware);
                         boss_data.setLastAware(NPC.getLastAware());
                         //List<CombatItem> fuckyou = combat_list.Where(x => x.getDstInstid() == deimos_2_instid ).ToList().Sum(x);
                         //int stop = 0;

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -305,12 +305,10 @@ namespace LuckParser.Controllers
         private void fillMissingData(MemoryStream stream)
         {
             // Set Agent instid, first_aware and last_aware
-            List<AgentItem> player_list = agent_data.getPlayerAgentList();
-            List<AgentItem> agent_list = agent_data.getAllAgentsList();
             List<CombatItem> combat_list = combat_data.getCombatList();
             foreach (CombatItem c in combat_list)
             {
-                foreach (AgentItem a in agent_list)
+                foreach (AgentItem a in agent_data.getAllAgentsList())
                 {
                     if (a.getInstid() == 0 && a.getAgent() == c.getSrcAgent() && c.isStateChange().getID() == 0)
                     {
@@ -333,10 +331,10 @@ namespace LuckParser.Controllers
             {
                 if (c.getSrcMasterInstid() != 0)
                 {
-                    AgentItem master = agent_list.Find(x => x.getInstid() == c.getSrcMasterInstid() && x.getFirstAware() < c.getTime() && c.getTime() < x.getLastAware());
+                    AgentItem master = agent_data.getAllAgentsList().Find(x => x.getInstid() == c.getSrcMasterInstid() && x.getFirstAware() < c.getTime() && c.getTime() < x.getLastAware());
                     if (master != null)
                     {
-                        AgentItem minion = agent_list.Find(x => x.getAgent() == c.getSrcAgent() && x.getFirstAware() < c.getTime() && c.getTime() < x.getLastAware());
+                        AgentItem minion = agent_data.getAllAgentsList().Find(x => x.getAgent() == c.getSrcAgent() && x.getFirstAware() < c.getTime() && c.getTime() < x.getLastAware());
                         if (minion != null)
                         {
                             minion.setMasterAgent(master.getAgent());
@@ -378,7 +376,7 @@ namespace LuckParser.Controllers
                 if (c.isStateChange().getID() == 13 && log_data.getPOV() == "N/A")//Point of View
                 {
                     ulong pov_agent = c.getSrcAgent();
-                    foreach (AgentItem p in player_list)
+                    foreach (AgentItem p in agent_data.getPlayerAgentList())
                     {
                         if (pov_agent == p.getAgent())
                         {
@@ -444,9 +442,9 @@ namespace LuckParser.Controllers
             if (boss_data.getID() == 17154)
             {
                 int deimos_2_instid = 0;
-                foreach (AgentItem NPC in NPC_list)
+                foreach (AgentItem NPC in agent_data.getGadgetAgentList())
                 {
-                    if (NPC.getProf().Contains("57069"))
+                    if (NPC.getProf().Contains("08467"))
                     {
                         deimos_2_instid = NPC.getInstid();
                         long oldAware = boss_data.getLastAware();

--- a/LuckParser/Controllers/Controller1.cs
+++ b/LuckParser/Controllers/Controller1.cs
@@ -590,7 +590,7 @@ namespace LuckParser.Controllers
                     string name = skill_data.getName(dLog.getID());
                     if (dLog.getResult().getID() < 3 ) {
 
-                        foreach (Mechanic mech in mech_data.GetMechList(boss_data.getID()).Where(x=>x.GetMechType() == 3))
+                        foreach (Mechanic mech in mech_data.GetMechList(boss_data.getID()).Where(x=>x.GetMechType() == Mechanic.MechType.SkillOnPlayer))
                         {
                             //Prevent multi hit attacks form multi registering
                             if (prevMech != null)
@@ -621,7 +621,7 @@ namespace LuckParser.Controllers
                         {
                             String name = skill_data.getName(c.getSkillID());
                             //buff on player 0
-                            foreach (Mechanic mech in mech_data.GetMechList(boss_data.getID()).Where(x => x.GetMechType() == 0))
+                            foreach (Mechanic mech in mech_data.GetMechList(boss_data.getID()).Where(x => x.GetMechType() == Mechanic.MechType.PlayerBoon))
                             {
                                 if (c.getSkillID() == mech.GetSkill())
                                 {
@@ -631,7 +631,7 @@ namespace LuckParser.Controllers
                                 }
                             }
                             //player on player 7
-                            foreach (Mechanic mech in mech_data.GetMechList(boss_data.getID()).Where(x => x.GetMechType() == 7))
+                            foreach (Mechanic mech in mech_data.GetMechList(boss_data.getID()).Where(x => x.GetMechType() == Mechanic.MechType.PlayerOnPlayer))
                             {
                                 if (c.getSkillID() == mech.GetSkill())
                                 {

--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -1106,7 +1106,7 @@ namespace LuckParser.Controllers
                             if (boonTable)
                             {
                                 long fight_duration = phases[phase_index].getDuration();
-                                Dictionary<int, long> boonPresence = player.getBoonPresence(boss_data, skill_data, combat_data.getCombatList(), phases, phase_index);
+                                Dictionary<int, long> boonPresence = player.getBoonPresence(boss_data, skill_data, combat_data.getCombatList(), agent_data, phases, phase_index);
                                 double avg_boons = 0.0;
                                 foreach (Boon boon in list_to_use)
                                 {
@@ -1452,7 +1452,7 @@ namespace LuckParser.Controllers
                                         {
                                             parseBoonsList.AddRange(present_personnal[p.getInstid()]);
                                         }
-                                        Dictionary<int, BoonsGraphModel> boonGraphData = p.getBoonGraphs(boss_data, skill_data, combat_data.getCombatList(), phases);
+                                        Dictionary<int, BoonsGraphModel> boonGraphData = p.getBoonGraphs(boss_data, skill_data, combat_data.getCombatList(), agent_data, phases);
                                         foreach (int boonid in boonGraphData.Keys.Reverse())
                                         {
                                             BoonsGraphModel bgm = boonGraphData[boonid];
@@ -2438,7 +2438,7 @@ namespace LuckParser.Controllers
                         parseBoonsList.AddRange(Boon.getCondiBoonList());
                         //Every buffs and boons
                         parseBoonsList.AddRange(Boon.getAllBuffList());
-                        Dictionary<int, BoonsGraphModel> boonGraphData = boss.getBoonGraphs(boss_data, skill_data, combat_data.getCombatList(), phases);
+                        Dictionary<int, BoonsGraphModel> boonGraphData = boss.getBoonGraphs(boss_data, skill_data, combat_data.getCombatList(), agent_data, phases);
                         foreach (int boonid in boonGraphData.Keys.Reverse())
                         {
                             if (parseBoonsList.FirstOrDefault(x => x.getID() == boonid) != null)
@@ -3121,7 +3121,7 @@ namespace LuckParser.Controllers
                         {
                             parseBoonsList.AddRange(present_personnal[p.getInstid()]);
                         }
-                        Dictionary<int, BoonsGraphModel> boonGraphData = p.getBoonGraphs(boss_data, skill_data, combat_data.getCombatList(), phases);
+                        Dictionary<int, BoonsGraphModel> boonGraphData = p.getBoonGraphs(boss_data, skill_data, combat_data.getCombatList(), agent_data, phases);
                         foreach (int boonid in boonGraphData.Keys.Reverse())
                         {
                             if (parseBoonsList.FirstOrDefault(x => x.getID() == boonid) != null)

--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -324,7 +324,7 @@ namespace LuckParser.Controllers
         public static Dictionary<int, string> getfinalboons(BossData b_data, CombatData c_data, SkillData s_data, AgentData a_data, Boss boss, Player p, int phase_index)
         {
             List<PhaseData> phases = boss.getPhases(b_data, c_data.getCombatList(), a_data, settings.ParsePhases);
-            BoonDistribution boon_distrib = p.getBoonDistribution(b_data, s_data, c_data.getCombatList(), phases, phase_index);
+            BoonDistribution boon_distrib = p.getBoonDistribution(b_data, s_data, c_data.getCombatList(), a_data, phases, phase_index);
             Dictionary<int, string> rates = new Dictionary<int, string>();
             long fight_duration = phases[phase_index].getEnd() - phases[phase_index].getStart();
             foreach (Boon boon in Boon.getAllBuffList())
@@ -357,7 +357,7 @@ namespace LuckParser.Controllers
             Dictionary<Player, BoonDistribution> boon_logsDist = new Dictionary<Player, BoonDistribution>();
             foreach (Player player in trgetPlayers)
             {
-                boon_logsDist[player] = player.getBoonDistribution(b_data, s_data, c_data.getCombatList(), phases, phase_index);
+                boon_logsDist[player] = player.getBoonDistribution(b_data, s_data, c_data.getCombatList(), a_data, phases, phase_index);
             }
             Dictionary<int, string> rates = new Dictionary<int, string>();
             foreach (Boon boon in Boon.getAllBuffList())
@@ -400,7 +400,7 @@ namespace LuckParser.Controllers
         public static Dictionary<int, string> getfinalcondis(BossData b_data, CombatData c_data, SkillData s_data, AgentData a_data, Boss boss, AbstractPlayer p, int phase_index)
         {
             List<PhaseData> phases = boss.getPhases(b_data, c_data.getCombatList(), a_data, settings.ParsePhases);
-            BoonDistribution boon_distrib = p.getBoonDistribution(b_data, s_data, c_data.getCombatList(),phases, phase_index);
+            BoonDistribution boon_distrib = p.getBoonDistribution(b_data, s_data, c_data.getCombatList(), a_data, phases, phase_index);
             Dictionary<int, string> rates = new Dictionary<int, string>();
             PhaseData phase = phases[phase_index];
             foreach (Boon boon in Boon.getCondiBoonList())

--- a/LuckParser/Models/ParseModels/Mechanic.cs
+++ b/LuckParser/Models/ParseModels/Mechanic.cs
@@ -2,25 +2,28 @@
 {
     public class Mechanic
     {
+        //X indicates not gathering mechanic in mech logs
+        /// <summary>
+        /// 0 - PlayerBoon 
+        /// 1 - BossBoon X
+        /// 2 - PlayerSkill X
+        /// 3 - SkillOnPlayer
+        /// 4 - EnemyBoonStrip X
+        /// 5 - Spawn X
+        /// 6 - BossCast X
+        /// 7 - PlayerOnPlayer
+        /// </summary>
+        public enum MechType { PlayerBoon, BossBoon, SkillOnPlayer, PlayerSkill, EnemyBoonStrip, Spawn, BossCast, PlayerOnPlayer }
         // Fields
        
         private int skill_id;
         private string name;
         private string altname;
-        private int mechType;
-        //X indicates not gathering mechanic in mech logs
-        //0 boon on player
-        //1 boon on boss X
-        //2 skill by player X
-        //3 skill on player
-        //4 enemy boon stripped X
-        //5 spawn check X
-        //6 boss cast (check finished) X
-        //7 player on player 
+        private MechType mechType;       
         private ushort bossid;
         private string plotlyShape;
 
-        public Mechanic( int skill_id, string name, int mechtype, ushort bossid, string plotlyShape,string friendlyName)
+        public Mechanic( int skill_id, string name, MechType mechtype, ushort bossid, string plotlyShape,string friendlyName)
         {
             this.skill_id = skill_id;
             this.name = name;
@@ -39,7 +42,7 @@
         {
             return name;
         }
-        public int GetMechType()
+        public MechType GetMechType()
         {
             return mechType;
         }

--- a/LuckParser/Models/ParseModels/MechanicData.cs
+++ b/LuckParser/Models/ParseModels/MechanicData.cs
@@ -9,177 +9,177 @@ namespace LuckParser.Models.ParseModels
         private List<Mechanic> globalMechList = new List<Mechanic>()
         {
             //VG
-            new Mechanic(31860,"Unstable Magic Spike",3, 15438, "symbol:'circle',color:'rgb(0,0,255)',", "Green Teleport blue"),
-            new Mechanic(31392, "Unstable Magic Spike", 3, 15438, "symbol:'circle',color:'rgb(0,0,255)',", "Boss Teleport blue"),
-            new Mechanic(31340, "Distributed Magic", 3, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
-            new Mechanic(31391, "Distributed Magic", 3, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
-            new Mechanic(31529, "Distributed Magic", 3, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
-            new Mechanic(31750, "Distributed Magic", 3, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
-            new Mechanic(31886, "Magic Pulse", 3, 15438, "symbol:'circle',color:'rgb(255,0,0)',", "Hit by Red"),
-            new Mechanic(-1, "Pylon Attunement: Red", 0, 15438, "symbol:'square',color:'rgb(255,0,0)',", "Attune:Red"),
-            new Mechanic(31317, "Pylon Attunement: Blue", 0, 15438, "symbol:'square',color:'rgb(0,0,255)',", "Attune:Blue"),
-            new Mechanic(-1, "Pylon Attunement: Green", 0, 15438, "symbol:'square',color:'rgb(0,128,0)',", "Attune:Green"),
-            new Mechanic(31413, "Blue Pylon Power", 4, 15438, "symbol:'square',color:'rgb(0,0,255)',", "Striped Blue Invuln"),
-            new Mechanic(31539, "Unstable Pylon", 3, 15438, "symbol:'hexagram',color:'rgb(255,0,0)',", "Floor Damage"),
-            new Mechanic(31828, "Unstable Pylon", 3, 15438, "symbol:'hexagram',color:'rgb(0,0,255)',", "Floor Damage"),
-            new Mechanic(31884, "Unstable Pylon", 3, 15438, "symbol:'hexagram',color:'rgb(0,128,0)',", "Floor Damage"),
+            new Mechanic(31860,"Unstable Magic Spike", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'circle',color:'rgb(0,0,255)',", "Green Teleport blue"),
+            new Mechanic(31392, "Unstable Magic Spike", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'circle',color:'rgb(0,0,255)',", "Boss Teleport blue"),
+            new Mechanic(31340, "Distributed Magic", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
+            new Mechanic(31391, "Distributed Magic", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
+            new Mechanic(31529, "Distributed Magic", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
+            new Mechanic(31750, "Distributed Magic", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'circle',color:'rgb(0,128,0)',", "Green Team"),
+            new Mechanic(31886, "Magic Pulse", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'circle',color:'rgb(255,0,0)',", "Hit by Red"),
+            new Mechanic(-1, "Pylon Attunement: Red", Mechanic.MechType.PlayerBoon, 15438, "symbol:'square',color:'rgb(255,0,0)',", "Attune:Red"),
+            new Mechanic(31317, "Pylon Attunement: Blue", Mechanic.MechType.PlayerBoon, 15438, "symbol:'square',color:'rgb(0,0,255)',", "Attune:Blue"),
+            new Mechanic(-1, "Pylon Attunement: Green", Mechanic.MechType.PlayerBoon, 15438, "symbol:'square',color:'rgb(0,128,0)',", "Attune:Green"),
+            new Mechanic(31413, "Blue Pylon Power", Mechanic.MechType.EnemyBoonStrip, 15438, "symbol:'square',color:'rgb(0,0,255)',", "Striped Blue Invuln"),
+            new Mechanic(31539, "Unstable Pylon", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'hexagram',color:'rgb(255,0,0)',", "Floor Damage"),
+            new Mechanic(31828, "Unstable Pylon", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'hexagram',color:'rgb(0,0,255)',", "Floor Damage"),
+            new Mechanic(31884, "Unstable Pylon", Mechanic.MechType.SkillOnPlayer, 15438, "symbol:'hexagram',color:'rgb(0,128,0)',", "Floor Damage"),
             //gors         
-            new Mechanic(31875, "Spectral Impact", 3, 15429, "symbol:'hexagram',color:'rgb(255,0,0)',", "Slam"),
-            new Mechanic(31623, "Ghastly Prison", 3, 15429, "symbol:'pentagon',color:'rgb(0,0,255)',", "Egg"),
-            new Mechanic(31498, "Spectral Darkness", 0, 15429, "symbol:'circle',color:'rgb(0,0,255)',", "Orb Debuff"),
+            new Mechanic(31875, "Spectral Impact", Mechanic.MechType.SkillOnPlayer, 15429, "symbol:'hexagram',color:'rgb(255,0,0)',", "Slam"),
+            new Mechanic(31623, "Ghastly Prison", Mechanic.MechType.SkillOnPlayer, 15429, "symbol:'pentagon',color:'rgb(0,0,255)',", "Egg"),
+            new Mechanic(31498, "Spectral Darkness", Mechanic.MechType.PlayerBoon, 15429, "symbol:'circle',color:'rgb(0,0,255)',", "Orb Debuff"),
 
-            new Mechanic(31722, "Spirited Fusion", 1, 15429, "symbol:'square',color:'rgb(0,0,255)',", "Ate Spirit"),
+            new Mechanic(31722, "Spirited Fusion", Mechanic.MechType.BossBoon, 15429, "symbol:'square',color:'rgb(0,0,255)',", "Ate Spirit"),
             //sab
-            new Mechanic(34108, "Shell-Shocked", 0, 15375, "symbol:'circle',color:'rgb(255,0,0)',", "Canons"),
-            new Mechanic(31473, "Sapper Bomb", 0, 15375, "symbol:'circle',color:'rgb(0,128,0)',", "Green Bomb"),
-            new Mechanic(31485, "Time Bomb", 0, 15375, "symbol:'circle',color:'rgb(0,0,255)',", "Time Bomb"),//or 3? buff or hits
-            new Mechanic(31332, "Firestorm", 3, 15375, "symbol:'square',color:'rgb(255,0,0)',", "Flamewall"),
-            new Mechanic(31544, "Flak Shot", 3, 15375, "symbol:'hexagram',color:'rgb(255,0,0)',", "Flak"),
+            new Mechanic(34108, "Shell-Shocked", Mechanic.MechType.PlayerBoon, 15375, "symbol:'circle',color:'rgb(255,0,0)',", "Canons"),
+            new Mechanic(31473, "Sapper Bomb", Mechanic.MechType.PlayerBoon, 15375, "symbol:'circle',color:'rgb(0,128,0)',", "Green Bomb"),
+            new Mechanic(31485, "Time Bomb", Mechanic.MechType.PlayerBoon, 15375, "symbol:'circle',color:'rgb(0,0,255)',", "Time Bomb"),//or 3? buff or hits
+            new Mechanic(31332, "Firestorm", Mechanic.MechType.SkillOnPlayer, 15375, "symbol:'square',color:'rgb(255,0,0)',", "Flamewall"),
+            new Mechanic(31544, "Flak Shot", Mechanic.MechType.SkillOnPlayer, 15375, "symbol:'hexagram',color:'rgb(255,0,0)',", "Flak"),
 
                 //sloth
-                new Mechanic(34479, "Tantrum", 3, 16123, "symbol:'circle',color:'rgb(255,0,0)',", "Tantrum"),
-                new Mechanic(34387, "Volatile Poison", 0, 16123, "symbol:'circle',color:'rgb(0,128,0)',", "Poisin Buff"),
-                new Mechanic(34481, "Volatile Poison", 3, 16123, "symbol:'hexagram',color:'rgb(0,128,0)',", "Poisin AOE"),
-                new Mechanic(34516, "Halitosis", 3, 16123, "symbol:'hexagram',color:'rgb(255,0,0)',", "Flame Breathe"),
-                new Mechanic(34482, "Spore Release", 3, 16123, "symbol:'pentagon',color:'rgb(0,128,0)',", "Shake"),
-                new Mechanic(34362, "Magic Transformation", 0, 16123, "symbol:'square',color:'rgb(0,128,0)',", "Slub Transform"),
-                new Mechanic(34496, "Nauseated", 0, 16123, "symbol:'square',color:'rgb(0,0,255)',", "Slub CD"),
-                new Mechanic(34508, "Fixated", 0, 16123, "symbol:'star',color:'rgb(0,0,255)',", "Fixated"),
+                new Mechanic(34479, "Tantrum", Mechanic.MechType.SkillOnPlayer, 16123, "symbol:'circle',color:'rgb(255,0,0)',", "Tantrum"),
+                new Mechanic(34387, "Volatile Poison", Mechanic.MechType.PlayerBoon, 16123, "symbol:'circle',color:'rgb(0,128,0)',", "Poisin Buff"),
+                new Mechanic(34481, "Volatile Poison", Mechanic.MechType.SkillOnPlayer, 16123, "symbol:'hexagram',color:'rgb(0,128,0)',", "Poisin AOE"),
+                new Mechanic(34516, "Halitosis", Mechanic.MechType.SkillOnPlayer, 16123, "symbol:'hexagram',color:'rgb(255,0,0)',", "Flame Breathe"),
+                new Mechanic(34482, "Spore Release", Mechanic.MechType.SkillOnPlayer, 16123, "symbol:'pentagon',color:'rgb(0,128,0)',", "Shake"),
+                new Mechanic(34362, "Magic Transformation", Mechanic.MechType.PlayerBoon, 16123, "symbol:'square',color:'rgb(0,128,0)',", "Slub Transform"),
+                new Mechanic(34496, "Nauseated", Mechanic.MechType.PlayerBoon, 16123, "symbol:'square',color:'rgb(0,0,255)',", "Slub CD"),
+                new Mechanic(34508, "Fixated", Mechanic.MechType.PlayerBoon, 16123, "symbol:'star',color:'rgb(0,0,255)',", "Fixated"),
 
                 //matt
-                new Mechanic(34380, "Oppressive Gaze", 3, 16115, "symbol:'hexagram',color:'rgb(0,0,255)',", "Hadouken"),//human
-                new Mechanic(34371, "Oppressive Gaze", 3, 16115, "symbol:'hexagram',color:'rgb(0,0,255)',", "Hadouken"),//abom
-                new Mechanic(34404, "Shards of Rage", 3, 16115, "symbol:'hexagram',color:'rgb(255,0,0)',", "Backflip Shards"),//human
-                new Mechanic(34411, "Shards of Rage", 3, 16115, "symbol:'hexagram',color:'rgb(255,0,0)',", "Backflip Shards"),//abom
-                new Mechanic(34450, "Unstable Blood Magic", 0, 16115, "symbol:'diamond',color:'rgb(255,0,0)',", "Bomb"),
-                new Mechanic(34416, "Corruption", 0, 16115, "symbol:'circle',color:'rgb(255,0,0)',", "Corruption"),
-                new Mechanic(34442, "Sacrifice", 0, 16115, "symbol:'circle',color:'rgb(75,0,130)',", "Sacrifice"),
-                new Mechanic(34367, "Unbalanced", 0, 16115, "symbol:'square',color:'rgb(75,30,150)',", "Rain Knockdown"),
-                new Mechanic(34422, "Blood Fueled", 1, 16115, "symbol:'square',color:'rgb(255,0,0)',", "Ate Reflects(Bad)"),
-                new Mechanic(34428, "Blood Fueled", 1, 16115, "symbol:'square',color:'rgb(255,0,0)',", "Ate Reflects(Bad)"),
-                new Mechanic(34376, "Blood Shield", 1, 16115, "symbol:'octagon',color:'rgb(255,0,0)',", "Bubble"),
-                new Mechanic(34518, "Blood Shield", 1, 16115, "symbol:'octagon',color:'rgb(255,0,0)',", "Bubble"),
+                new Mechanic(34380, "Oppressive Gaze", Mechanic.MechType.SkillOnPlayer, 16115, "symbol:'hexagram',color:'rgb(0,0,255)',", "Hadouken"),//human
+                new Mechanic(34371, "Oppressive Gaze", Mechanic.MechType.SkillOnPlayer, 16115, "symbol:'hexagram',color:'rgb(0,0,255)',", "Hadouken"),//abom
+                new Mechanic(34404, "Shards of Rage", Mechanic.MechType.SkillOnPlayer, 16115, "symbol:'hexagram',color:'rgb(255,0,0)',", "Backflip Shards"),//human
+                new Mechanic(34411, "Shards of Rage", Mechanic.MechType.SkillOnPlayer, 16115, "symbol:'hexagram',color:'rgb(255,0,0)',", "Backflip Shards"),//abom
+                new Mechanic(34450, "Unstable Blood Magic", Mechanic.MechType.PlayerBoon, 16115, "symbol:'diamond',color:'rgb(255,0,0)',", "Bomb"),
+                new Mechanic(34416, "Corruption", Mechanic.MechType.PlayerBoon, 16115, "symbol:'circle',color:'rgb(255,0,0)',", "Corruption"),
+                new Mechanic(34442, "Sacrifice", Mechanic.MechType.PlayerBoon, 16115, "symbol:'circle',color:'rgb(75,0,130)',", "Sacrifice"),
+                new Mechanic(34367, "Unbalanced", Mechanic.MechType.PlayerBoon, 16115, "symbol:'square',color:'rgb(75,30,150)',", "Rain Knockdown"),
+                new Mechanic(34422, "Blood Fueled", Mechanic.MechType.BossBoon, 16115, "symbol:'square',color:'rgb(255,0,0)',", "Ate Reflects(Bad)"),
+                new Mechanic(34428, "Blood Fueled", Mechanic.MechType.BossBoon, 16115, "symbol:'square',color:'rgb(255,0,0)',", "Ate Reflects(Bad)"),
+                new Mechanic(34376, "Blood Shield", Mechanic.MechType.BossBoon, 16115, "symbol:'octagon',color:'rgb(255,0,0)',", "Bubble"),
+                new Mechanic(34518, "Blood Shield", Mechanic.MechType.BossBoon, 16115, "symbol:'octagon',color:'rgb(255,0,0)',", "Bubble"),
 
                 //KC
-                new Mechanic(34912, "Fixate", 0, 16235, "symbol:'star',color:'rgb(0,0,250)',", "Fixate"),
-                new Mechanic(34925, "Fixate", 0, 16235, "symbol:'star',color:'rgb(0,0,250)',", "Fixate"),
-                new Mechanic(35077, "Hail of Fury", 3, 16235, "symbol:'hexagram',color:'rgb(0,0,250)',", "Debris"),
-                new Mechanic(-1, "Insidious Projection", 5, 16235, "symbol:'octagram',color:'rgb(0,0,250)',", "Merge"),//Spawn check
-                new Mechanic(35137, "Phantasmal Blades", 3, 16235, "symbol:'star',color:'rgb(250,0,0)',", "Bunker and rotate"),
-                new Mechanic(35064, "Phantasmal Blades", 3, 16235, "symbol:'star',color:'rgb(250,0,0)',", "Bunker and rotate"),
-                new Mechanic(35086, "Tower Drop", 3, 16235, "symbol:'circle',color:'rgb(250,0,0)',", "Tower Drop"),
+                new Mechanic(34912, "Fixate", Mechanic.MechType.PlayerBoon, 16235, "symbol:'star',color:'rgb(0,0,250)',", "Fixate"),
+                new Mechanic(34925, "Fixate", Mechanic.MechType.PlayerBoon, 16235, "symbol:'star',color:'rgb(0,0,250)',", "Fixate"),
+                new Mechanic(35077, "Hail of Fury", Mechanic.MechType.SkillOnPlayer, 16235, "symbol:'hexagram',color:'rgb(0,0,250)',", "Debris"),
+                new Mechanic(-1, "Insidious Projection", Mechanic.MechType.Spawn, 16235, "symbol:'octagram',color:'rgb(0,0,250)',", "Merge"),//Spawn check
+                new Mechanic(35137, "Phantasmal Blades", Mechanic.MechType.SkillOnPlayer, 16235, "symbol:'star',color:'rgb(250,0,0)',", "Bunker and rotate"),
+                new Mechanic(35064, "Phantasmal Blades", Mechanic.MechType.SkillOnPlayer, 16235, "symbol:'star',color:'rgb(250,0,0)',", "Bunker and rotate"),
+                new Mechanic(35086, "Tower Drop", Mechanic.MechType.SkillOnPlayer, 16235, "symbol:'circle',color:'rgb(250,0,0)',", "Tower Drop"),
                 //hit orb
 
                 //Xera
-                new Mechanic(35128, "Temporal Shred", 3, 16246, "symbol:'circle',color:'rgb(250,0,0)',", "Orb"),
-                new Mechanic(34913, "Temporal Shred", 3, 16246, "symbol:'square',color:'rgb(250,0,0)',", "Orb Aoe"),
-                new Mechanic(35000, "Intervention", 0, 16246, "symbol:'circle',color:'rgb(75,30,150)',", "Bubble"),
-                new Mechanic(35168, "Bloodstone Protection", 0, 16246, "symbol:'hourglass',color:'rgb(75,30,150)',", "In Bubble"),
-                new Mechanic(34887, "Summon Fragment", 6, 16246, "symbol:'diamond',color:'rgb(75,30,150)',", "CC Too long"),
-                new Mechanic(34965, "Derangement", 0, 16246, "symbol:'square',color:'rgb(75,30,150)',", "Stacking buff"),
-                new Mechanic(35084, "Bending Chaos", 0, 16246, "symbol:'pentagon',color:'rgb(75,30,150)',", "Button 1"),
-                new Mechanic(35162, "Shifting Chaos", 0, 16246, "symbol:'hexagon',color:'rgb(75,30,150)',", "Button 2"),
-                new Mechanic(35032, "Twisting Chaos", 0, 16246, "symbol:'octagon',color:'rgb(75,30,150)',", "Button 3"),
+                new Mechanic(35128, "Temporal Shred", Mechanic.MechType.SkillOnPlayer, 16246, "symbol:'circle',color:'rgb(250,0,0)',", "Orb"),
+                new Mechanic(34913, "Temporal Shred", Mechanic.MechType.SkillOnPlayer, 16246, "symbol:'square',color:'rgb(250,0,0)',", "Orb Aoe"),
+                new Mechanic(35000, "Intervention", Mechanic.MechType.PlayerBoon, 16246, "symbol:'circle',color:'rgb(75,30,150)',", "Bubble"),
+                new Mechanic(35168, "Bloodstone Protection", Mechanic.MechType.PlayerBoon, 16246, "symbol:'hourglass',color:'rgb(75,30,150)',", "In Bubble"),
+                new Mechanic(34887, "Summon Fragment", Mechanic.MechType.BossCast, 16246, "symbol:'diamond',color:'rgb(75,30,150)',", "CC Too long"),
+                new Mechanic(34965, "Derangement", Mechanic.MechType.PlayerBoon, 16246, "symbol:'square',color:'rgb(75,30,150)',", "Stacking buff"),
+                new Mechanic(35084, "Bending Chaos", Mechanic.MechType.PlayerBoon, 16246, "symbol:'pentagon',color:'rgb(75,30,150)',", "Button 1"),
+                new Mechanic(35162, "Shifting Chaos", Mechanic.MechType.PlayerBoon, 16246, "symbol:'hexagon',color:'rgb(75,30,150)',", "Button 2"),
+                new Mechanic(35032, "Twisting Chaos", Mechanic.MechType.PlayerBoon, 16246, "symbol:'octagon',color:'rgb(75,30,150)',", "Button 3"),
                 //teleport
                 //hit move orb
 
                 //Cairn
-                new Mechanic(38113, "Displacement", 3, 17194, "symbol:'circle',color:'rgb(0,0,250)',", "Blue TP"),
-                new Mechanic(37611, "Spatial Manipulation", 3, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
-                new Mechanic(37629, "Spatial Manipulation", 3, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
-                new Mechanic(37642, "Spatial Manipulation", 3, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
-                new Mechanic(37673, "Spatial Manipulation", 3, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
-                new Mechanic(38074, "Spatial Manipulation", 3, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
-                new Mechanic(38302, "Spatial Manipulation", 3, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
-                new Mechanic(38313, "Meteor Swarm", 3, 17194, "symbol:'diamond',color:'rgb(250,0,0)',", "Knockback crystal"),
-                new Mechanic(38049, "Shared Agony", 0, 17194, "symbol:'circle',color:'rgb(250,0,0)',", "Agony Buff"),//could flip
-                new Mechanic(38210, "Shared Agony", 3, 17194, "symbol:'hexagon',color:'rgb(250,0,0)',", "Agony Damage"),//could flip
-                new Mechanic(38060, "Energy Surge", 3, 17194, "symbol:'triangle-left',color:'rgb(250,0,0)',", "Leap"),
-                new Mechanic(37631, "Orbital Sweep", 3, 17194, "symbol:'circle',color:'rgb(0,0,250)',", "Sweep"),
+                new Mechanic(38113, "Displacement", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,0,250)',", "Blue TP"),
+                new Mechanic(37611, "Spatial Manipulation", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
+                new Mechanic(37629, "Spatial Manipulation", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
+                new Mechanic(37642, "Spatial Manipulation", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
+                new Mechanic(37673, "Spatial Manipulation", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
+                new Mechanic(38074, "Spatial Manipulation", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
+                new Mechanic(38302, "Spatial Manipulation", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,150,0)',", "Green"),
+                new Mechanic(38313, "Meteor Swarm", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'diamond',color:'rgb(250,0,0)',", "Knockback crystal"),
+                new Mechanic(38049, "Shared Agony", Mechanic.MechType.PlayerBoon, 17194, "symbol:'circle',color:'rgb(250,0,0)',", "Agony Buff"),//could flip
+                new Mechanic(38210, "Shared Agony", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'hexagon',color:'rgb(250,0,0)',", "Agony Damage"),//could flip
+                new Mechanic(38060, "Energy Surge", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'triangle-left',color:'rgb(250,0,0)',", "Leap"),
+                new Mechanic(37631, "Orbital Sweep", Mechanic.MechType.SkillOnPlayer, 17194, "symbol:'circle',color:'rgb(0,0,250)',", "Sweep"),
 
                 //mo
-                new Mechanic(37788, "Jade Explosion", 3, 17172, "symbol:'circle',color:'rgb(250,0,0)',", "Jade Dieing"),
-                new Mechanic(37779, "Claim", 0, 17172, "symbol:'circle',color:'rgb(0,0,250)',", "Claim"),
-                new Mechanic(37697, "Dispel", 0, 17172, "symbol:'square',color:'rgb(0,0,250)',", "Dispel"),
-                new Mechanic(37813, "Protect", 0, 17172, "symbol:'square',color:'rgb(0,158,0)',", "Protect"),
-                new Mechanic(38155, "Mursaat Overseer's Shield", 0, 17172, "symbol:'circle',color:'rgb(0,158,0)',", "Bubble Invuln"),
-                new Mechanic(38184, "Enemy Tile", 3, 17172, "symbol:'square',color:'rgb(255,0,0)',", "Tile Dmg"),
+                new Mechanic(37788, "Jade Explosion", Mechanic.MechType.SkillOnPlayer, 17172, "symbol:'circle',color:'rgb(250,0,0)',", "Jade Dieing"),
+                new Mechanic(37779, "Claim", Mechanic.MechType.PlayerBoon, 17172, "symbol:'circle',color:'rgb(0,0,250)',", "Claim"),
+                new Mechanic(37697, "Dispel", Mechanic.MechType.PlayerBoon, 17172, "symbol:'square',color:'rgb(0,0,250)',", "Dispel"),
+                new Mechanic(37813, "Protect", Mechanic.MechType.PlayerBoon, 17172, "symbol:'square',color:'rgb(0,158,0)',", "Protect"),
+                new Mechanic(38155, "Mursaat Overseer's Shield", Mechanic.MechType.PlayerBoon, 17172, "symbol:'circle',color:'rgb(0,158,0)',", "Bubble Invuln"),
+                new Mechanic(38184, "Enemy Tile", Mechanic.MechType.SkillOnPlayer, 17172, "symbol:'square',color:'rgb(255,0,0)',", "Tile Dmg"),
 
                 //sam
-                new Mechanic(37996, "Shockwave", 3, 17188, "symbol:'circle',color:'rgb(0,0,255)',", "Knockback"),
-                new Mechanic(38168, "Prisoner Sweep", 3, 17188, "symbol:'hexagon',color:'rgb(255,0,0)',", "Sweep"),
-                new Mechanic(38305, "Bludgeon", 3, 17188, "symbol:'square',color:'rgb(255,0,0)',", "Slam"),
-                new Mechanic(37868, "Fixate: Samarog", 0, 17188, "symbol:'star',color:'rgb(0,0,255)',", "Fixate: Samarog"),
-                new Mechanic(38223, "Fixate: Guldhem", 0, 17188, "symbol:'star',color:'rgb(0,150,0)',", "Fixate: Guldhem"),
-                new Mechanic(37693, "Fixate: Rigom", 0, 17188, "symbol:'star',color:'rgb(255,0,0)',", "Fixate: Rigom"),
-                new Mechanic(37693, "Fixate: Rigom", 0, 17188, "symbol:'star',color:'rgb(255,0,0)',", "Fixate: Rigom"),
-                new Mechanic(37966, "Big Hug", 0, 17188, "symbol:'circle',color:'rgb(0,150,0)',", "Big Green"),
-                new Mechanic(38247, "Small Hug", 0, 17188, "symbol:'octagon',color:'rgb(0,150,0)',", "Small Green"),
-                new Mechanic(38260, "Inevitable Betrayal", 3, 17188, "symbol:'triangle-down',color:'rgb(255,0,0)',", "Failed Kissing"),
-                new Mechanic(37851, "Inevitable Betrayal", 3, 17188, "symbol:'triangle-down',color:'rgb(255,0,0)',", "Failed Kissing"),
-                new Mechanic(37901, "Effigy Pulse", 3, 17188, "symbol:'triangle-nw',color:'rgb(255,0,0)',", "Stood in Spear"),
-                new Mechanic(37816, "Spear Impact", 3, 17188, "symbol:'triangle-sw',color:'rgb(255,0,0)',", "Spear Spawned"),
-                //  new Mechanic(37816, "Brutalize", 3, 17188, "symbol:'star-square',color:'rgb(255,0,0)',", "CC Target", casted without dmg odd
+                new Mechanic(37996, "Shockwave", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'circle',color:'rgb(0,0,255)',", "Knockback"),
+                new Mechanic(38168, "Prisoner Sweep", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'hexagon',color:'rgb(255,0,0)',", "Sweep"),
+                new Mechanic(38305, "Bludgeon", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'square',color:'rgb(255,0,0)',", "Slam"),
+                new Mechanic(37868, "Fixate: Samarog", Mechanic.MechType.PlayerBoon, 17188, "symbol:'star',color:'rgb(0,0,255)',", "Fixate: Samarog"),
+                new Mechanic(38223, "Fixate: Guldhem", Mechanic.MechType.PlayerBoon, 17188, "symbol:'star',color:'rgb(0,150,0)',", "Fixate: Guldhem"),
+                new Mechanic(37693, "Fixate: Rigom", Mechanic.MechType.PlayerBoon, 17188, "symbol:'star',color:'rgb(255,0,0)',", "Fixate: Rigom"),
+                new Mechanic(37693, "Fixate: Rigom", Mechanic.MechType.PlayerBoon, 17188, "symbol:'star',color:'rgb(255,0,0)',", "Fixate: Rigom"),
+                new Mechanic(37966, "Big Hug", Mechanic.MechType.PlayerBoon, 17188, "symbol:'circle',color:'rgb(0,150,0)',", "Big Green"),
+                new Mechanic(38247, "Small Hug", Mechanic.MechType.PlayerBoon, 17188, "symbol:'octagon',color:'rgb(0,150,0)',", "Small Green"),
+                new Mechanic(38260, "Inevitable Betrayal", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'triangle-down',color:'rgb(255,0,0)',", "Failed Kissing"),
+                new Mechanic(37851, "Inevitable Betrayal", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'triangle-down',color:'rgb(255,0,0)',", "Failed Kissing"),
+                new Mechanic(37901, "Effigy Pulse", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'triangle-nw',color:'rgb(255,0,0)',", "Stood in Spear"),
+                new Mechanic(37816, "Spear Impact", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'triangle-sw',color:'rgb(255,0,0)',", "Spear Spawned"),
+                //  new Mechanic(37816, "Brutalize", Mechanic.MechType.SkillOnPlayer, 17188, "symbol:'star-square',color:'rgb(255,0,0)',", "CC Target", casted without dmg odd
 
                 //deiimos
-                new Mechanic(37716, "Rapid Decay", 3, 17154, "symbol:'circle',color:'rgb(0,0,0)',", "Black Oil"),
-                new Mechanic(38208, "Annihilate", 3, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "Boss Smash"),
-                new Mechanic(37929, "Annihilate", 3, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "Chain Smash"),
-                new Mechanic(37980, "Demonic Shock Wave", 3, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "10% Smash"),
-                new Mechanic(37982, "Demonic Shock Wave", 3, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "10% Smash"),
-                new Mechanic(37733, "Tear Instability", 0, 17154, "symbol:'diamond',color:'rgb(0,150,0)',", "Tear"),
-                new Mechanic(37613, "Mind Crush", 3, 17154, "symbol:'square',color:'rgb(250,0,0)',", "Mind Crush"),
-                new Mechanic(38187, "Weak Minded", 0, 17154, "symbol:'square',color:'rgb(0,0,250)',", "Weak Minded"),
+                new Mechanic(37716, "Rapid Decay", Mechanic.MechType.SkillOnPlayer, 17154, "symbol:'circle',color:'rgb(0,0,0)',", "Black Oil"),
+                new Mechanic(38208, "Annihilate", Mechanic.MechType.SkillOnPlayer, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "Boss Smash"),
+                new Mechanic(37929, "Annihilate", Mechanic.MechType.SkillOnPlayer, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "Chain Smash"),
+                new Mechanic(37980, "Demonic Shock Wave", Mechanic.MechType.SkillOnPlayer, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "10% Smash"),
+                new Mechanic(37982, "Demonic Shock Wave", Mechanic.MechType.SkillOnPlayer, 17154, "symbol:'circle',color:'rgb(255,0,0)',", "10% Smash"),
+                new Mechanic(37733, "Tear Instability", Mechanic.MechType.PlayerBoon, 17154, "symbol:'diamond',color:'rgb(0,150,0)',", "Tear"),
+                new Mechanic(37613, "Mind Crush", Mechanic.MechType.SkillOnPlayer, 17154, "symbol:'square',color:'rgb(250,0,0)',", "Mind Crush"),
+                new Mechanic(38187, "Weak Minded", Mechanic.MechType.PlayerBoon, 17154, "symbol:'square',color:'rgb(0,0,250)',", "Weak Minded"),
                 //mlist.Add("Chosen by Eye of Janthir");
                 //mlist.Add("");//tp from drunkard
                 //mlist.Add("");//bon currupt from thief
                 //mlist.Add("Teleport");//to demonic realm
 
                 //horror
-                new Mechanic(47327, "Vortex Slash", 3, 19767, "symbol:'circle',color:'rgb(250,0,0)',", "Donut Inner"),
-                new Mechanic(48432, "Vortex Slash", 3, 19767, "symbol:'circle-open',color:'rgb(250,0,0)',", "Donut Outer"),
-                new Mechanic(47430, "Soul Rift", 3, 19767, "symbol:'circle',color:'rgb(250,140,0)',", "Golem AOE"),
-                new Mechanic(48363, "Quad Slash", 3, 19767, "symbol:'trianlge-up',color:'rgb(250,140,0)',", "Slices"),
-                new Mechanic(47915, "Quad Slash", 3, 19767, "symbol:'trianlge-up',color:'rgb(250,140,0)',", "Slices"),
-                new Mechanic(47363, "Spinning Slash", 3, 19767, "symbol:'trianlge-up',color:'rgb(250,140,0)',", "Sythe"),
-                new Mechanic(47434, "Fixated", 0, 19767, "symbol:'circle',color:'rgb(0,0,250)',", "Fixate"),
-                new Mechanic(47414, "Necrosis", 0, 19767, "symbol:'square',color:'rgb(0,150,0)',", "Necrosis Debuff"),
+                new Mechanic(47327, "Vortex Slash", Mechanic.MechType.SkillOnPlayer, 19767, "symbol:'circle',color:'rgb(250,0,0)',", "Donut Inner"),
+                new Mechanic(48432, "Vortex Slash", Mechanic.MechType.SkillOnPlayer, 19767, "symbol:'circle-open',color:'rgb(250,0,0)',", "Donut Outer"),
+                new Mechanic(47430, "Soul Rift", Mechanic.MechType.SkillOnPlayer, 19767, "symbol:'circle',color:'rgb(250,140,0)',", "Golem AOE"),
+                new Mechanic(48363, "Quad Slash", Mechanic.MechType.SkillOnPlayer, 19767, "symbol:'trianlge-up',color:'rgb(250,140,0)',", "Slices"),
+                new Mechanic(47915, "Quad Slash", Mechanic.MechType.SkillOnPlayer, 19767, "symbol:'trianlge-up',color:'rgb(250,140,0)',", "Slices"),
+                new Mechanic(47363, "Spinning Slash", Mechanic.MechType.SkillOnPlayer, 19767, "symbol:'trianlge-up',color:'rgb(250,140,0)',", "Sythe"),
+                new Mechanic(47434, "Fixated", Mechanic.MechType.PlayerBoon, 19767, "symbol:'circle',color:'rgb(0,0,250)',", "Fixate"),
+                new Mechanic(47414, "Necrosis", Mechanic.MechType.PlayerBoon, 19767, "symbol:'square',color:'rgb(0,150,0)',", "Necrosis Debuff"),
 
                 //dhuum
-                new Mechanic(48172, "Hateful Ephemera", 3, 19450, "symbol:'square',color:'rgb(0,150,0)',", "Golem"),//Buff or dmg?
-                new Mechanic(47646, "Arcing Affliction", 0, 19450, "symbol:'hexagon',color:'rgb(250,0,0)',", "Arcing Affliction DMG"),//Buff or dmg?
-                new Mechanic(48121, "Arcing Affliction", 3, 19450, "symbol:'circle',color:'rgb(250,0,0)',", "Arcing Affliction"),//Buff or dmg?
-                new Mechanic(47476, "Residual Affliction", 0, 19450, "symbol:'square',color:'rgb(0,0,250)',", "Bomb CD"),
-                new Mechanic(47335, "Soul Shackle", 7, 19450, "symbol:'diamond',color:'rgb(0,0,250)',", "Shackle"),//4 calls probably this one
-                new Mechanic(47561, "Slash", 3, 19450, "symbol:'triangle',color:'rgb(0,150,0)',", "Cone boon rip"),
-                new Mechanic(48752, "Cull", 3, 19450, "symbol:'diamond',color:'rgb(0,150,0)',", "Crack"),
-                new Mechanic(48760, "Putrid Bomb", 3, 19450, "symbol:'circle',color:'rgb(0,75,0)',", "Mark"),
-                new Mechanic(48398, "Cataclysmic Cycle", 3, 19450, "symbol:'triangle',color:'rgb(250,0,0)',", "Suck Center"),
-                new Mechanic(48176, "Death Mark", 3, 19450, "symbol:'circle',color:'rgb(250,140,0)',", "Dip Aoe"),
-                new Mechanic(48210, "Greater Death Mark", 3, 19450, "symbol:'circle-open',color:'rgb(250,140,0)',", "Suck Dmg"),
-              //  new Mechanic(48281, "Mortal Coil", 0, 19450, "symbol:'circle',color:'rgb(0,150,0)',", "Green Orbs",
-                new Mechanic(46950, "Fractured Spirit", 0, 19450, "symbol:'square',color:'rgb(0,150,0)',", "Green Orbs CD"),
+                new Mechanic(48172, "Hateful Ephemera", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'square',color:'rgb(0,150,0)',", "Golem"),//Buff or dmg?
+                new Mechanic(47646, "Arcing Affliction", Mechanic.MechType.PlayerBoon, 19450, "symbol:'hexagon',color:'rgb(250,0,0)',", "Arcing Affliction DMG"),//Buff or dmg?
+                new Mechanic(48121, "Arcing Affliction", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'circle',color:'rgb(250,0,0)',", "Arcing Affliction"),//Buff or dmg?
+                new Mechanic(47476, "Residual Affliction", Mechanic.MechType.PlayerBoon, 19450, "symbol:'square',color:'rgb(0,0,250)',", "Bomb CD"),
+                new Mechanic(47335, "Soul Shackle", Mechanic.MechType.PlayerOnPlayer, 19450, "symbol:'diamond',color:'rgb(0,0,250)',", "Shackle"),//4 calls probably this one
+                new Mechanic(47561, "Slash", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'triangle',color:'rgb(0,150,0)',", "Cone boon rip"),
+                new Mechanic(48752, "Cull", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'diamond',color:'rgb(0,150,0)',", "Crack"),
+                new Mechanic(48760, "Putrid Bomb", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'circle',color:'rgb(0,75,0)',", "Mark"),
+                new Mechanic(48398, "Cataclysmic Cycle", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'triangle',color:'rgb(250,0,0)',", "Suck Center"),
+                new Mechanic(48176, "Death Mark", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'circle',color:'rgb(250,140,0)',", "Dip Aoe"),
+                new Mechanic(48210, "Greater Death Mark", Mechanic.MechType.SkillOnPlayer, 19450, "symbol:'circle-open',color:'rgb(250,140,0)',", "Suck Dmg"),
+              //  new Mechanic(48281, "Mortal Coil", Mechanic.MechType.PlayerBoon, 19450, "symbol:'circle',color:'rgb(0,150,0)',", "Green Orbs",
+                new Mechanic(46950, "Fractured Spirit", Mechanic.MechType.PlayerBoon, 19450, "symbol:'square',color:'rgb(0,150,0)',", "Green Orbs CD"),
 
                 // Fractals            
                 // MAMA   
-                new Mechanic(37408, "Blastwave", 0, 0x427D, "symbol:'square',color:'rgb(0,150,0)',", "Blastwave"),
-                new Mechanic(37103, "Blastwave", 0, 0x427D, "symbol:'square',color:'rgb(0,150,0)',", "Blastwave"),
-                new Mechanic(37391, "Tantrum", 0, 0x427D, "symbol:'square',color:'rgb(0,150,0)',", "Tantrum"),
-                new Mechanic(37577, "Leap", 0, 0x427D, "symbol:'square',color:'rgb(0,150,0)',", "Leap"),
-                new Mechanic(37437, "Shoot", 0, 0x427D, "symbol:'square',color:'rgb(0,150,0)',", "Shoot"),
-                new Mechanic(37185, "Explosive Impact", 0, 0x427D, "symbol:'square',color:'rgb(0,150,0)',", "Explosive Impact"),
+                new Mechanic(37408, "Blastwave", Mechanic.MechType.SkillOnPlayer, 0x427D, "symbol:'circle',color:'rgb(100,150,0)',", "Blastwave"),
+                new Mechanic(37103, "Blastwave", Mechanic.MechType.SkillOnPlayer, 0x427D, "symbol:'circle',color:'rgb(100,150,0)',", "Blastwave"),
+                new Mechanic(37391, "Tantrum", Mechanic.MechType.SkillOnPlayer, 0x427D, "symbol:'circle',color:'rgb(50,150,0)',", "Tantrum"),
+                new Mechanic(37577, "Leap", Mechanic.MechType.SkillOnPlayer, 0x427D, "symbol:'circle',color:'rgb(150,150,0)',", "Leap"),
+                new Mechanic(37437, "Shoot", Mechanic.MechType.SkillOnPlayer, 0x427D, "symbol:'circle',color:'rgb(200,150,0)',", "Shoot"),
+                new Mechanic(37185, "Explosive Impact", Mechanic.MechType.SkillOnPlayer, 0x427D, "symbol:'circle',color:'rgb(125,50,0)',", "Explosive Impact"),
                 // SIAX
-                new Mechanic(37477, "Vile Spit", 0, 0x4284, "symbol:'square',color:'rgb(0,150,0)',", "Vile Spit"),
+                new Mechanic(37477, "Vile Spit", Mechanic.MechType.SkillOnPlayer, 0x4284, "symbol:'circle',color:'rgb(150,150,0)',", "Vile Spit"),
                 // ENSOLYSS
-                new Mechanic(37154, "Lunge", 0, 0x4234, "symbol:'square',color:'rgb(0,150,0)',", "Lunge"),
-                new Mechanic(37278, "First Smash", 0, 0x4234, "symbol:'square',color:'rgb(0,150,0)',", "First Smash"),
-                new Mechanic(36962, "Torment Smash", 0, 0x4234, "symbol:'square',color:'rgb(0,150,0)',", "Torment Smash"),
+                new Mechanic(37154, "Lunge", Mechanic.MechType.SkillOnPlayer, 0x4234, "symbol:'circle',color:'rgb(50,150,0)',", "Lunge"),
+                new Mechanic(37278, "First Smash", Mechanic.MechType.SkillOnPlayer, 0x4234, "symbol:'circle',color:'rgb(100,150,0)',", "First Smash"),
+                new Mechanic(36962, "Torment Smash", Mechanic.MechType.SkillOnPlayer, 0x4234, "symbol:'circle',color:'rgb(150,150,0)',", "Torment Smash"),
                 // ARKK
-                new Mechanic(39685, "Horizon Strike 1", 0, 0x455F, "symbol:'square',color:'rgb(0,150,0)',", "Horizon Strike 1"),
-                new Mechanic(39001, "Horizon Strike 2", 0, 0x455F, "symbol:'square',color:'rgb(0,150,0)',", "Horizon Strike 2"),
-                new Mechanic(39297, "Horizon Strike Normal", 0, 0x455F, "symbol:'square',color:'rgb(0,150,0)',", "Horizon Strike Normal"),
-                new Mechanic(38844, "Overhead Smash", 0, 0x455F, "symbol:'square',color:'rgb(0,150,0)',", "Overhead Smash"),
-                new Mechanic(38880, "Corporeal Reassignment", 0, 0x455F, "symbol:'square',color:'rgb(0,150,0)',", "Corporeal Reassignment")
+                new Mechanic(39685, "Horizon Strike 1", Mechanic.MechType.SkillOnPlayer, 0x455F, "symbol:'circle',color:'rgb(50,0,0)',", "Horizon Strike 1"),
+                new Mechanic(39001, "Horizon Strike 2", Mechanic.MechType.SkillOnPlayer, 0x455F, "symbol:'circle',color:'rgb(100,0,0)',", "Horizon Strike 2"),
+                new Mechanic(39297, "Horizon Strike Normal", Mechanic.MechType.SkillOnPlayer, 0x455F, "symbol:'circle',color:'rgb(150,0,0)',", "Horizon Strike Normal"),
+                new Mechanic(38844, "Overhead Smash", Mechanic.MechType.SkillOnPlayer, 0x455F, "symbol:'circle',color:'rgb(200,0,0)',", "Overhead Smash"),
+                new Mechanic(38880, "Corporeal Reassignment", Mechanic.MechType.PlayerBoon, 0x455F, "symbol:'square',color:'rgb(0,150,0)',", "Corporeal Reassignment")
         };
 
         public MechanicData()

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -46,7 +46,7 @@ namespace LuckParser.Models.ParseModels
             long time_start = bossData.getFirstAware();
             foreach (CombatItem c in combatList)
             {
-                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware())
+                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > bossData.getFirstAware() && c.getTime() < bossData.getLastAware())
                 {
                     long time = c.getTime() - time_start;
                     addDamageLog(time, bossData.getInstid(), c, damage_logsFiltered);
@@ -67,7 +67,7 @@ namespace LuckParser.Models.ParseModels
 
             foreach (CombatItem c in combatList)
             {
-                if (! (c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware()))
+                if (! (c.getTime() > bossData.getFirstAware() && c.getTime() < bossData.getLastAware()))
                 {
                     continue;
                 }

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -35,7 +35,7 @@ namespace LuckParser.Models.ParseModels
                 string id = agent.getName();
                 if (!minions.ContainsKey(id))
                 {
-                    minions[id] = new Minions();
+                    minions[id] = new Minions(id.GetHashCode());
                 }
                 minions[id].Add(new Minion(agent.getInstid(), agent));
             }

--- a/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
@@ -95,27 +95,27 @@ namespace LuckParser.Models.ParseModels
             }
             return damageTaken_logs.Where(x => x.getTime() >= start && x.getTime() <= end).ToList();
         }
-        public BoonDistribution getBoonDistribution(BossData bossData, SkillData skillData, List<CombatItem> combatList, List<PhaseData> phases, int phase_index)
+        public BoonDistribution getBoonDistribution(BossData bossData, SkillData skillData, List<CombatItem> combatList, AgentData agentData, List<PhaseData> phases, int phase_index)
         {
             if (boon_distribution.Count == 0)
             {
-                setBoonDistribution(bossData, skillData, combatList, phases);
+                setBoonDistribution(bossData, skillData, combatList, agentData, phases);
             }
             return boon_distribution[phase_index];
         }
-        public Dictionary<int, BoonsGraphModel> getBoonGraphs(BossData bossData, SkillData skillData, List<CombatItem> combatList, List<PhaseData> phases)
+        public Dictionary<int, BoonsGraphModel> getBoonGraphs(BossData bossData, SkillData skillData, List<CombatItem> combatList, AgentData agentData, List<PhaseData> phases)
         {
             if (boon_distribution.Count == 0)
             {
-                setBoonDistribution(bossData, skillData, combatList, phases);
+                setBoonDistribution(bossData, skillData, combatList, agentData, phases);
             }
             return boon_points;
         }
-        public Dictionary<int, long> getBoonPresence(BossData bossData, SkillData skillData, List<CombatItem> combatList, List<PhaseData> phases, int phase_index)
+        public Dictionary<int, long> getBoonPresence(BossData bossData, SkillData skillData, List<CombatItem> combatList, AgentData agentData, List<PhaseData> phases, int phase_index)
         {
             if (boon_distribution.Count == 0)
             {
-                setBoonDistribution(bossData, skillData, combatList, phases);
+                setBoonDistribution(bossData, skillData, combatList, agentData, phases);
             }
             return boon_presence[phase_index];
         }
@@ -196,7 +196,7 @@ namespace LuckParser.Models.ParseModels
         protected abstract void setCastLogs(BossData bossData, List<CombatItem> combatList, AgentData agentData);
         protected abstract void setDamagetakenLogs(BossData bossData, List<CombatItem> combatList, AgentData agentData, MechanicData m_data);
 
-        private void setBoonDistribution(BossData bossData, SkillData skillData, List<CombatItem> combatList, List<PhaseData> phases)
+        private void setBoonDistribution(BossData bossData, SkillData skillData, List<CombatItem> combatList, AgentData agentData, List<PhaseData> phases)
         {
             BoonMap to_use = getBoonMap(bossData, skillData, combatList, true);
             List<Boon> boon_to_use = Boon.getAllBuffList();
@@ -231,7 +231,7 @@ namespace LuckParser.Models.ParseModels
                     BoonSimulator simulator = boon.getSimulator();
                     simulator.simulate(logs, dur);
                     long death = getDeath(bossData, combatList, 0, dur);
-                    if (death > 0)
+                    if (death > 0 && getCastLogs(bossData,combatList,agentData, death + 1, fight_duration).Count > 0)
                     {
                         simulator.trim(death - bossData.getFirstAware());
                     }

--- a/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
@@ -292,12 +292,8 @@ namespace LuckParser.Models.ParseModels
 
                         for (int i = start; i <= end; i++)
                         {
-                            if (i >= 0)
-                            {
-                                toFill[i] = new Point(i, simul.getStack(i));
-                                toFillPresence[i] = new Point(i, simul.getItemDuration() > 0 ? 1 : 0);
-                            }
-                          
+                            toFill[i] = new Point(i, simul.getStack(i));
+                            toFillPresence[i] = new Point(i, simul.getItemDuration() > 0 ? 1 : 0);                     
                         }
                     }
                     // reduce precision to seconds

--- a/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
@@ -325,13 +325,13 @@ namespace LuckParser.Models.ParseModels
 
             foreach (CombatItem c in combatList)
             {
-                if (c.isBuff() != 1 || !boon_map.ContainsKey(c.getSkillID()) || ! (c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware()))
+                if (c.isBuff() != 1 || !boon_map.ContainsKey(c.getSkillID()))
                 {
                     continue;
                 }
                 long time = c.getTime() - time_start;
                 ushort dst = c.isBuffremove().getID() == 0 ? c.getDstInstid() : c.getSrcInstid();
-                if (agent.getInstid() == dst)
+                if (agent.getInstid() == dst && time > 0 && time < bossData.getAwareDuration())
                 {
                     ushort src = c.getSrcMasterInstid() > 0 ? c.getSrcMasterInstid() : c.getSrcInstid();
                     if (c.isBuffremove().getID() == 0)

--- a/LuckParser/Models/ParseModels/Players/Boss.cs
+++ b/LuckParser/Models/ParseModels/Players/Boss.cs
@@ -302,7 +302,7 @@ namespace LuckParser.Models.ParseModels
                     {
                         end = invulDei.getTime() - bossData.getFirstAware();
                         phases.Add(new PhaseData(start, end));
-                        start = (phaseData.Count == 1 ? phaseData[0] : fight_dur) - bossData.getFirstAware();
+                        start = (phaseData.Count == 1 ? phaseData[0] - bossData.getFirstAware() : fight_dur) ;
                         cast_logs.Add(new CastLog(end, -6, (int)(start - end), new ParseEnums.Activation(0), (int)(start - end), new ParseEnums.Activation(0)));
                     }
                     if (fight_dur - start > 5000 && start >= phases.Last().getEnd())

--- a/LuckParser/Models/ParseModels/Players/Minion.cs
+++ b/LuckParser/Models/ParseModels/Players/Minion.cs
@@ -16,9 +16,11 @@ namespace LuckParser.Models.ParseModels
         protected override void setDamageLogs(BossData bossData, List<CombatItem> combatList, AgentData agentData)
         {
             long time_start = bossData.getFirstAware();
+            long min_time = Math.Max(time_start, agent.getFirstAware());
+            long max_time = Math.Min(bossData.getLastAware(), agent.getLastAware());
             foreach (CombatItem c in combatList)
             {
-                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware())//selecting minion as caster
+                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > min_time && c.getTime() < max_time)//selecting minion as caster
                 {
                     long time = c.getTime() - time_start;
                     foreach (AgentItem item in agentData.getNPCAgentList())
@@ -32,9 +34,11 @@ namespace LuckParser.Models.ParseModels
         protected override void setFilteredLogs(BossData bossData, List<CombatItem> combatList, AgentData agentData)
         {
             long time_start = bossData.getFirstAware();
+            long min_time = Math.Max(time_start, agent.getFirstAware());
+            long max_time = Math.Min(bossData.getLastAware(), agent.getLastAware());
             foreach (CombatItem c in combatList)
             {
-                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware())//selecting player
+                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > min_time && c.getTime() < max_time)//selecting player
                 {
                     long time = c.getTime() - time_start;
                     addDamageLog(time, bossData.getInstid(), c, damage_logsFiltered);
@@ -47,9 +51,11 @@ namespace LuckParser.Models.ParseModels
             long time_start = bossData.getFirstAware();
             CastLog curCastLog = null;
 
+            long min_time = Math.Max(time_start, agent.getFirstAware());
+            long max_time = Math.Min(bossData.getLastAware(), agent.getLastAware());
             foreach (CombatItem c in combatList)
             {
-                if (!(c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware()))
+                if (!(c.getTime() > min_time && c.getTime() < max_time))
                 {
                     continue;
                 }

--- a/LuckParser/Models/ParseModels/Players/Minions.cs
+++ b/LuckParser/Models/ParseModels/Players/Minions.cs
@@ -8,8 +8,10 @@ namespace LuckParser.Models.ParseModels
 {
     public class Minions : List<Minion>
     {
-        public Minions() : base()
+        private int instid;
+        public Minions(int instid) : base()
         {
+            this.instid = instid;
         }
 
         public List<DamageLog> getDamageLogs(int instidFilter, BossData bossData, List<CombatItem> combatList, AgentData agentData, long start, long end)
@@ -32,13 +34,9 @@ namespace LuckParser.Models.ParseModels
             return res;
         }
 
-        public ushort getInstid()
+        public int getInstid()
         {
-            if (Count > 0)
-            {
-                return this[0].getInstid();
-            }
-            return 0;
+            return instid;
         }
 
         public string getCharacter()

--- a/LuckParser/Models/ParseModels/Players/Player.cs
+++ b/LuckParser/Models/ParseModels/Players/Player.cs
@@ -218,7 +218,7 @@ namespace LuckParser.Models.ParseModels
             long time_start = bossData.getFirstAware();
             foreach (CombatItem c in combatList)
             {
-                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware())//selecting player or minion as caster
+                if (agent.getInstid() == c.getSrcInstid() && c.getTime() > bossData.getFirstAware() && c.getTime() < bossData.getLastAware())//selecting player or minion as caster
                 {
                     long time = c.getTime() - time_start;
                     foreach (AgentItem item in agentData.getNPCAgentList())
@@ -237,7 +237,7 @@ namespace LuckParser.Models.ParseModels
         protected override void setDamagetakenLogs(BossData bossData, List<CombatItem> combatList, AgentData agentData,MechanicData m_data) {
             long time_start = bossData.getFirstAware();               
             foreach (CombatItem c in combatList) {
-                if (agent.getInstid() == c.getDstInstid() && c.getTime() > agent.getFirstAware() && c.getTime() < agent.getLastAware()) {//selecting player as target
+                if (agent.getInstid() == c.getDstInstid() && c.getTime() > bossData.getFirstAware() && c.getTime() < bossData.getLastAware()) {//selecting player as target
                     long time = c.getTime() - time_start;
                     foreach (AgentItem item in agentData.getNPCAgentList())
                     {//selecting all


### PR DESCRIPTION
Bugs:
- Fixed a bug where we would parse data outside of the fight
- Fixed a reg with Deimos where the split was not detected anymore (due to agents going from Int to Uint, the Contains("57069") was not valid anymore).
- Fixed a fractal bug where if a player died and then got rezzed we would strop tracking their boons (I check if the supposedly dead player did cast something after their death)
- Fixed a sneaky bug where damage dist table generation would fail for minions (ex: you summon a spirit with id X, the spirit dies, you switch your pet, it also gets id X, boom you got two tables with the same id, an extremely rare bug)

Improvements:
- Improved Deimos phase detection, the last phase starts when the structure becomes attackable and not when the group gets teleported.
- Enum based Mechanics type, like for boons
- Mechanics for fractals for real this time!