### PR TITLE
Some improvements

### DIFF
--- a/LuckParser/Controllers/CSVBuilder.cs
+++ b/LuckParser/Controllers/CSVBuilder.cs
@@ -832,7 +832,7 @@ namespace LuckParser.Controllers
             List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
             long fight_duration = phases[phase_index].getDuration();
             Dictionary<long, Statistics.FinalBossBoon> conditions = statistics.bossConditions[phase_index];
-            bool hasBoons = false;
+            //bool hasBoons = false;
             int count = 0;
             WriteCell("Sub");
             WriteCell("");

--- a/LuckParser/Controllers/CSVBuilder.cs
+++ b/LuckParser/Controllers/CSVBuilder.cs
@@ -87,7 +87,6 @@ namespace LuckParser.Controllers
                 durationString = duration.ToString("hh") + "h " + durationString;
             }
             string bossname = log.getBossData().getName();
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
             //header
             WriteLine(new string[] { "Elite Insights Version", Application.ProductVersion });
             WriteLine(new string[] { "ARC Version", log.getLogData().getBuildVersion().ToString() });
@@ -184,7 +183,7 @@ namespace LuckParser.Controllers
         }
         private void CreateDPSTable(StreamWriter sw, int phase_index)
         {
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             WriteLine(new string[] { "Sub Group", "Profession","Role","Name","Account","WepSet1_1","WepSet1_2","WepSet2_1","WepSet2_2",
                 "Boss DPS","Boss DMG","Boss Power DPS","Boss Power DMG","Boss Condi DPS","Boss Condi DMG",
                 "All DPS","All DMG","All Power DPS","All Power DMG","All Condi DPS","All Condi DMG",
@@ -229,7 +228,7 @@ namespace LuckParser.Controllers
         private void CreateBossDMGStatsTable(StreamWriter sw, int phase_index)
         {
             //generate dmgstats table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             WriteLine(new string[] { "Sub Group", "Profession", "Name" ,
                 "Critical%","Critical hits","Critical DMG",
                 "Scholar%","Scholar hits","Scholar DMG","Scholar % increase",
@@ -265,7 +264,7 @@ namespace LuckParser.Controllers
         private void CreateDMGStatsTable(StreamWriter sw, int phase_index)
         {
             //generate dmgstats table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             WriteLine(new string[] { "Sub Group", "Profession", "Name" ,
                 "Critical%","Critical hits","Critical DMG",
                 "Scholar%","Scholar hits","Scholar DMG","Scholar % increase",
@@ -301,7 +300,7 @@ namespace LuckParser.Controllers
         private void CreateDefTable(StreamWriter sw, int phase_index)
         {
             //generate deftats table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             WriteLine(new string[] { "Sub Group", "Profession", "Name" ,
                 "DMG Taken","DMG Barrier","Blocked","Invulned","Evaded","Dodges" });
             int count = 0;
@@ -323,7 +322,7 @@ namespace LuckParser.Controllers
         private void CreateSupTable(StreamWriter sw, int phase_index)
         {
             //generate supstats table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             WriteLine(new string[] { "Sub Group", "Profession", "Name" ,
                 "Condi Cleanse","Condi Cleanse time","Resurrects","Time Resurecting" });
             int count = 0;
@@ -344,8 +343,8 @@ namespace LuckParser.Controllers
         private void CreateUptimeTable(StreamWriter sw, List<Boon> list_to_use, int phase_index)
         {
             //generate Uptime Table table
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            List<PhaseData> phases = statistics.phases;
+            PhaseData phase = statistics.phases[phase_index];
             HashSet<int> intensityBoon = new HashSet<int>();
             long fight_duration = phases[phase_index].getDuration();
 
@@ -403,7 +402,7 @@ namespace LuckParser.Controllers
         private void CreateGenSelfTable(StreamWriter sw, List<Boon> list_to_use, int phase_index)
         {
             //generate Uptime Table table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             HashSet<int> intensityBoon = new HashSet<int>();
 
             WriteCell("Name");
@@ -457,7 +456,7 @@ namespace LuckParser.Controllers
         private void CreateGenGroupTable(StreamWriter sw, List<Boon> list_to_use, int phase_index)
         {
             //generate Uptime Table table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             HashSet<int> intensityBoon = new HashSet<int>();
 
             WriteCell("Name");
@@ -512,7 +511,7 @@ namespace LuckParser.Controllers
         private void CreateGenOGroupTable(StreamWriter sw, List<Boon> list_to_use, int phase_index)
         {
             //generate Uptime Table table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             HashSet<int> intensityBoon = new HashSet<int>();
 
             WriteCell("Name");
@@ -567,7 +566,7 @@ namespace LuckParser.Controllers
         private void CreateGenSquadTable(StreamWriter sw, List<Boon> list_to_use, int phase_index)
         {
             //generate Uptime Table table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             HashSet<int> intensityBoon = new HashSet<int>();
 
             WriteCell("Name");
@@ -625,7 +624,7 @@ namespace LuckParser.Controllers
             //Dictionary<string, List<Mechanic>> presBossMech = new Dictionary<string, List<Mechanic>>();
             //Dictionary<string, List<Mechanic>> presMobMech = new Dictionary<string, List<Mechanic>>();
             Dictionary<string, List<Mechanic>> presEnemyMech = new Dictionary<string, List<Mechanic>>();
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
 
             //create list of enemys that had mechanics
             List<AbstractMasterPlayer> enemyList = new List<AbstractMasterPlayer>();
@@ -719,7 +718,7 @@ namespace LuckParser.Controllers
         }
         private void CreateMechList(StreamWriter sw, int phase_index)
         {
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
 
             List<MechanicLog> m_Logs = log.getMechanicData().GetMDataLogs().OrderByDescending(x=>x.GetTime()).ToList();
             m_Logs.Reverse();
@@ -753,7 +752,7 @@ namespace LuckParser.Controllers
         }
         private void CreateCondiUptime(StreamWriter sw,int phase_index) {
             Boss boss = log.getBoss();
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             long fight_duration = phases[phase_index].getDuration();
             Dictionary<long, Statistics.FinalBossBoon> conditions = statistics.bossConditions[phase_index];
             bool hasBoons = false;
@@ -829,7 +828,7 @@ namespace LuckParser.Controllers
         private void CreateCondiGen(StreamWriter sw, int phase_index)
         {
             Boss boss = log.getBoss();
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             long fight_duration = phases[phase_index].getDuration();
             Dictionary<long, Statistics.FinalBossBoon> conditions = statistics.bossConditions[phase_index];
             //bool hasBoons = false;

--- a/LuckParser/Controllers/GraphHelper.cs
+++ b/LuckParser/Controllers/GraphHelper.cs
@@ -12,7 +12,7 @@ namespace LuckParser.Controllers
 
         public enum GraphMode { Full, s10, s30 };
 
-        public static List<Point> getDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, ushort dstid, GraphMode mode)
+        public static List<Point> getDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, PhaseData phase, ushort dstid, GraphMode mode)
         {
             int asked_id = (phase_index + "_" + dstid + "_" + mode).GetHashCode();
             if (p.getDPSGraph(asked_id).Count > 0)
@@ -23,7 +23,6 @@ namespace LuckParser.Controllers
             List<Point> dmgList = new List<Point>();
             List<Point> dmgList10s = new List<Point>();
             List<Point> dmgList30s = new List<Point>();
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
             List<DamageLog> damage_logs = p.getDamageLogs(dstid, log, phase.getStart(), phase.getEnd());
             // fill the graph, full precision
             List<double> dmgListFull = new List<double>();
@@ -105,9 +104,9 @@ namespace LuckParser.Controllers
         /// </summary>
         /// <param name="p">The player</param>
         /// <returns></returns>
-        public static List<Point> getBossDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, GraphMode mode)
+        public static List<Point> getBossDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, PhaseData phase, GraphMode mode)
         {
-            return getDPSGraph(log, p, phase_index, log.getBossData().getInstid(), mode);
+            return getDPSGraph(log, p, phase_index, phase, log.getBossData().getInstid(), mode);
         }
 
         /// <summary>
@@ -115,9 +114,9 @@ namespace LuckParser.Controllers
         /// </summary>
         /// <param name="p">The player</param>
         /// <returns></returns>
-        public static List<Point> getTotalDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, GraphMode mode)
+        public static List<Point> getTotalDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, PhaseData phase, GraphMode mode)
         {
-            return getDPSGraph(log, p, phase_index, 0, mode);
+            return getDPSGraph(log, p, phase_index, phase, 0, mode);
         }
 
         /// <summary>
@@ -125,15 +124,15 @@ namespace LuckParser.Controllers
         /// </summary>
         /// <param name="p">The player</param>
         /// <returns></returns>
-        public static List<Point> getCleaveDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, GraphMode mode)
+        public static List<Point> getCleaveDPSGraph(ParsedLog log, AbstractMasterPlayer p, int phase_index, PhaseData phase, GraphMode mode)
         {           
             int asked_id = (phase_index + "_" + (-1) + "_" + mode).GetHashCode();
             if (p.getDPSGraph(asked_id).Count > 0)
             {
                 return p.getDPSGraph(asked_id);
             }
-            List<Point> total = getTotalDPSGraph(log, p, phase_index, mode);
-            List<Point> boss = getBossDPSGraph(log, p, phase_index, mode);
+            List<Point> total = getTotalDPSGraph(log, p, phase_index, phase, mode);
+            List<Point> boss = getBossDPSGraph(log, p, phase_index, phase, mode);
             List<Point> cleave = new List<Point>();
             for (int i = 0; i < boss.Count; i++)
             {

--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -70,7 +70,7 @@ namespace LuckParser.Controllers
             string plotID = "DPSGraph" + phase_index + "_" + mode;
             sw.Write("<div id=\"" + plotID + "\" style=\"height: 1000px;width:1200px; display:inline-block \"></div>");
             sw.Write("<script>");
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             sw.Write("document.addEventListener(\"DOMContentLoaded\", function() {");
             {
                 sw.Write("var data = [");
@@ -85,7 +85,7 @@ namespace LuckParser.Controllers
                     {//Turns display on or off
                         sw.Write("{");
                         //Adding dps axis
-                        List<Point> playertotaldpsgraphdata = GraphHelper.getTotalDPSGraph(log, p, phase_index, mode);
+                        List<Point> playertotaldpsgraphdata = GraphHelper.getTotalDPSGraph(log, p, phase_index, phase, mode);
                         sw.Write("y: [");
                         pbdgdCount = 0;
                         foreach (Point dp in playertotaldpsgraphdata)
@@ -135,7 +135,7 @@ namespace LuckParser.Controllers
                                 "visible:'legendonly'," +
                                 "name: '" + p.getCharacter() + " TDPS'" + "},");
                     }
-                    List<Point> playerbossdpsgraphdata = GraphHelper.getBossDPSGraph(log, p, phase_index, mode);
+                    List<Point> playerbossdpsgraphdata = GraphHelper.getBossDPSGraph(log, p, phase_index, phase, mode);
                     if (totalDpsAllPlayers.Count == 0)
                     {
                         //totalDpsAllPlayers = new List<int[]>(playerbossdpsgraphdata);
@@ -202,7 +202,7 @@ namespace LuckParser.Controllers
                     {//Turns display on or off
                         sw.Write("{");
                         //Adding dps axis
-                        List<Point> playercleavedpsgraphdata = GraphHelper.getCleaveDPSGraph(log, p, phase_index, mode);
+                        List<Point> playercleavedpsgraphdata = GraphHelper.getCleaveDPSGraph(log, p, phase_index, phase, mode);
                         sw.Write("y: [");
                         pbdgdCount = 0;
                         foreach (Point dp in playercleavedpsgraphdata)
@@ -317,10 +317,10 @@ namespace LuckParser.Controllers
                         Point check = new Point();
                         if (ml.GetPlayer() != log.getBoss())
                         {
-                            check = GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, mode).FirstOrDefault(x => x.X == ml.GetTime() - Math.Round(phase.getStart() / 1000.0));
+                            check = GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, phase, mode).FirstOrDefault(x => x.X == ml.GetTime() - Math.Round(phase.getStart() / 1000.0));
                             if (check == Point.Empty)
                             {
-                                check = new Point(0, GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, mode).Last().Y);
+                                check = new Point(0, GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, phase, mode).Last().Y);
                             }
                         }
                         else
@@ -412,7 +412,7 @@ namespace LuckParser.Controllers
                         {
                             foreach (MechanicLog ml in DnDList)
                             {
-                                Point check = GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, mode).FirstOrDefault(x => x.X == ml.GetTime() - Math.Round(phase.getStart() / 1000.0));
+                                Point check = GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, phase, mode).FirstOrDefault(x => x.X == ml.GetTime() - Math.Round(phase.getStart() / 1000.0));
                                 if (mcount == DnDList.Count - 1)
                                 {
                                     if (check != null)
@@ -421,7 +421,7 @@ namespace LuckParser.Controllers
                                     }
                                     else
                                     {
-                                        sw.Write("'" + GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, mode).Last().Y + "'");
+                                        sw.Write("'" + GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, phase, mode).Last().Y + "'");
                                     }
 
                                 }
@@ -433,7 +433,7 @@ namespace LuckParser.Controllers
                                     }
                                     else
                                     {
-                                        sw.Write("'" + GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, mode).Last().Y + "',");
+                                        sw.Write("'" + GraphHelper.getBossDPSGraph(log, ml.GetPlayer(), phase_index, phase, mode).Last().Y + "',");
                                     }
                                 }
 
@@ -694,7 +694,7 @@ namespace LuckParser.Controllers
         private void CreateDPSTable(StreamWriter sw, int phase_index)
         {
             //generate dps table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             sw.Write("<script>");
             {
                 sw.Write("document.addEventListener(\"DOMContentLoaded\", function() {");
@@ -843,7 +843,7 @@ namespace LuckParser.Controllers
         private void CreateDMGStatsTable(StreamWriter sw, int phase_index)
         {
             //generate dmgstats table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             sw.Write("<script>");
             {
                 sw.Write("document.addEventListener(\"DOMContentLoaded\", function() {");
@@ -976,7 +976,7 @@ namespace LuckParser.Controllers
         private void CreateDMGStatsBossTable(StreamWriter sw, int phase_index)
         {
             //generate dmgstats table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             sw.Write("<script>");
             {
                 sw.Write("document.addEventListener(\"DOMContentLoaded\", function() {");
@@ -1109,7 +1109,7 @@ namespace LuckParser.Controllers
         private void CreateDefTable(StreamWriter sw, int phase_index)
         {
             //generate Tankstats table
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             sw.Write("<script>");
             {
                 sw.Write("document.addEventListener(\"DOMContentLoaded\", function() {");
@@ -1370,7 +1370,7 @@ namespace LuckParser.Controllers
         /// <param name="table_id">id of the table</param>
         private void CreateUptimeTable(StreamWriter sw, List<Boon> list_to_use, string table_id, int phase_index)
         {
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             //Generate Boon table------------------------------------------------------------------------------------------------
             sw.Write("<script>");
             {
@@ -1846,7 +1846,7 @@ namespace LuckParser.Controllers
         /// <param name="sw">Stream writer</param>
         private void CreatePlayerTab(StreamWriter sw, int phase_index)
         {
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             PhaseData phase = phases[phase_index];
             long start = phase.getStart() + log.getBossData().getFirstAware();
             long end = phase.getEnd() + log.getBossData().getFirstAware();
@@ -1992,38 +1992,38 @@ namespace LuckParser.Controllers
                                         {//show total dps plot
                                             sw.Write("{");
                                             { //Adding dps axis
-                                                HTMLHelper.writeDPSGraph(sw, "Total DPS", GraphHelper.getTotalDPSGraph(log, p, phase_index, GraphHelper.GraphMode.Full), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Total DPS", GraphHelper.getTotalDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.Full), p);
                                             }
                                             sw.Write("},");
                                             if (settings.Show10s)
                                             {
                                                 sw.Write("{");
-                                                HTMLHelper.writeDPSGraph(sw, "Total DPS - 10s", GraphHelper.getTotalDPSGraph(log, p, phase_index, GraphHelper.GraphMode.s10), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Total DPS - 10s", GraphHelper.getTotalDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.s10), p);
                                                 sw.Write("},");
                                             }
                                             if (settings.Show30s)
                                             {
                                                 sw.Write("{");
-                                                HTMLHelper.writeDPSGraph(sw, "Total DPS - 30s", GraphHelper.getTotalDPSGraph(log, p, phase_index, GraphHelper.GraphMode.s30), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Total DPS - 30s", GraphHelper.getTotalDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.s30), p);
                                                 sw.Write("},");
                                             }
                                         }
                                          //Adding dps axis
                                             sw.Write("{");
                                             {
-                                                HTMLHelper.writeDPSGraph(sw, "Boss DPS", GraphHelper.getBossDPSGraph(log, p, phase_index, GraphHelper.GraphMode.Full), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Boss DPS", GraphHelper.getBossDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.Full), p);
                                             }
                                             sw.Write("},");
                                             if (settings.Show10s)
                                             {
                                                 sw.Write("{");
-                                                HTMLHelper.writeDPSGraph(sw, "Boss DPS - 10s", GraphHelper.getBossDPSGraph(log, p, phase_index, GraphHelper.GraphMode.s10), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Boss DPS - 10s", GraphHelper.getBossDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.s10), p);
                                                 sw.Write("},");
                                             }
                                             if (settings.Show30s)
                                             {
                                                 sw.Write("{");
-                                                HTMLHelper.writeDPSGraph(sw, "Boss DPS - 30s", GraphHelper.getBossDPSGraph(log, p, phase_index, GraphHelper.GraphMode.s30), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Boss DPS - 30s", GraphHelper.getBossDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.s30), p);
                                                 sw.Write("},");
                                             }
 
@@ -2032,19 +2032,19 @@ namespace LuckParser.Controllers
                                         {//show total dps plot
                                             sw.Write("{");
                                             { //Adding dps axis
-                                                HTMLHelper.writeDPSGraph(sw, "Cleave DPS", GraphHelper.getCleaveDPSGraph(log, p, phase_index, GraphHelper.GraphMode.Full), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Cleave DPS", GraphHelper.getCleaveDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.Full), p);
                                             }
                                             sw.Write("},");
                                             if (settings.Show10s)
                                             {
                                                 sw.Write("{");
-                                                HTMLHelper.writeDPSGraph(sw, "Cleave DPS - 10s", GraphHelper.getCleaveDPSGraph(log, p, phase_index, GraphHelper.GraphMode.s10), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Cleave DPS - 10s", GraphHelper.getCleaveDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.s10), p);
                                                 sw.Write("},");
                                             }
                                             if (settings.Show30s)
                                             {
                                                 sw.Write("{");
-                                                HTMLHelper.writeDPSGraph(sw, "Cleave DPS - 30s", GraphHelper.getCleaveDPSGraph(log, p, phase_index, GraphHelper.GraphMode.s30), p);
+                                                HTMLHelper.writeDPSGraph(sw, "Cleave DPS - 30s", GraphHelper.getCleaveDPSGraph(log, p, phase_index, phase, GraphHelper.GraphMode.s30), p);
                                                 sw.Write("},");
                                             }
                                         }
@@ -2204,7 +2204,7 @@ namespace LuckParser.Controllers
         {
             if (settings.PlayerRot)//Display rotation
             {
-                PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+                PhaseData phase = statistics.phases[phase_index];
                 List<CastLog> casting = p.getCastLogs(log, phase.getStart(), phase.getEnd());
                 //GW2APISkill autoSkill = null;
                 //int autosCount = 0;
@@ -2581,7 +2581,7 @@ namespace LuckParser.Controllers
         /// <param name="p">The player</param>
         private void CreateDMGDistTable(StreamWriter sw, Player p, bool toBoss, int phase_index)
         {
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             List<CastLog> casting = p.getCastLogs(log, phase.getStart(), phase.getEnd());
             List<DamageLog> damageLogs = p.getJustPlayerDamageLogs(toBoss ? log.getBossData().getInstid() : 0,log, phase.getStart(), phase.getEnd());
             Statistics.FinalDPS dps = statistics.dps[p][phase_index];
@@ -2638,7 +2638,7 @@ namespace LuckParser.Controllers
         /// <param name="p">The player</param>
         private void CreateDMGBossDistTable(StreamWriter sw, AbstractPlayer p, int phase_index)
         {
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             List<CastLog> casting = p.getCastLogs(log, phase.getStart(), phase.getEnd());
             List<DamageLog> damageLogs = p.getJustPlayerDamageLogs(0, log, phase.getStart(), phase.getEnd());
             Statistics.FinalDPS dps = statistics.bossDps[phase_index];
@@ -2701,7 +2701,7 @@ namespace LuckParser.Controllers
 
             int totalDamage = toBoss ? dps.bossDamage : dps.allDamage;
             string tabid = p.getInstid() + "_" + phase_index + "_" + minions.getInstid() + (toBoss ? "_boss" : "");
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             List<CastLog> casting = minions.getCastLogs(log, phase.getStart(), phase.getEnd());
             List<DamageLog> damageLogs = minions.getDamageLogs(toBoss ? log.getBossData().getInstid() : 0, log, phase.getStart(), phase.getEnd());
             int finalTotalDamage = damageLogs.Count > 0 ? damageLogs.Sum(x => x.getDamage()) : 0;
@@ -2760,7 +2760,7 @@ namespace LuckParser.Controllers
 
             int totalDamage =  dps.allDamage;
             string tabid = p.getInstid() + "_" + phase_index + "_" + minions.getInstid();
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             List<CastLog> casting = minions.getCastLogs(log, phase.getStart(), phase.getEnd());
             List<DamageLog> damageLogs = minions.getDamageLogs(0, log, phase.getStart(), phase.getEnd());
             int finalTotalDamage = damageLogs.Count > 0 ? damageLogs.Sum(x => x.getDamage()) : 0;
@@ -2813,7 +2813,7 @@ namespace LuckParser.Controllers
         /// <param name="p">The player</param>
         private void CreateDMGTakenDistTable(StreamWriter sw, Player p, int phase_index)
         {
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
             List<DamageLog> damageLogs = p.getDamageTakenLogs(log, phase.getStart(), phase.getEnd());
             List<SkillItem> s_list = log.getSkillData().getSkillList();
             long finalTotalDamage = damageLogs.Count > 0 ? damageLogs.Sum(x => (long)x.getDamage()) : 0;
@@ -2982,7 +2982,7 @@ namespace LuckParser.Controllers
             //Dictionary<string, List<Mechanic>> presBossMech = new Dictionary<string, List<Mechanic>>();
             //Dictionary<string, List<Mechanic>> presMobMech = new Dictionary<string, List<Mechanic>>();
             Dictionary<string, List<Mechanic>> presEnemyMech = new Dictionary<string, List<Mechanic>>();
-            PhaseData phase = log.getBoss().getPhases(log, settings.ParsePhases)[phase_index];
+            PhaseData phase = statistics.phases[phase_index];
 
             //create list of enemys that had mechanics
             List<AbstractMasterPlayer> enemyList = new List<AbstractMasterPlayer>();
@@ -3353,7 +3353,7 @@ namespace LuckParser.Controllers
         /// <param name="boss">The boss</param>
         private void CreateCondiUptimeTable(StreamWriter sw, Boss boss, int phase_index)
         {
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             long fight_duration = phases[phase_index].getDuration();
             Dictionary<long, Statistics.FinalBossBoon> conditions = statistics.bossConditions[phase_index];
             bool hasBoons = false;
@@ -3553,7 +3553,7 @@ namespace LuckParser.Controllers
         private void CreateBossSummary(StreamWriter sw, int phase_index)
         {
             //generate Player list Graphs
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             PhaseData phase = phases[phase_index];
             List<CastLog> casting = log.getBoss().getCastLogsActDur(log, phase.getStart(), phase.getEnd());
             List<SkillItem> s_list = log.getSkillData().getSkillList();
@@ -3608,7 +3608,7 @@ namespace LuckParser.Controllers
                             //int maxDPS = 0;
                             if (settings.DPSGraphTotals)
                             {//show total dps plot
-                                List<Point> playertotaldpsgraphdata = GraphHelper.getTotalDPSGraph(log, log.getBoss(), phase_index, GraphHelper.GraphMode.Full);
+                                List<Point> playertotaldpsgraphdata = GraphHelper.getTotalDPSGraph(log, log.getBoss(), phase_index, phase, GraphHelper.GraphMode.Full);
                                 sw.Write("{");
                                 {
                                     //Adding dps axis
@@ -3617,7 +3617,7 @@ namespace LuckParser.Controllers
                                 sw.Write("},");
                             }
                             sw.Write("{");
-                            HTMLHelper.writeBossHealthGraph(sw, GraphHelper.getTotalDPSGraph(log, log.getBoss(), phase_index, GraphHelper.GraphMode.Full).Max(x => x.Y), phase.getStart(), phase.getEnd(), log.getBossData(), "y3");
+                            HTMLHelper.writeBossHealthGraph(sw, GraphHelper.getTotalDPSGraph(log, log.getBoss(), phase_index, phase, GraphHelper.GraphMode.Full).Max(x => x.Y), phase.getStart(), phase.getEnd(), log.getBossData(), "y3");
                             sw.Write("}");
                         }
                         sw.Write("];");
@@ -3812,7 +3812,7 @@ namespace LuckParser.Controllers
                 durationString = duration.Hours + "h " + durationString;
             }
             string bossname = FilterStringChars(log.getBossData().getName());
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             // HTML STARTS
             sw.Write("<!DOCTYPE html><html lang=\"en\">");
             {
@@ -4354,7 +4354,7 @@ namespace LuckParser.Controllers
         }
         public void CreateSoloHTML(StreamWriter sw)
         {
-            List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            List<PhaseData> phases = statistics.phases;
             double fight_duration = (log.getBossData().getAwareDuration()) / 1000.0;
             Player p = log.getPlayerList()[0];
             List<CastLog> casting = p.getCastLogsActDur(log, 0, log.getBossData().getAwareDuration());
@@ -4403,7 +4403,7 @@ namespace LuckParser.Controllers
                         int maxDPS = 0;
                         if (settings.DPSGraphTotals)
                         {//show total dps plot
-                            List<Point> playertotaldpsgraphdata = GraphHelper.getTotalDPSGraph(log, p, 0, GraphHelper.GraphMode.Full);
+                            List<Point> playertotaldpsgraphdata = GraphHelper.getTotalDPSGraph(log, p, 0, statistics.phases[0], GraphHelper.GraphMode.Full);
                             sw.Write("{");
                             {
                                 HTMLHelper.writeDPSGraph(sw, "Total DPS", playertotaldpsgraphdata, p);
@@ -4411,7 +4411,7 @@ namespace LuckParser.Controllers
                             sw.Write("},");
                         }
                         //Adding dps axis
-                        List<Point> playerbossdpsgraphdata = GraphHelper.getBossDPSGraph(log, p, 0, GraphHelper.GraphMode.Full);
+                        List<Point> playerbossdpsgraphdata = GraphHelper.getBossDPSGraph(log, p, 0, statistics.phases[0], GraphHelper.GraphMode.Full);
                         sw.Write("{");
                         {
                             HTMLHelper.writeDPSGraph(sw, "Boss DPS", playerbossdpsgraphdata, p);

--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -1102,7 +1102,7 @@ namespace LuckParser.Controllers
                 {
                     sw.Write("{");
                     sw.Write("var a = new circleActor("+a.getRadius()+","+(a.isFilled() ? "true" : "false") + ","+a.getGrowing() / pollingRate + ","+a.getColor()+","+a.getLifespan().Item1/pollingRate+","+ a.getLifespan().Item2 / pollingRate + ");");
-                    sw.Write("circleData.add(a);");
+                    sw.Write("mechanicData.add(a);");
                     sw.Write("a.pos ="+a.getPosition(mob.getInstid() + "_" + mob.getCombatReplay().getTimeOffsets().Item1 / pollingRate + "_" + mob.getCombatReplay().getTimeOffsets().Item2 / pollingRate, map)+";");
                     sw.Write("}");
                 }
@@ -1114,7 +1114,7 @@ namespace LuckParser.Controllers
                 {
                     sw.Write("{");
                     sw.Write("var a = new circleActor(" + a.getRadius() + "," + (a.isFilled() ? "true" : "false") + "," + a.getGrowing() / pollingRate + "," + a.getColor() + "," + a.getLifespan().Item1 / pollingRate + "," + a.getLifespan().Item2 / pollingRate + ");");
-                    sw.Write("circleData.add(a);");
+                    sw.Write("mechanicData.add(a);");
                     sw.Write("a.pos =" + a.getPosition(player.getInstid().ToString(), map) + ";");
                     sw.Write("}");
                 }
@@ -1123,7 +1123,88 @@ namespace LuckParser.Controllers
             {
                 sw.Write("{");
                 sw.Write("var a = new circleActor(" + a.getRadius() + "," + (a.isFilled() ? "true" : "false") + "," + a.getGrowing() / pollingRate + "," + a.getColor() + "," + a.getLifespan().Item1 / pollingRate + "," + a.getLifespan().Item2 / pollingRate + ");");
-                sw.Write("circleData.add(a);");
+                sw.Write("mechanicData.add(a);");
+                sw.Write("a.pos =" + a.getPosition(log.getBossData().getInstid().ToString(), map) + ";");
+                sw.Write("}");
+
+            }
+        }
+
+        private static void writeCombatReplayDoughnutActors(StreamWriter sw, ParsedLog log, CombatReplayMap map, int pollingRate)
+        {
+            // Circle actors
+            sw.Write("var doughnutActor = function(innerRadius,outerRadius,growing, color, start, end) {" +
+                    "this.pos = null;" +
+                    "this.master = null;" +
+                    "this.start = start;" +
+                    "this.innerRadius = innerRadius;" +
+                    "this.outerRadius = outerRadius;" +
+                    "this.end = end;" +
+                    "this.growing = growing;" +
+                    "this.color = color;" +
+                "};");
+            sw.Write("doughnutActor.prototype.draw = function(ctx,timeToUse){" +
+                    "if (!(this.start > timeToUse || this.end < timeToUse)) {" +
+                        "var x,y;" +
+                        "if (this.pos instanceof Array) {" +
+                            "x = this.pos[0];" +
+                            "y = this.pos[1];" +
+                        "} else {" +
+                            "if (!this.master) {" +
+                                "var playerID = parseInt(this.pos);" +
+                                "this.master = data.has(playerID) ? data.get(playerID) : (secondaryData.has(this.pos) ? secondaryData.get(this.pos): boss);" +
+                            "}" +
+                            "var start = this.master.start ? this.master.start : 0;" +
+                            "x = this.master.pos.length > 2 ? this.master.pos[2*(timeToUse - start)] : this.master.pos[0];" +
+                            "y = this.master.pos.length > 2 ? this.master.pos[2*(timeToUse - start) + 1] : this.master.pos[1];" +
+                        "}" +
+                        "var radius = 0.5*(this.innerRadius + this.outerRadius);" +
+                        "var width = (this.outerRadius - this.innerRadius);" +
+                        "if (this.growing) {" +
+                            "var percent = Math.min((timeToUse - this.start)/(this.growing - this.start),1.0);" +
+                            "ctx.beginPath();" +
+                            "ctx.arc(x,y,inch * radius,0,2*Math.PI);" +
+                            "ctx.lineWidth=(inch * percent * width).toString();" +
+                            "ctx.strokeStyle=this.color;" +
+                            "ctx.stroke();" +
+                        "} else {" +
+                            "ctx.beginPath();" +
+                            "ctx.arc(x,y,inch * radius,0,2*Math.PI);" +
+                            "ctx.lineWidth=(inch * width).toString();" +
+                            "ctx.strokeStyle=this.color;" +
+                            "ctx.stroke();" +
+                        "}" +
+                    "}" +
+                "};");
+            foreach (Mob mob in log.getBoss().getThrashMobs())
+            {
+                CombatReplay replay = mob.getCombatReplay();
+                foreach (DoughnutActor a in replay.getDoughnutActors())
+                {
+                    sw.Write("{");
+                    sw.Write("var a = new doughnutActor(" + a.getInnerRadius() + "," + a.getOuterRadius() + "," + a.getGrowing() / pollingRate + "," + a.getColor() + "," + a.getLifespan().Item1 / pollingRate + "," + a.getLifespan().Item2 / pollingRate + ");");
+                    sw.Write("mechanicData.add(a);");
+                    sw.Write("a.pos =" + a.getPosition(mob.getInstid() + "_" + mob.getCombatReplay().getTimeOffsets().Item1 / pollingRate + "_" + mob.getCombatReplay().getTimeOffsets().Item2 / pollingRate, map) + ";");
+                    sw.Write("}");
+                }
+            }
+            foreach (Player player in log.getPlayerList())
+            {
+                CombatReplay replay = player.getCombatReplay();
+                foreach (DoughnutActor a in replay.getDoughnutActors())
+                {
+                    sw.Write("{");
+                    sw.Write("var a = new doughnutActor(" + a.getInnerRadius() + "," + a.getOuterRadius() + "," + a.getGrowing() / pollingRate + "," + a.getColor() + "," + a.getLifespan().Item1 / pollingRate + "," + a.getLifespan().Item2 / pollingRate + ");");
+                    sw.Write("mechanicData.add(a);");
+                    sw.Write("a.pos =" + a.getPosition(player.getInstid().ToString(), map) + ";");
+                    sw.Write("}");
+                }
+            }
+            foreach (DoughnutActor a in log.getBoss().getCombatReplay().getDoughnutActors())
+            {
+                sw.Write("{");
+                sw.Write("var a = new doughnutActor(" + a.getInnerRadius() + "," + a.getOuterRadius() + "," + a.getGrowing() / pollingRate + "," + a.getColor() + "," + a.getLifespan().Item1 / pollingRate + "," + a.getLifespan().Item2 / pollingRate + ");");
+                sw.Write("mechanicData.add(a);");
                 sw.Write("a.pos =" + a.getPosition(log.getBossData().getInstid().ToString(), map) + ";");
                 sw.Write("}");
 
@@ -1143,7 +1224,7 @@ namespace LuckParser.Controllers
                 sw.Write("var selectedPlayer = null;");
                 sw.Write("var data = new Map();");
                 sw.Write("var secondaryData = new Map();");
-                sw.Write("var circleData = new Set();");
+                sw.Write("var mechanicData = new Set();");
                 sw.Write("var deadIcon = new Image();" +
                             "deadIcon.src = '"+GetLink("Dead")+"';");
                 sw.Write("var downIcon = new Image();" +
@@ -1153,6 +1234,7 @@ namespace LuckParser.Controllers
                 writeCombatReplayMainClass(sw, log, map, pollingRate);
                 writeCombatReplaySecondaryClass(sw, log, map, pollingRate);
                 writeCombatReplayCircleActors(sw, log, map, pollingRate);
+                writeCombatReplayDoughnutActors(sw, log, map, pollingRate);
                 // Main loop
                 sw.Write("var ctx = document.getElementById('replayCanvas').getContext('2d');");
                 sw.Write("ctx.imageSmoothingEnabled = true;");
@@ -1162,11 +1244,9 @@ namespace LuckParser.Controllers
                     sw.Write("ctx.clearRect(0,0," + canvasSize.Item1 + "," + canvasSize.Item2 + ");");
                     // draw arena
                     sw.Write("ctx.drawImage(bgImage,0,0," + canvasSize.Item1 + "," + canvasSize.Item2 + ");");
-                    // draw circles
-                    sw.Write("circleData.forEach(function(value,key,map) {" +
-                            "if (!value.selected) {" +
-                                "value.draw(ctx,timeToUse);" +
-                            "}" +
+                    // draw mechanics
+                    sw.Write("mechanicData.forEach(function(value,key,map) {" +
+                            "value.draw(ctx,timeToUse);" +
                         "});");
                     // draw unselected players
                     sw.Write("data.forEach(function(value,key,map) {" +

--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -736,7 +736,6 @@ namespace LuckParser.Controllers
 
         public static void writeCombatReplayInterface(StreamWriter sw, Tuple<int,int> canvasSize, ParsedLog log)
         {
-            int endTime = log.getPlayerList().Select(x => x.getCombatReplay().getPositions().Count - 1).Max();
             sw.Write("<div class=\"d-flex justify-content-around align-items-center justify-content-center\">");
             {
                 sw.Write("<div class=\"d-flex flex-column flex-wrap\">");
@@ -745,7 +744,7 @@ namespace LuckParser.Controllers
                     sw.Write("</canvas>");
                     sw.Write("<div class=\"d-flex justify-content-center slidecontainer\">");
                     {
-                        sw.Write("<input oninput=\"updateTime(this.value);\"type=\"range\" min=\"0\" max=\"" + endTime + "\" value=\"0\" class=\"slider\" id=\"timeRange\">");
+                        sw.Write("<input oninput=\"updateTime(this.value);\"type=\"range\" min=\"0\" max=\"" + (log.getBoss().getCombatReplay().getPositions().Count - 1) + "\" value=\"0\" class=\"slider\" id=\"timeRange\">");
                         sw.Write("<input class=\"ml-5\" type=\"text\" id=\"timeRangeDisplay\" disabled value=\"0 secs\">");
                     }
                     sw.Write("</div>");
@@ -835,10 +834,9 @@ namespace LuckParser.Controllers
 
         private static void writeCombatReplayControls(StreamWriter sw, ParsedLog log, int pollingRate)
         {
-            int endTime = log.getPlayerList().Select(x => x.getCombatReplay().getPositions().Count - 1).Max();
             // animation control
             sw.Write("function startAnimate() {if (animation === null) { " +
-                "if (time ===" + endTime + ") {" +
+                "if (time ===" + (log.getBoss().getCombatReplay().getPositions().Count - 1) + ") {" +
                     "time = 0;" +
                 "}" +
                 "animation = setInterval(function(){myanimate(time++)},speed);" +
@@ -1134,8 +1132,6 @@ namespace LuckParser.Controllers
 
         public static void writeCombatReplayScript(StreamWriter sw, ParsedLog log, Tuple<int,int> canvasSize, CombatReplayMap map, int pollingRate)
         {
-
-            int endTime = log.getPlayerList().Select(x => x.getCombatReplay().getPositions().Count - 1).Max();
             sw.Write("<script>");
             {
                 // globals
@@ -1188,7 +1184,7 @@ namespace LuckParser.Controllers
                     sw.Write("if (selectedPlayer) {" +
                                 "selectedPlayer.draw(ctx,timeToUse,20);"+                              
                             "}");
-                    sw.Write("if (timeToUse === " + endTime + ") {stopAnimate();}");
+                    sw.Write("if (timeToUse === " + (log.getBoss().getCombatReplay().getPositions().Count - 1) + ") {stopAnimate();}");
                     sw.Write("timeSlider.value = time;");
                     sw.Write("updateTextInput(time);");
                 }

--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -391,14 +391,14 @@ namespace LuckParser.Controllers
                                 {
                                     GroupsPosList.Add(list);
                                 }
-                            }
-                            int active_players = GroupsPosList.Count();
-                            for (int time = 0; time < GroupsPosList[0].Count(); time++)
+                            }                       
+                            for (int time = 0; time < GroupsPosList[0].Count; time++)
                             {
                                 float x = 0;
                                 float y = 0;
                                 float z = 0;
-                                for (int play = 0; play < active_players; play++)
+                                int active_players = GroupsPosList.Count;
+                                for (int play = 0; play < GroupsPosList.Count; play++)
                                 {
                                     Point3D point = GroupsPosList[play][time];
                                     if (point != null)
@@ -419,21 +419,22 @@ namespace LuckParser.Controllers
                                 statistics.StackCenterPositions.Add(new Point3D(x, y, z, time));
                             }
                         }
-                        List<Point3D> positions = player.getCombatReplay().getPositions();
+                        List<Point3D> positions = player.getCombatReplay().getPositions().Where(x => x.time >= phase.getStart() && x.time <= phase.getEnd()).ToList();
+                        int offset = player.getCombatReplay().getPositions().Count(x => x.time < phase.getStart());
                         if (positions.Count > 1)
                         {
                             List<float> distances = new List<float>();
-                            for (int time = 0; time < positions.Count(); time++)
+                            for (int time = 0; time < positions.Count; time++)
                             {
 
-                                float deltaX = positions[time].X - statistics.StackCenterPositions[time].X;
-                                float deltaY = positions[time].Y - statistics.StackCenterPositions[time].Y;
+                                float deltaX = positions[time].X - statistics.StackCenterPositions[time + offset].X;
+                                float deltaY = positions[time].Y - statistics.StackCenterPositions[time + offset].Y;
                                 //float deltaZ = positions[time].Z - Statistics.StackCenterPositions[time].Z;
 
 
                                 distances.Add((float)Math.Sqrt(deltaX * deltaX + deltaY * deltaY));
                             }
-                            final.stackDist = distances.Sum() / distances.Count();
+                            final.stackDist = distances.Sum() / distances.Count;
                         }
                         else
                         {

--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -51,9 +51,9 @@ namespace LuckParser.Controllers
             {
                 foreach (Player p in log.getPlayerList())
                 {
-                    p.initCombatReplay(log, settings.PollingRate);
+                    p.initCombatReplay(log, settings.PollingRate, false, true);
                 }
-                log.getBoss().initCombatReplay(log, settings.PollingRate);
+                log.getBoss().initCombatReplay(log, settings.PollingRate, false, true);
             }
             if (switches.calculateDPS) calculateDPS();
             if (switches.calculateStats) calculateStats();
@@ -378,7 +378,7 @@ namespace LuckParser.Controllers
                     final.ressCount = combatData.getSkillCount(instid, 1066, start, end); //Res = 1066
 
                     //Stack Distance
-                    if (log.getMovementData().Count > 0)
+                    if (settings.ParseCombatReplay && log.getBoss().getCombatReplay() != null)
                     {
                         if (statistics.StackCenterPositions == null)
                         {
@@ -386,36 +386,19 @@ namespace LuckParser.Controllers
                             List<List<Point3D>> GroupsPosList = new List<List<Point3D>>();
                             foreach (Player p in log.getPlayerList())
                             {
-                                List<Point3D> list = p.getCombatReplay().getPositions();
+                                List<Point3D> list = p.getCombatReplay().getActivePositions();  
                                 if (list.Count > 1)
                                 {
-                                    List<CombatItem> dead_2 = combatData.getStates(instid, ParseEnum.StateChange.ChangeDead, start, end);
-                                    foreach (CombatItem deadEvent in dead_2)
-                                    {
-                                        for (int strt = (int)deadEvent.getTime(); start <= list.Count; strt++)
-                                        {
-                                            list[strt] = null;
-                                        }
-                                    }
-                                    List<CombatItem> disconect_2 = combatData.getStates(instid, ParseEnum.StateChange.Despawn, start, end);
-                                    foreach (CombatItem dcEvent in disconect_2)
-                                    {
-                                        for (int strt = (int)dcEvent.getTime(); start <= list.Count; strt++)
-                                        {
-                                            list[strt] = null;
-                                        }
-                                    }
                                     GroupsPosList.Add(list);
                                 }
-                               
                             }
+                            int active_players = GroupsPosList.Count();
                             for (int time = 0; time < GroupsPosList[0].Count(); time++)
                             {
                                 float x = 0;
                                 float y = 0;
                                 float z = 0;
-                                int active_players = GroupsPosList.Count();
-                                for (int play = 0; play < GroupsPosList.Count(); play++)
+                                for (int play = 0; play < active_players; play++)
                                 {
                                     Point3D point = GroupsPosList[play][time];
                                     if (point != null)
@@ -436,10 +419,6 @@ namespace LuckParser.Controllers
                                 statistics.StackCenterPositions.Add(new Point3D(x, y, z, time));
                             }
                         }
-                   
-                    }
-                    if (log.getMovementData().Count > 0)
-                    {
                         List<Point3D> positions = player.getCombatReplay().getPositions();
                         if (positions.Count > 1)
                         {
@@ -460,7 +439,6 @@ namespace LuckParser.Controllers
                         {
                             final.stackDist = -1;
                         }
-                       
                     }
                     // R.I.P
                     List<CombatItem> dead = combatData.getStates(instid, ParseEnum.StateChange.ChangeDead, start, end);

--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -28,8 +28,6 @@ namespace LuckParser.Controllers
 
         private ParsedLog log;
 
-        private List<PhaseData> phases;
-
         public StatisticsCalculator(SettingsContainer settings)
         {
             this.settings = settings;
@@ -46,7 +44,7 @@ namespace LuckParser.Controllers
 
             this.log = log;
 
-            phases = log.getBoss().getPhases(log, settings.ParsePhases);
+            statistics.phases = log.getBoss().getPhases(log, settings.ParsePhases);
             if (switches.calculateCombatReplay && settings.ParseCombatReplay)
             {
                 foreach (Player p in log.getPlayerList())
@@ -85,7 +83,7 @@ namespace LuckParser.Controllers
         {
             Statistics.FinalDPS final = new Statistics.FinalDPS();
 
-            PhaseData phase = phases[phaseIndex];
+            PhaseData phase = statistics.phases[phaseIndex];
 
             double phaseDuration = (phase.getDuration()) / 1000.0;
 
@@ -172,8 +170,8 @@ namespace LuckParser.Controllers
         {
             foreach (Player player in log.getPlayerList())
             {
-                Statistics.FinalDPS[] phaseDps = new Statistics.FinalDPS[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Statistics.FinalDPS[] phaseDps = new Statistics.FinalDPS[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {
                     phaseDps[phaseIndex] = getFinalDPS(player,phaseIndex);
                 }
@@ -181,8 +179,8 @@ namespace LuckParser.Controllers
                 statistics.dps[player] = phaseDps;
             }
 
-            Statistics.FinalDPS[] phaseBossDps = new Statistics.FinalDPS[phases.Count];
-            for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+            Statistics.FinalDPS[] phaseBossDps = new Statistics.FinalDPS[statistics.phases.Count];
+            for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
             {
                 phaseBossDps[phaseIndex] = getFinalDPS(log.getBoss(), phaseIndex);
             }
@@ -194,12 +192,12 @@ namespace LuckParser.Controllers
         {
             foreach (Player player in log.getPlayerList())
             {
-                Statistics.FinalStats[] phaseStats = new Statistics.FinalStats[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Statistics.FinalStats[] phaseStats = new Statistics.FinalStats[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {
                     Statistics.FinalStats final = new Statistics.FinalStats();
 
-                    PhaseData phase = phases[phaseIndex];
+                    PhaseData phase =statistics.phases[phaseIndex];
                     long start = phase.getStart() + log.getBossData().getFirstAware();
                     long end = phase.getEnd() + log.getBossData().getFirstAware();
 
@@ -466,12 +464,12 @@ namespace LuckParser.Controllers
         {
             foreach (Player player in log.getPlayerList())
             {
-                Statistics.FinalDefenses[] phaseDefense = new Statistics.FinalDefenses[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Statistics.FinalDefenses[] phaseDefense = new Statistics.FinalDefenses[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {
                     Statistics.FinalDefenses final = new Statistics.FinalDefenses();
 
-                    PhaseData phase = phases[phaseIndex];
+                    PhaseData phase =statistics.phases[phaseIndex];
                     long start = phase.getStart() + log.getBossData().getFirstAware();
                     long end = phase.getEnd() + log.getBossData().getFirstAware();
 
@@ -504,12 +502,12 @@ namespace LuckParser.Controllers
         {
             foreach (Player player in log.getPlayerList())
             {
-                Statistics.FinalSupport[] phaseSupport = new Statistics.FinalSupport[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Statistics.FinalSupport[] phaseSupport = new Statistics.FinalSupport[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {
                     Statistics.FinalSupport final = new Statistics.FinalSupport();
 
-                    PhaseData phase = phases[phaseIndex];
+                    PhaseData phase =statistics.phases[phaseIndex];
                     long start = phase.getStart() + log.getBossData().getFirstAware();
                     long end = phase.getEnd() + log.getBossData().getFirstAware();
 
@@ -533,13 +531,13 @@ namespace LuckParser.Controllers
 
         private Dictionary<long, Statistics.FinalBoonUptime> getBoonsForList(List<Player> playerList, Player player, List<Boon> to_track, int phaseIndex)
         {
-            PhaseData phase = phases[phaseIndex];
+            PhaseData phase =statistics.phases[phaseIndex];
             long fightDuration = phase.getEnd() - phase.getStart();
 
             Dictionary<Player, BoonDistribution> boonDistributions = new Dictionary<Player, BoonDistribution>();
             foreach (Player p in playerList)
             {
-                boonDistributions[p] = p.getBoonDistribution(log, phases, to_track, phaseIndex);
+                boonDistributions[p] = p.getBoonDistribution(log,statistics.phases, to_track, phaseIndex);
             }
 
             Dictionary<long, Statistics.FinalBoonUptime> final =
@@ -590,14 +588,14 @@ namespace LuckParser.Controllers
                 boon_to_track.AddRange(statistics.present_offbuffs);
                 boon_to_track.AddRange(statistics.present_defbuffs);
                 boon_to_track.AddRange(statistics.present_personnal[player.getInstid()]);
-                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {
                     Dictionary<long, Statistics.FinalBoonUptime> final = new Dictionary<long, Statistics.FinalBoonUptime>();
 
-                    PhaseData phase = phases[phaseIndex];
+                    PhaseData phase =statistics.phases[phaseIndex];
 
-                    BoonDistribution selfBoons = player.getBoonDistribution(log, phases, boon_to_track, phaseIndex);
+                    BoonDistribution selfBoons = player.getBoonDistribution(log,statistics.phases, boon_to_track, phaseIndex);
 
                     long fightDuration = phase.getEnd() - phase.getStart();
                     foreach (Boon boon in boon_to_track)
@@ -646,8 +644,8 @@ namespace LuckParser.Controllers
                 {
                     if (p.getGroup() == player.getGroup() && player.getInstid() != p.getInstid()) groupPlayers.Add(p);
                 }
-                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {
                     phaseBoons[phaseIndex] = getBoonsForList(groupPlayers, player, boon_to_track, phaseIndex);
                 }
@@ -667,8 +665,8 @@ namespace LuckParser.Controllers
                 {
                     if (p.getGroup() != player.getGroup()) groupPlayers.Add(p);
                 }
-                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {                    
                     phaseBoons[phaseIndex] = getBoonsForList(groupPlayers, player, boon_to_track, phaseIndex);
                 }
@@ -689,8 +687,8 @@ namespace LuckParser.Controllers
                     if (p.getInstid() != player.getInstid())
                         groupPlayers.Add(p);
                 }
-                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[phases.Count];
-                for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+                Dictionary<long, Statistics.FinalBoonUptime>[] phaseBoons = new Dictionary<long, Statistics.FinalBoonUptime>[statistics.phases.Count];
+                for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
                 {                
                     phaseBoons[phaseIndex] = getBoonsForList(groupPlayers, player, boon_to_track, phaseIndex);
                 }
@@ -700,16 +698,15 @@ namespace LuckParser.Controllers
 
         public void calculateConditions()
         {
-            statistics.bossConditions = new Dictionary<long, Statistics.FinalBossBoon>[phases.Count];
+            statistics.bossConditions = new Dictionary<long, Statistics.FinalBossBoon>[statistics.phases.Count];
             List<Boon> boon_to_track = Boon.getCondiBoonList();
             boon_to_track.AddRange(Boon.getBoonList());
-            for (int phaseIndex = 0; phaseIndex < phases.Count; phaseIndex++)
+            for (int phaseIndex = 0; phaseIndex <statistics.phases.Count; phaseIndex++)
             {
-                List<PhaseData> phases = log.getBoss().getPhases(log, settings.ParsePhases);
-                BoonDistribution boonDistribution = log.getBoss().getBoonDistribution(log, phases, boon_to_track, phaseIndex);
+                BoonDistribution boonDistribution = log.getBoss().getBoonDistribution(log,statistics.phases, boon_to_track, phaseIndex);
                 Dictionary<long, Statistics.FinalBossBoon> rates = new Dictionary<long, Statistics.FinalBossBoon>();
 
-                PhaseData phase = phases[phaseIndex];
+                PhaseData phase =statistics.phases[phaseIndex];
                 long fightDuration = phase.getDuration();
 
                 foreach (Boon boon in boon_to_track)

--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Models\DataModels\Statistics.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\Actor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\CircleActor.cs" />
+    <Compile Include="Models\ParseModels\CombatReplay\Actors\DoughnutActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\ImmobileActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\MobileActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\Mobility.cs" />

--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -122,8 +122,9 @@
     <Compile Include="Models\DataModels\Statistics.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\Actor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\CircleActor.cs" />
-    <Compile Include="Models\ParseModels\CombatReplay\Actors\FollowingCircle.cs" />
-    <Compile Include="Models\ParseModels\CombatReplay\Actors\ImmobileCircle.cs" />
+    <Compile Include="Models\ParseModels\CombatReplay\Actors\ImmobileActor.cs" />
+    <Compile Include="Models\ParseModels\CombatReplay\Actors\MobileActor.cs" />
+    <Compile Include="Models\ParseModels\CombatReplay\Actors\Mobility.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\CombatReplay.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\CombatReplayMap.cs" />
     <Compile Include="Models\ParseModels\EffectStackingLogic\HealingLogic.cs" />

--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Models\DataModels\ParsedLog.cs" />
     <Compile Include="Models\DataModels\SettingsContainer.cs" />
     <Compile Include="Models\DataModels\Statistics.cs" />
+    <Compile Include="Models\ParseModels\CombatReplay\Actors\Actor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\CircleActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\FollowingCircle.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\ImmobileCircle.cs" />

--- a/LuckParser/Models/BossStrategy/Cairn.cs
+++ b/LuckParser/Models/BossStrategy/Cairn.cs
@@ -72,7 +72,7 @@ namespace LuckParser.Models
                 else
                 {
                     agonyEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(false, 0, 220, new Tuple<int, int>(agonyStart, agonyEnd), "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 220, new Tuple<int, int>(agonyStart, agonyEnd), "rgba(255, 0, 0, 0.5)"));
                 }
             }
         }

--- a/LuckParser/Models/BossStrategy/Deimos.cs
+++ b/LuckParser/Models/BossStrategy/Deimos.cs
@@ -113,11 +113,11 @@ namespace LuckParser.Models
             {
                 int start = (int)c.getTime();
                 int end = start + 5000;
-                replay.addCircleActor(new FollowingCircle(true, end, 180, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
-                replay.addCircleActor(new FollowingCircle(false, 0, 180, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(true, end, 180, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(false, 0, 180, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
                 if (!log.getBossData().getCM())
                 {
-                    replay.addCircleActor(new ImmobileCircle(true, 0, 180, new Tuple<int, int>(start, end), "rgba(0, 0, 255, 0.3)", new Point3D(-8421.818f, 3091.72949f, -9.818082e8f, 216)));
+                    replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(start, end), "rgba(0, 0, 255, 0.3)", new Point3D(-8421.818f, 3091.72949f, -9.818082e8f, 216)));
                 }
             }
             return ids;
@@ -138,8 +138,8 @@ namespace LuckParser.Models
                 else
                 {
                     tpEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
-                    replay.addCircleActor(new FollowingCircle(true, tpEnd, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, tpEnd, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
                 }
             }
         }

--- a/LuckParser/Models/BossStrategy/Dhuum.cs
+++ b/LuckParser/Models/BossStrategy/Dhuum.cs
@@ -129,9 +129,9 @@ namespace LuckParser.Models
                 Point3D pos = replay.getPositions().FirstOrDefault(x => x.time > cast_end);
                 if (pos != null)
                 {
-                    replay.addCircleActor(new ImmobileCircle(true, cast_end, 450, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
-                    replay.addCircleActor(new ImmobileCircle(false, 0, 450, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
-                    replay.addCircleActor(new ImmobileCircle(true, 0, 450, new Tuple<int, int>(cast_end, zone_end), "rgba(200, 255, 100, 0.5)", pos));
+                    replay.addCircleActor(new CircleActor(true, cast_end, 450, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
+                    replay.addCircleActor(new CircleActor(false, 0, 450, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
+                    replay.addCircleActor(new CircleActor(true, 0, 450, new Tuple<int, int>(cast_end, zone_end), "rgba(200, 255, 100, 0.5)", pos));
                 }
             }
             List<CastLog> cataCycle = cls.Where(x => x.getID() == 48398).ToList();
@@ -139,14 +139,14 @@ namespace LuckParser.Models
             {
                 int start = (int)c.getTime();
                 int end = start + c.getActDur();
-                replay.addCircleActor(new FollowingCircle(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.7)"));
-                replay.addCircleActor(new FollowingCircle(true, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.7)"));
+                replay.addCircleActor(new CircleActor(true, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
             }
             if (majorSplit != null)
             {
                 int start = (int)majorSplit.getTime();
                 int end = (int)log.getBossData().getAwareDuration();
-                replay.addCircleActor(new FollowingCircle(true, 0, 320, new Tuple<int, int>(start, end), "rgba(0, 180, 255, 0.2)"));
+                replay.addCircleActor(new CircleActor(true, 0, 320, new Tuple<int, int>(start, end), "rgba(0, 180, 255, 0.2)"));
             }
             return ids;
         }
@@ -169,8 +169,8 @@ namespace LuckParser.Models
                 {
                     end = (int)(removedBuff.getTime() - log.getBossData().getFirstAware());
                 }
-                replay.addCircleActor(new FollowingCircle(true, 0, 100, new Tuple<int, int>(start, end), "rgba(0, 50, 200, 0.3)"));
-                replay.addCircleActor(new FollowingCircle(true, start + duration, 100, new Tuple<int, int>(start, end), "rgba(0, 50, 200, 0.5)"));
+                replay.addCircleActor(new CircleActor(true, 0, 100, new Tuple<int, int>(start, end), "rgba(0, 50, 200, 0.3)"));
+                replay.addCircleActor(new CircleActor(true, start + duration, 100, new Tuple<int, int>(start, end), "rgba(0, 50, 200, 0.5)"));
             }
             // bomb
             List<CombatItem> bombDhuum = getFilteredList(log, 47646, p.getInstid());
@@ -185,8 +185,8 @@ namespace LuckParser.Models
                 else
                 {
                     bombDhuumEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 100, new Tuple<int, int>(bombDhuumStart, bombDhuumEnd), "rgba(80, 180, 0, 0.3)"));
-                    replay.addCircleActor(new FollowingCircle(true, bombDhuumStart + 13000, 100, new Tuple<int, int>(bombDhuumStart, bombDhuumEnd), "rgba(80, 180, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 100, new Tuple<int, int>(bombDhuumStart, bombDhuumEnd), "rgba(80, 180, 0, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, bombDhuumStart + 13000, 100, new Tuple<int, int>(bombDhuumStart, bombDhuumEnd), "rgba(80, 180, 0, 0.5)"));
                 }
             }
         }

--- a/LuckParser/Models/BossStrategy/Dhuum.cs
+++ b/LuckParser/Models/BossStrategy/Dhuum.cs
@@ -129,9 +129,9 @@ namespace LuckParser.Models
                 Point3D pos = replay.getPositions().FirstOrDefault(x => x.time > cast_end);
                 if (pos != null)
                 {
-                    replay.addCircleActor(new ImmobileCircle(true, cast_end, 360, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
-                    replay.addCircleActor(new ImmobileCircle(false, 0, 360, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
-                    replay.addCircleActor(new ImmobileCircle(true, 0, 360, new Tuple<int, int>(cast_end, zone_end), "rgba(200, 255, 100, 0.5)", pos));
+                    replay.addCircleActor(new ImmobileCircle(true, cast_end, 450, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
+                    replay.addCircleActor(new ImmobileCircle(false, 0, 450, new Tuple<int, int>(start, cast_end), "rgba(200, 255, 100, 0.5)", pos));
+                    replay.addCircleActor(new ImmobileCircle(true, 0, 450, new Tuple<int, int>(cast_end, zone_end), "rgba(200, 255, 100, 0.5)", pos));
                 }
             }
             List<CastLog> cataCycle = cls.Where(x => x.getID() == 48398).ToList();

--- a/LuckParser/Models/BossStrategy/Gorseval.cs
+++ b/LuckParser/Models/BossStrategy/Gorseval.cs
@@ -150,6 +150,7 @@ namespace LuckParser.Models
                         default:
                             throw new Exception("how the fuck");
                     }
+                    start += 2200;
                     for (int i = 0; i < ticks; i++)
                     {
                         int tickStart = start + 4000 * i;

--- a/LuckParser/Models/BossStrategy/Gorseval.cs
+++ b/LuckParser/Models/BossStrategy/Gorseval.cs
@@ -179,8 +179,11 @@ namespace LuckParser.Models
                         }
                         if (pattern.Contains("Full"))
                         {
-                            replay.addCircleActor(new CircleActor(true, explosion, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", log.getBoss().getCombatReplay().getPositions().First()));
-                            replay.addCircleActor(new CircleActor(true, 0, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", log.getBoss().getCombatReplay().getPositions().First()));
+                            tickStart -= 1000;
+                            explosion -= 1000;
+                            tickEnd -= 1000;
+                            replay.addCircleActor(new CircleActor(true, explosion, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
+                            replay.addCircleActor(new CircleActor(true, 0, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
                         }
                     }
                 }

--- a/LuckParser/Models/BossStrategy/Gorseval.cs
+++ b/LuckParser/Models/BossStrategy/Gorseval.cs
@@ -117,11 +117,11 @@ namespace LuckParser.Models
                         case 1:
                             patterns = new List<string>
                             {
-                                "2+3",
+                                "2+3+5",
                                 "2+3+4",
-                                "1+4",
-                                "1+2",
-                                "1+3",
+                                "1+4+5",
+                                "1+2+5",
+                                "1+3+5",
                                 "Full"
                             };
                             break;
@@ -129,9 +129,9 @@ namespace LuckParser.Models
                             patterns = new List<string>
                             {
                                 "2+3+4",
-                                "1+4",
+                                "1+4+5",
                                 "1+3+4",
-                                "1+2",
+                                "1+2+5",
                                 "1+2+3",
                                 "Full"
                             };
@@ -139,11 +139,11 @@ namespace LuckParser.Models
                         case 5:
                             patterns = new List<string>
                             {
-                                "1+4",
-                                "1+2",
-                                "2+3",
-                                "3+4",
-                                "3+4",
+                                "1+4+5",
+                                "1+2+5",
+                                "2+3+5",
+                                "3+4+5",
+                                "3+4+5",
                                 "Full"
                             };
                             break;
@@ -177,13 +177,18 @@ namespace LuckParser.Models
                             replay.addDoughnutActor(new DoughnutActor(explosion, 900, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
                             replay.addDoughnutActor(new DoughnutActor(0, 900, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
                         }
+                        if (pattern.Contains("5"))
+                        {
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 1200, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 1200, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                        }
                         if (pattern.Contains("Full"))
                         {
                             tickStart -= 1000;
                             explosion -= 1000;
                             tickEnd -= 1000;
-                            replay.addCircleActor(new CircleActor(true, explosion, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
-                            replay.addCircleActor(new CircleActor(true, 0, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                            replay.addCircleActor(new CircleActor(true, explosion, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
+                            replay.addCircleActor(new CircleActor(true, 0, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
                         }
                     }
                 }

--- a/LuckParser/Models/BossStrategy/Gorseval.cs
+++ b/LuckParser/Models/BossStrategy/Gorseval.cs
@@ -20,7 +20,7 @@ namespace LuckParser.Models
             new Mechanic(31498, "Spectral Darkness", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Gorseval, "symbol:'circle',color:'rgb(0,0,255)',", "Orb Debuff",0),
             new Mechanic(31722, "Spirited Fusion", Mechanic.MechType.EnemyBoon, ParseEnum.BossIDS.Gorseval, "symbol:'square',color:'rgb(255,140,0)',", "Ate Spirit",0),
             new Mechanic(31720, "Kick", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Gorseval, "symbol:'triangle-right',color:'rgb(255,0,255)',", "Kicked by Spirit",0)
-            //new Mechanic(738, "Ghastly Rampage", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Gorseval, "symbol:'circle',color:'rgb(0,0,0)',", "Stood in black",2), //stood in black? Trigger via (25 stacks) vuln (ID 738) application would be possible
+            //new Mechanic(31834, "Ghastly Rampage", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Gorseval, "symbol:'circle',color:'rgb(0,0,0)',", "Stood in black",2), //stood in black? Trigger via (25 stacks) vuln (ID 738) application would be possible
             };
         }
 
@@ -87,6 +87,104 @@ namespace LuckParser.Models
                 replay.addCircleActor(new CircleActor(true, c.getExpDur() + (int)c.getTime(), 600, new Tuple<int, int>(start, end), "rgba(255, 125, 0, 0.5)"));
                 replay.addCircleActor(new CircleActor(false, 0, 600, new Tuple<int, int>(start, end), "rgba(255, 125, 0, 0.5)"));
             }
+            List<PhaseData> phases = log.getBoss().getPhases(log, true);
+            if (phases.Count > 1)
+            {
+                List<CastLog> rampage = cls.Where(x => x.getID() == 31834).ToList();
+                foreach (CastLog c in rampage)
+                {
+                    int start = (int)c.getTime();
+                    int end = start + c.getActDur();
+                    replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(start, end), "rgba(0, 125, 255, 0.3)"));
+                    // or spawn -> 3 secs -> explosion -> 0.5 secs -> fade -> 0.5  secs-> next
+                    int ticks = (int)Math.Ceiling(c.getActDur() / 4000.0);
+                    int phaseIndex = 1;
+                    for (phaseIndex = 1; phaseIndex < phases.Count; phaseIndex++)
+                    {
+                        if (phases[phaseIndex].inInterval(start))
+                        {
+                            break;
+                        }
+                    }
+                    Point3D pos = log.getBoss().getCombatReplay().getPositions().FirstOrDefault(x => x.time >= start);
+                    if (pos == null)
+                    {
+                        break;
+                    }
+                    List<string> patterns = new List<string>();
+                    switch (phaseIndex)
+                    {
+                        case 1:
+                            patterns = new List<string>
+                            {
+                                "2+3",
+                                "2+3+4",
+                                "1+4",
+                                "1+2",
+                                "1+3",
+                                "Full"
+                            };
+                            break;
+                        case 3:
+                            patterns = new List<string>
+                            {
+                                "2+3+4",
+                                "1+4",
+                                "1+3+4",
+                                "1+2",
+                                "1+2+3",
+                                "Full"
+                            };
+                            break;
+                        case 5:
+                            patterns = new List<string>
+                            {
+                                "1+4",
+                                "1+2",
+                                "2+3",
+                                "3+4",
+                                "3+4",
+                                "Full"
+                            };
+                            break;
+                        default:
+                            throw new Exception("how the fuck");
+                    }
+                    for (int i = 0; i < ticks; i++)
+                    {
+                        int tickStart = start + 4000 * i;
+                        int explosion = tickStart + 3000;
+                        int tickEnd = tickStart + 3500;
+                        string pattern = patterns[i];
+                        if (pattern.Contains("1"))
+                        {
+                            replay.addCircleActor(new CircleActor(true, explosion, 300, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
+                            replay.addCircleActor(new CircleActor(true,0 , 300, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                        }
+                        if (pattern.Contains("2"))
+                        {
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 300, 600, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 300,600, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                        }
+                        if (pattern.Contains("3"))
+                        {
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 600, 900, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 600, 900, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                        }
+                        if (pattern.Contains("4"))
+                        {
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 900, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 900, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                        }
+                        if (pattern.Contains("Full"))
+                        {
+                            replay.addCircleActor(new CircleActor(true, explosion, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", log.getBoss().getCombatReplay().getPositions().First()));
+                            replay.addCircleActor(new CircleActor(true, 0, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", log.getBoss().getCombatReplay().getPositions().First()));
+                        }
+                    }
+                }
+            }
+
             return ids;
         }
 

--- a/LuckParser/Models/BossStrategy/Gorseval.cs
+++ b/LuckParser/Models/BossStrategy/Gorseval.cs
@@ -159,28 +159,28 @@ namespace LuckParser.Models
                         string pattern = patterns[i];
                         if (pattern.Contains("1"))
                         {
-                            replay.addCircleActor(new CircleActor(true, explosion, 400, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
-                            replay.addCircleActor(new CircleActor(true,0 , 400, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
+                            replay.addCircleActor(new CircleActor(true, explosion, 360, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addCircleActor(new CircleActor(true,0 , 360, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("2"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 400, 800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 400, 800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 360, 720, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 360, 720, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("3"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 800, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 800, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 720, 1080, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 720, 1080, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("4"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 1200, 1600, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 1200, 1600, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 1080, 1440, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 1080, 1440, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("5"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 1600, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 1600, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 1440, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 1440, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("Full"))
                         {

--- a/LuckParser/Models/BossStrategy/Gorseval.cs
+++ b/LuckParser/Models/BossStrategy/Gorseval.cs
@@ -28,7 +28,7 @@ namespace LuckParser.Models
         {
             return new CombatReplayMap("https://i.imgur.com/nTueZcX.png",
                             Tuple.Create(1354, 1415),
-                            Tuple.Create(-623, -6754, 3731, -2206),
+                            Tuple.Create(-653, -6754, 3701, -2206),
                             Tuple.Create(-15360, -36864, 15360, 39936),
                             Tuple.Create(3456, 11012, 4736, 14212));
         }
@@ -91,6 +91,7 @@ namespace LuckParser.Models
             if (phases.Count > 1)
             {
                 List<CastLog> rampage = cls.Where(x => x.getID() == 31834).ToList();
+                Point3D pos = log.getBoss().getCombatReplay().getPositions().First();
                 foreach (CastLog c in rampage)
                 {
                     int start = (int)c.getTime();
@@ -106,7 +107,6 @@ namespace LuckParser.Models
                             break;
                         }
                     }
-                    Point3D pos = log.getBoss().getCombatReplay().getPositions().FirstOrDefault(x => x.time >= start);
                     if (pos == null)
                     {
                         break;
@@ -159,36 +159,36 @@ namespace LuckParser.Models
                         string pattern = patterns[i];
                         if (pattern.Contains("1"))
                         {
-                            replay.addCircleActor(new CircleActor(true, explosion, 300, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
-                            replay.addCircleActor(new CircleActor(true,0 , 300, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                            replay.addCircleActor(new CircleActor(true, explosion, 400, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addCircleActor(new CircleActor(true,0 , 400, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("2"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 300, 600, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 300,600, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 400, 800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 400, 800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("3"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 600, 900, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 600, 900, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 800, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 800, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("4"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 900, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 900, 1200, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 1200, 1600, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 1200, 1600, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("5"))
                         {
-                            replay.addDoughnutActor(new DoughnutActor(explosion, 1200, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
-                            replay.addDoughnutActor(new DoughnutActor(0, 1200, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(explosion, 1600, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addDoughnutActor(new DoughnutActor(0, 1600, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                         if (pattern.Contains("Full"))
                         {
                             tickStart -= 1000;
                             explosion -= 1000;
                             tickEnd -= 1000;
-                            replay.addCircleActor(new CircleActor(true, explosion, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.2)", pos));
-                            replay.addCircleActor(new CircleActor(true, 0, 1500, new Tuple<int, int>(tickStart, tickEnd), "rgba(0, 0, 0, 0.4)", pos));
+                            replay.addCircleActor(new CircleActor(true, explosion, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.2)", pos));
+                            replay.addCircleActor(new CircleActor(true, 0, 1800, new Tuple<int, int>(tickStart, tickEnd), "rgba(25,25,112, 0.4)", pos));
                         }
                     }
                 }

--- a/LuckParser/Models/BossStrategy/Gorseval.cs
+++ b/LuckParser/Models/BossStrategy/Gorseval.cs
@@ -84,8 +84,8 @@ namespace LuckParser.Models
             {
                 int start = (int)c.getTime();
                 int end = start + c.getActDur();
-                replay.addCircleActor(new FollowingCircle(true, c.getExpDur() + (int)c.getTime(), 600, new Tuple<int, int>(start, end), "rgba(255, 125, 0, 0.5)"));
-                replay.addCircleActor(new FollowingCircle(false, 0, 600, new Tuple<int, int>(start, end), "rgba(255, 125, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(true, c.getExpDur() + (int)c.getTime(), 600, new Tuple<int, int>(start, end), "rgba(255, 125, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(false, 0, 600, new Tuple<int, int>(start, end), "rgba(255, 125, 0, 0.5)"));
             }
             return ids;
         }

--- a/LuckParser/Models/BossStrategy/KeepConstruct.cs
+++ b/LuckParser/Models/BossStrategy/KeepConstruct.cs
@@ -160,6 +160,28 @@ namespace LuckParser.Models
             return ids;
         }
 
+        public override void getAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
+        {
+            // Bombs
+            List<CombatItem> xeraFury = getFilteredList(log, 34511, p.getInstid());
+            int xeraFuryStart = 0;
+            int xeraFuryEnd = 0;
+            foreach (CombatItem c in xeraFury)
+            {
+                if (c.isBuffremove() == ParseEnum.BuffRemove.None)
+                {
+                    xeraFuryStart = (int)(c.getTime() - log.getBossData().getFirstAware());
+                }
+                else
+                {
+                    xeraFuryEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
+                    replay.addCircleActor(new FollowingCircle(true, 0, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.2)"));
+                    replay.addCircleActor(new FollowingCircle(true, xeraFuryEnd, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.4)"));
+                }
+
+            }
+        }
+
         public override string getReplayIcon()
         {
             return "https://i.imgur.com/Kq0kL07.png";

--- a/LuckParser/Models/BossStrategy/KeepConstruct.cs
+++ b/LuckParser/Models/BossStrategy/KeepConstruct.cs
@@ -22,7 +22,8 @@ namespace LuckParser.Models
             new Mechanic(-1, "Insidious Projection", Mechanic.MechType.Spawn, ParseEnum.BossIDS.KeepConstruct, "symbol:'bowtie',color:'rgb(255,0,0)',", "Merge",0),//Spawn check; How should this be handled? Species ID is 16227 if that helps. Could check combat events with state_change 'spawn' if it is an insidious projection?
             new Mechanic(35137, "Phantasmal Blades", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.KeepConstruct, "symbol:'hexagram-open',color:'rgb(255,0,255)',", "Phantasmal Blades",0),
             new Mechanic(35064, "Phantasmal Blades", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.KeepConstruct, "symbol:'hexagram-open',color:'rgb(255,0,255)',", "Phantasmal Blades",0),
-            new Mechanic(35086, "Tower Drop", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.KeepConstruct, "symbol:'circle',color:'rgb(255,140,0)',", "Tower Drop",0)
+            new Mechanic(35086, "Tower Drop", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.KeepConstruct, "symbol:'circle',color:'rgb(255,140,0)',", "Tower Drop",0),
+            new Mechanic(35103, "Xera's Fury", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.KeepConstruct, "symbol:'circle',color:'rgb(200,140,0)',", "Xera's Fury (Bombs)",0)
             //hit orb: May need different format since the Skill ID is irrelevant but any combat event with dst_agent of the species ID 16261 (Construct Core) should be shown. Tracking either via the different Construct Core adresses or their instance_id? (every phase it's a new one)
             };
         }
@@ -158,7 +159,7 @@ namespace LuckParser.Models
             }
             return ids;
         }
-     
+
         public override string getReplayIcon()
         {
             return "https://i.imgur.com/Kq0kL07.png";

--- a/LuckParser/Models/BossStrategy/KeepConstruct.cs
+++ b/LuckParser/Models/BossStrategy/KeepConstruct.cs
@@ -141,8 +141,8 @@ namespace LuckParser.Models
                     CastLog fire = magicExplose[i];
                     int start = (int)charge.getTime();
                     int end = (int)fire.getTime() + fire.getActDur();
-                    replay.addCircleActor(new FollowingCircle(false, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
-                    replay.addCircleActor(new FollowingCircle(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
                 }
             }
             List<CastLog> towerDrop = cls.Where(x => x.getID() == 35086).ToList();
@@ -153,8 +153,8 @@ namespace LuckParser.Models
                 Point3D pos = replay.getPositions().FirstOrDefault(x => x.time > end);
                 if (pos != null)
                 {
-                    replay.addCircleActor(new ImmobileCircle(false, 0, 400, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
-                    replay.addCircleActor(new ImmobileCircle(true, end, 400, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
+                    replay.addCircleActor(new CircleActor(false, 0, 400, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
+                    replay.addCircleActor(new CircleActor(true, end, 400, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
                 }
             }
             return ids;
@@ -175,8 +175,8 @@ namespace LuckParser.Models
                 else
                 {
                     xeraFuryEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.2)"));
-                    replay.addCircleActor(new FollowingCircle(true, xeraFuryEnd, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.4)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.2)"));
+                    replay.addCircleActor(new CircleActor(true, xeraFuryEnd, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.4)"));
                 }
 
             }

--- a/LuckParser/Models/BossStrategy/Matthias.cs
+++ b/LuckParser/Models/BossStrategy/Matthias.cs
@@ -206,6 +206,24 @@ namespace LuckParser.Models
                     replay.addCircleActor(new FollowingCircle(true, sacrificeMatthiasStart + 10000, 120, new Tuple<int, int>(sacrificeMatthiasStart, sacrificeMatthiasEnd), "rgba(0, 150, 250, 0.35)"));
                 }
             }
+            // Bombs
+            List<CombatItem> zealousBenediction = getFilteredList(log, 34511, p.getInstid());
+            int zealousStart = 0;
+            int zealousEnd = 0;
+            foreach (CombatItem c in zealousBenediction)
+            {
+                if (c.isBuffremove() == ParseEnum.BuffRemove.None)
+                {
+                    zealousStart = (int)(c.getTime() - log.getBossData().getFirstAware());
+                }
+                else
+                {
+                    zealousEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
+                    replay.addCircleActor(new FollowingCircle(true, 0, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.2)"));
+                    replay.addCircleActor(new FollowingCircle(true, zealousEnd, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.4)"));
+                }
+
+            }
         }
 
         public override string getReplayIcon()

--- a/LuckParser/Models/BossStrategy/Matthias.cs
+++ b/LuckParser/Models/BossStrategy/Matthias.cs
@@ -110,10 +110,10 @@ namespace LuckParser.Models
                 if (i < humanShieldRemoval.Count)
                 {
                     int removal = humanShieldRemoval[i];
-                    replay.addCircleActor(new FollowingCircle(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), removal), "rgba(255, 0, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), removal), "rgba(255, 0, 255, 0.5)"));
                 } else
                 {
-                    replay.addCircleActor(new FollowingCircle(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), (int)log.getBossData().getAwareDuration()), "rgba(255, 0, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), (int)log.getBossData().getAwareDuration()), "rgba(255, 0, 255, 0.5)"));
                 }
             }
             List<CastLog> aboShield = cls.Where(x => x.getID() == 34510).ToList();
@@ -124,11 +124,11 @@ namespace LuckParser.Models
                 if (i < aboShieldRemoval.Count)
                 {
                     int removal = aboShieldRemoval[i];
-                    replay.addCircleActor(new FollowingCircle(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), removal), "rgba(255, 0, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), removal), "rgba(255, 0, 255, 0.5)"));
                 }
                 else
                 {
-                    replay.addCircleActor(new FollowingCircle(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), (int)log.getBossData().getAwareDuration()), "rgba(255, 0, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 250, new Tuple<int, int>((int)shield.getTime(), (int)log.getBossData().getAwareDuration()), "rgba(255, 0, 255, 0.5)"));
                 }
             }
             List<CastLog> rageShards = cls.Where(x => x.getID() == 34404 || x.getID() == 34411).ToList();
@@ -136,8 +136,8 @@ namespace LuckParser.Models
             {
                 int start = (int)c.getTime();
                 int end = start + c.getActDur();
-                replay.addCircleActor(new FollowingCircle(false, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
-                replay.addCircleActor(new FollowingCircle(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(false, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
             }
             return ids;
         }
@@ -158,12 +158,12 @@ namespace LuckParser.Models
                 else
                 {
                     corruptedMatthiasEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 180, new Tuple<int, int>(corruptedMatthiasStart, corruptedMatthiasEnd), "rgba(255, 150, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(corruptedMatthiasStart, corruptedMatthiasEnd), "rgba(255, 150, 0, 0.5)"));
                     Point3D wellPosition = replay.getPositions().FirstOrDefault(x => x.time > corruptedMatthiasEnd);
                     if (wellPosition != null)
                     {
-                        replay.addCircleActor(new ImmobileCircle(true, 0, 180, new Tuple<int, int>(corruptedMatthiasEnd, corruptedMatthiasEnd + 100000), "rgba(0, 0, 0, 0.3)", wellPosition));
-                        replay.addCircleActor(new ImmobileCircle(true, corruptedMatthiasEnd + 100000, 180, new Tuple<int, int>(corruptedMatthiasEnd, corruptedMatthiasEnd + 100000), "rgba(0, 0, 0, 0.3)", wellPosition));
+                        replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(corruptedMatthiasEnd, corruptedMatthiasEnd + 100000), "rgba(0, 0, 0, 0.3)", wellPosition));
+                        replay.addCircleActor(new CircleActor(true, corruptedMatthiasEnd + 100000, 180, new Tuple<int, int>(corruptedMatthiasEnd, corruptedMatthiasEnd + 100000), "rgba(0, 0, 0, 0.3)", wellPosition));
                     }
                 }
             }
@@ -180,12 +180,12 @@ namespace LuckParser.Models
                 else
                 {
                     wellMatthiasEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(false, 0, 120, new Tuple<int, int>(wellMatthiasStart, wellMatthiasEnd), "rgba(150, 255, 80, 0.5)"));
-                    replay.addCircleActor(new FollowingCircle(true, wellMatthiasStart + 9000, 120, new Tuple<int, int>(wellMatthiasStart, wellMatthiasEnd), "rgba(150, 255, 80, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 120, new Tuple<int, int>(wellMatthiasStart, wellMatthiasEnd), "rgba(150, 255, 80, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, wellMatthiasStart + 9000, 120, new Tuple<int, int>(wellMatthiasStart, wellMatthiasEnd), "rgba(150, 255, 80, 0.5)"));
                     Point3D wellPosition = replay.getPositions().FirstOrDefault(x => x.time > wellMatthiasEnd);
                     if (wellPosition != null)
                     {
-                        replay.addCircleActor(new ImmobileCircle(true, 0, 300, new Tuple<int, int>(wellMatthiasEnd, wellMatthiasEnd + 90000), "rgba(255, 0, 50, 0.5)", wellPosition));
+                        replay.addCircleActor(new CircleActor(true, 0, 300, new Tuple<int, int>(wellMatthiasEnd, wellMatthiasEnd + 90000), "rgba(255, 0, 50, 0.5)", wellPosition));
                     }
                 }
             }
@@ -202,8 +202,8 @@ namespace LuckParser.Models
                 else
                 {
                     sacrificeMatthiasEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 120, new Tuple<int, int>(sacrificeMatthiasStart, sacrificeMatthiasEnd), "rgba(0, 150, 250, 0.2)"));
-                    replay.addCircleActor(new FollowingCircle(true, sacrificeMatthiasStart + 10000, 120, new Tuple<int, int>(sacrificeMatthiasStart, sacrificeMatthiasEnd), "rgba(0, 150, 250, 0.35)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 120, new Tuple<int, int>(sacrificeMatthiasStart, sacrificeMatthiasEnd), "rgba(0, 150, 250, 0.2)"));
+                    replay.addCircleActor(new CircleActor(true, sacrificeMatthiasStart + 10000, 120, new Tuple<int, int>(sacrificeMatthiasStart, sacrificeMatthiasEnd), "rgba(0, 150, 250, 0.35)"));
                 }
             }
             // Bombs
@@ -219,8 +219,8 @@ namespace LuckParser.Models
                 else
                 {
                     zealousEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.2)"));
-                    replay.addCircleActor(new FollowingCircle(true, zealousEnd, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.4)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.2)"));
+                    replay.addCircleActor(new CircleActor(true, zealousEnd, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.4)"));
                 }
 
             }

--- a/LuckParser/Models/BossStrategy/Sabetha.cs
+++ b/LuckParser/Models/BossStrategy/Sabetha.cs
@@ -95,8 +95,8 @@ namespace LuckParser.Models
             {
                 int start = (int)(c.getTime() - log.getBossData().getFirstAware());
                 int end = start + 3000;
-                replay.addCircleActor(new FollowingCircle(false, 0, 280, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
-                replay.addCircleActor(new FollowingCircle(true, end, 280, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(false, 0, 280, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
+                replay.addCircleActor(new CircleActor(true, end, 280, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
             }
             // Sapper bombs
             List<CombatItem> sapperBombs = getFilteredList(log, 31473, p.getInstid());
@@ -110,8 +110,8 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    sapperEnd = (int)(c.getTime() - log.getBossData().getFirstAware()); replay.addCircleActor(new FollowingCircle(false, 0, 180, new Tuple<int, int>(sapperStart, sapperEnd), "rgba(200, 255, 100, 0.5)"));
-                    replay.addCircleActor(new FollowingCircle(true, sapperStart + 5000, 180, new Tuple<int, int>(sapperStart, sapperEnd), "rgba(200, 255, 100, 0.5)"));
+                    sapperEnd = (int)(c.getTime() - log.getBossData().getFirstAware()); replay.addCircleActor(new CircleActor(false, 0, 180, new Tuple<int, int>(sapperStart, sapperEnd), "rgba(200, 255, 100, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, sapperStart + 5000, 180, new Tuple<int, int>(sapperStart, sapperEnd), "rgba(200, 255, 100, 0.5)"));
                 }
             }
         }

--- a/LuckParser/Models/BossStrategy/Samarog.cs
+++ b/LuckParser/Models/BossStrategy/Samarog.cs
@@ -118,7 +118,7 @@ namespace LuckParser.Models
                 else
                 {
                     brutEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 120, new Tuple<int, int>(brutStart, brutEnd), "rgba(0, 180, 255, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 120, new Tuple<int, int>(brutStart, brutEnd), "rgba(0, 180, 255, 0.3)"));
                 }
             }
             return ids;
@@ -139,8 +139,8 @@ namespace LuckParser.Models
                 else
                 {
                     bigEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 300, new Tuple<int, int>(bigStart, bigEnd), "rgba(150, 80, 0, 0.2)"));
-                    replay.addCircleActor(new FollowingCircle(true, bigEnd, 300, new Tuple<int, int>(bigStart, bigEnd), "rgba(150, 80, 0, 0.2)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 300, new Tuple<int, int>(bigStart, bigEnd), "rgba(150, 80, 0, 0.2)"));
+                    replay.addCircleActor(new CircleActor(true, bigEnd, 300, new Tuple<int, int>(bigStart, bigEnd), "rgba(150, 80, 0, 0.2)"));
                 }
             }
             // small bomb
@@ -156,7 +156,7 @@ namespace LuckParser.Models
                 else
                 {
                     smallEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 80, new Tuple<int, int>(smallStart, smallEnd), "rgba(80, 150, 0, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 80, new Tuple<int, int>(smallStart, smallEnd), "rgba(80, 150, 0, 0.3)"));
                 }
             }
             // fixated
@@ -172,7 +172,7 @@ namespace LuckParser.Models
                 else
                 {
                     fixatedSamEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 80, new Tuple<int, int>(fixatedSamStart, fixatedSamEnd), "rgba(255, 80, 255, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 80, new Tuple<int, int>(fixatedSamStart, fixatedSamEnd), "rgba(255, 80, 255, 0.3)"));
                 }
             }
         }

--- a/LuckParser/Models/BossStrategy/Slothasor.cs
+++ b/LuckParser/Models/BossStrategy/Slothasor.cs
@@ -50,7 +50,7 @@ namespace LuckParser.Models
             List<CastLog> sleepy = cls.Where(x => x.getID() == 34515).ToList();
             foreach (CastLog c in sleepy)
             {
-                replay.addCircleActor(new FollowingCircle(true, 0, 180, new Tuple<int, int>((int)c.getTime(), (int)c.getTime() + c.getActDur()), "rgba(0, 180, 255, 0.3)"));
+                replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>((int)c.getTime(), (int)c.getTime() + c.getActDur()), "rgba(0, 180, 255, 0.3)"));
             }
 
             List<CastLog> tantrum = cls.Where(x => x.getID() == 34547).ToList();
@@ -58,16 +58,16 @@ namespace LuckParser.Models
             {
                 int start = (int)c.getTime();
                 int end = start + c.getActDur();
-                replay.addCircleActor(new FollowingCircle(false, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.4)"));
-                replay.addCircleActor(new FollowingCircle(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.4)"));
+                replay.addCircleActor(new CircleActor(false, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.4)"));
+                replay.addCircleActor(new CircleActor(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.4)"));
             }
             List<CastLog> shakes = cls.Where(x => x.getID() == 34482).ToList();
             foreach (CastLog c in shakes)
             {
                 int start = (int)c.getTime();
                 int end = start + c.getActDur();
-                replay.addCircleActor(new FollowingCircle(false, 0, 700, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.4)"));
-                replay.addCircleActor(new FollowingCircle(true, end, 700, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.4)"));
+                replay.addCircleActor(new CircleActor(false, 0, 700, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.4)"));
+                replay.addCircleActor(new CircleActor(true, end, 700, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.4)"));
             }
             return ids;
         }
@@ -86,12 +86,12 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    toDropEnd = (int)(c.getTime() - log.getBossData().getFirstAware()); replay.addCircleActor(new FollowingCircle(false, 0, 180, new Tuple<int, int>(toDropStart, toDropEnd), "rgba(255, 255, 100, 0.5)"));
-                    replay.addCircleActor(new FollowingCircle(true, toDropStart + 8000, 180, new Tuple<int, int>(toDropStart, toDropEnd), "rgba(255, 255, 100, 0.5)"));
+                    toDropEnd = (int)(c.getTime() - log.getBossData().getFirstAware()); replay.addCircleActor(new CircleActor(false, 0, 180, new Tuple<int, int>(toDropStart, toDropEnd), "rgba(255, 255, 100, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, toDropStart + 8000, 180, new Tuple<int, int>(toDropStart, toDropEnd), "rgba(255, 255, 100, 0.5)"));
                     Point3D poisonPos = replay.getPositions().FirstOrDefault(x => x.time > toDropEnd);
                     if (poisonPos != null)
                     {
-                        replay.addCircleActor(new ImmobileCircle(true, toDropStart + 90000, 900, new Tuple<int, int>(toDropEnd, toDropEnd + 90000), "rgba(255, 0, 0, 0.3)", poisonPos));
+                        replay.addCircleActor(new CircleActor(true, toDropStart + 90000, 900, new Tuple<int, int>(toDropEnd, toDropEnd + 90000), "rgba(255, 0, 0, 0.3)", poisonPos));
                     }
                 }
             }
@@ -108,7 +108,7 @@ namespace LuckParser.Models
                 else
                 {
                     transfoEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 160, new Tuple<int, int>(transfoStart, transfoEnd), "rgba(0, 80, 255, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 160, new Tuple<int, int>(transfoStart, transfoEnd), "rgba(0, 80, 255, 0.3)"));
                 }
             }
             // fixated
@@ -124,7 +124,7 @@ namespace LuckParser.Models
                 else
                 {
                     fixatedSlothEnd = (int)(c.getTime() - log.getBossData().getFirstAware());
-                    replay.addCircleActor(new FollowingCircle(true, 0, 120, new Tuple<int, int>(fixatedSlothStart, fixatedSlothEnd), "rgba(255, 80, 255, 0.3)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 120, new Tuple<int, int>(fixatedSlothStart, fixatedSlothEnd), "rgba(255, 80, 255, 0.3)"));
                 }
             }
         }

--- a/LuckParser/Models/BossStrategy/SoullessHorror.cs
+++ b/LuckParser/Models/BossStrategy/SoullessHorror.cs
@@ -70,6 +70,7 @@ namespace LuckParser.Models
                 {
                     replay.addCircleActor(new CircleActor(false, 0, 380, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
                     replay.addCircleActor(new CircleActor(true, end, 380, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
+                    replay.addDoughnutActor(new DoughnutActor(0, 380,760, new Tuple<int, int>(end, end+1000), "rgba(255, 150, 0, 0.5)", pos));
                 }
             }
             return ids;

--- a/LuckParser/Models/BossStrategy/SoullessHorror.cs
+++ b/LuckParser/Models/BossStrategy/SoullessHorror.cs
@@ -57,8 +57,8 @@ namespace LuckParser.Models
             {
                 int start = (int)c.getTime();
                 int end = start + c.getActDur();
-                replay.addCircleActor(new FollowingCircle(true, (int)c.getTime() + c.getExpDur(), 180, new Tuple<int, int>(start, end), "rgba(0, 180, 255, 0.3)"));
-                replay.addCircleActor(new FollowingCircle(true, 0, 180, new Tuple<int, int>(start, end), "rgba(0, 180, 255, 0.3)"));
+                replay.addCircleActor(new CircleActor(true, (int)c.getTime() + c.getExpDur(), 180, new Tuple<int, int>(start, end), "rgba(0, 180, 255, 0.3)"));
+                replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(start, end), "rgba(0, 180, 255, 0.3)"));
             }
             List<CastLog> vortex = cls.Where(x => x.getID() == 47327).ToList();
             foreach (CastLog c in vortex)
@@ -68,8 +68,8 @@ namespace LuckParser.Models
                 Point3D pos = replay.getPositions().FirstOrDefault(x => x.time > start);
                 if (pos != null)
                 {
-                    replay.addCircleActor(new ImmobileCircle(false, 0, 380, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
-                    replay.addCircleActor(new ImmobileCircle(true, end, 380, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
+                    replay.addCircleActor(new CircleActor(false, 0, 380, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
+                    replay.addCircleActor(new CircleActor(true, end, 380, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)", pos));
                 }
             }
             return ids;

--- a/LuckParser/Models/BossStrategy/ValeGuardian.cs
+++ b/LuckParser/Models/BossStrategy/ValeGuardian.cs
@@ -93,7 +93,7 @@ namespace LuckParser.Models
             List<CastLog> magicStorms = cls.Where(x => x.getID() == 31419).ToList();
             foreach (CastLog c in magicStorms)
             {
-                replay.addCircleActor(new FollowingCircle(true, 0, 100, new Tuple<int, int>((int)c.getTime(), (int)c.getTime() + c.getActDur()), "rgba(0, 180, 255, 0.3)"));
+                replay.addCircleActor(new CircleActor(true, 0, 100, new Tuple<int, int>((int)c.getTime(), (int)c.getTime() + c.getActDur()), "rgba(0, 180, 255, 0.3)"));
             }
             return ids;
         }

--- a/LuckParser/Models/BossStrategy/Xera.cs
+++ b/LuckParser/Models/BossStrategy/Xera.cs
@@ -77,7 +77,7 @@ namespace LuckParser.Models
             List<CastLog> summon = cls.Where(x => x.getID() == 34887).ToList();
             foreach (CastLog c in summon)
             {
-                replay.addCircleActor(new FollowingCircle(true, 0, 180, new Tuple<int, int>((int)c.getTime(), (int)c.getTime() + c.getActDur()), "rgba(0, 180, 255, 0.3)"));
+                replay.addCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>((int)c.getTime(), (int)c.getTime() + c.getActDur()), "rgba(0, 180, 255, 0.3)"));
             }
             return ids;
         }

--- a/LuckParser/Models/DataModels/Statistics.cs
+++ b/LuckParser/Models/DataModels/Statistics.cs
@@ -22,7 +22,10 @@ namespace LuckParser.Models.DataModels
             groupBoons = new Dictionary<Player, Dictionary<long, FinalBoonUptime>[]>();
             offGroupBoons = new Dictionary<Player, Dictionary<long, FinalBoonUptime>[]>();
             squadBoons = new Dictionary<Player, Dictionary<long, FinalBoonUptime>[]>();
+            phases = new List<PhaseData>();
         }
+
+        public List<PhaseData> phases;
 
         public class FinalDPS
         {

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/Actor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/Actor.cs
@@ -12,12 +12,14 @@ namespace LuckParser.Models.ParseModels
         private Tuple<int, int> lifespan;
         private string color;
         private int growing;
+        private Mobility mobility;
 
-        public Actor(bool fill, int growing, Tuple<int, int> lifespan, string color)
+        public Actor(bool fill, int growing, Tuple<int, int> lifespan, string color, Mobility mobility)
         {
             this.lifespan = lifespan;
             this.color = color;
             this.fill = fill;
+            this.mobility = mobility;
             this.growing = growing;
         }
 
@@ -29,6 +31,11 @@ namespace LuckParser.Models.ParseModels
         public bool isFilled()
         {
             return fill;
+        }
+
+        public string getPosition(string id, CombatReplayMap map)
+        {
+            return mobility.getPosition(id, map);
         }
 
         public Tuple<int, int> getLifespan()

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/Actor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/Actor.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LuckParser.Models.ParseModels
+{
+    public abstract class Actor
+    {
+        private bool fill;
+        private Tuple<int, int> lifespan;
+        private string color;
+        private int growing;
+
+        public Actor(bool fill, int growing, Tuple<int, int> lifespan, string color)
+        {
+            this.lifespan = lifespan;
+            this.color = color;
+            this.fill = fill;
+            this.growing = growing;
+        }
+
+        public int getGrowing()
+        {
+            return growing;
+        }
+
+        public bool isFilled()
+        {
+            return fill;
+        }
+
+        public Tuple<int, int> getLifespan()
+        {
+            return lifespan;
+        }
+
+        public string getColor()
+        {
+            return "'" + color + "'";
+        }
+    }
+}

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/CircleActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/CircleActor.cs
@@ -10,7 +10,7 @@ namespace LuckParser.Models.ParseModels
     {
         private int radius;
 
-        public CircleActor(bool fill, int growing, int radius, Tuple<int,int> lifespan, string color) : base(fill, growing,lifespan, color, new MobileActor())
+        public CircleActor(bool fill, int growing, int radius, Tuple<int, int> lifespan, string color) : base(fill, growing, lifespan, color, new MobileActor())
         {
             this.radius = radius;
         }

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/CircleActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/CircleActor.cs
@@ -6,11 +6,16 @@ using System.Threading.Tasks;
 
 namespace LuckParser.Models.ParseModels
 {
-    public abstract class CircleActor : Actor
+    public class CircleActor : Actor
     {
         private int radius;
 
-        public CircleActor(bool fill, int growing, int radius, Tuple<int,int> lifespan, string color) : base(fill, growing,lifespan, color)
+        public CircleActor(bool fill, int growing, int radius, Tuple<int,int> lifespan, string color) : base(fill, growing,lifespan, color, new MobileActor())
+        {
+            this.radius = radius;
+        }
+
+        public CircleActor(bool fill, int growing, int radius, Tuple<int, int> lifespan, string color, Point3D position) : base(fill, growing, lifespan, color, new ImmobileActor(position))
         {
             this.radius = radius;
         }
@@ -19,8 +24,6 @@ namespace LuckParser.Models.ParseModels
         {
             return radius;
         }
-
-        public abstract string getPosition(string id, CombatReplayMap map);
 
     }
 }

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/CircleActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/CircleActor.cs
@@ -6,46 +6,18 @@ using System.Threading.Tasks;
 
 namespace LuckParser.Models.ParseModels
 {
-    public abstract class CircleActor
+    public abstract class CircleActor : Actor
     {
-        private bool fill;
-        private int growing;
         private int radius;
-        private Tuple<int, int> lifespan;
-        private string color;
 
-        public CircleActor(bool fill, int growing, int radius, Tuple<int,int> lifespan, string color)
+        public CircleActor(bool fill, int growing, int radius, Tuple<int,int> lifespan, string color) : base(fill, growing,lifespan, color)
         {
-            this.fill = fill;
-            this.growing = growing;
             this.radius = radius;
-            this.lifespan = lifespan;
-            this.color = color;
-        }
-
-        public int getGrowing()
-        {
-            return growing;
-        }
-
-        public bool isFilled()
-        {
-            return fill;
         }
 
         public int getRadius()
         {
             return radius;
-        }
-
-        public Tuple<int,int> getLifespan()
-        {
-            return lifespan;
-        }
-
-        public string getColor()
-        {
-            return "'" + color + "'";
         }
 
         public abstract string getPosition(string id, CombatReplayMap map);

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/DoughnutActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/DoughnutActor.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LuckParser.Models.ParseModels
+{
+    public class DoughnutActor : Actor
+    {
+        private int outerRadius;
+        private int innerRadius;
+
+        public DoughnutActor(int growing, int innerRadius, int outerRadius, Tuple<int, int> lifespan, string color) : base(true, growing, lifespan, color, new MobileActor())
+        {
+            this.innerRadius = innerRadius;
+            this.outerRadius = outerRadius;
+        }
+
+        public DoughnutActor(int growing, int innerRadius, int outerRadius, Tuple<int, int> lifespan, string color, Point3D position) : base(true, growing, lifespan, color, new ImmobileActor(position))
+        {
+            this.innerRadius = innerRadius;
+            this.outerRadius = outerRadius;
+        }
+
+        public int getInnerRadius()
+        {
+            return innerRadius;
+        }
+
+        public int getOuterRadius()
+        {
+            return outerRadius;
+        }
+
+    }
+}

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/ImmobileActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/ImmobileActor.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace LuckParser.Models.ParseModels
 {
-    public class ImmobileCircle : CircleActor
+    public class ImmobileActor : Mobility
     {
         private Point3D position;
 
-        public ImmobileCircle(bool fill, int growing, int radius, Tuple<int, int> lifespan, string color, Point3D position) : base(fill, growing, radius,lifespan,color)
+        public ImmobileActor(Point3D position) : base()
         {
             this.position = position;
         }
@@ -18,7 +18,7 @@ namespace LuckParser.Models.ParseModels
         public override string getPosition(string id, CombatReplayMap map)
         {
             Tuple<int, int> coord = map.getMapCoord(position.X, position.Y);
-            return "["+coord.Item1+","+coord.Item2+"]";
+            return "[" + coord.Item1 + "," + coord.Item2 + "]";
         }
     }
 }

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/MobileActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/MobileActor.cs
@@ -6,12 +6,11 @@ using System.Threading.Tasks;
 
 namespace LuckParser.Models.ParseModels
 {
-    public class FollowingCircle : CircleActor
+    public class MobileActor : Mobility
     {
 
-        public FollowingCircle(bool fill, int growing, int radius, Tuple<int, int> lifespan, string color) : base(fill, growing, radius, lifespan, color)
+        public MobileActor() : base()
         {
-
         }
 
         public override string getPosition(string id, CombatReplayMap map)

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/Mobility.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/Mobility.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LuckParser.Models.ParseModels
+{
+    public abstract class Mobility
+    {
+
+        public Mobility()
+        {
+
+        }
+
+        public abstract string getPosition(string id, CombatReplayMap map);
+    }
+}

--- a/LuckParser/Models/ParseModels/CombatReplay/CombatReplay.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/CombatReplay.cs
@@ -45,8 +45,8 @@ namespace LuckParser.Models.ParseModels
         {
             velocities.Add(vel);
         }
-        
-        public Tuple<long,long> getTimeOffsets()
+
+        public Tuple<long, long> getTimeOffsets()
         {
             return new Tuple<long, long>(start, end);
         }
@@ -91,7 +91,7 @@ namespace LuckParser.Models.ParseModels
             return circleActors;
         }
 
-        public List<Tuple<long,long>> getDead()
+        public List<Tuple<long, long>> getDead()
         {
             return dead;
         }
@@ -104,7 +104,7 @@ namespace LuckParser.Models.ParseModels
         public void addBoon(long id, int value)
         {
             List<int> ll;
-            if (!boons.TryGetValue(id,out ll))
+            if (!boons.TryGetValue(id, out ll))
             {
                 ll = new List<int>();
                 boons.Add(id, ll);
@@ -129,7 +129,8 @@ namespace LuckParser.Models.ParseModels
                 start = -1;
                 end = -1;
                 return;
-            } else if (positions.Count == 1)
+            }
+            else if (positions.Count == 1)
             {
                 velocities = null;
                 return;

--- a/LuckParser/Models/ParseModels/CombatReplay/CombatReplay.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/CombatReplay.cs
@@ -26,6 +26,7 @@ namespace LuckParser.Models.ParseModels
         private Dictionary<long, List<int>> boons = new Dictionary<long, List<int>>();
         // actors
         private List<CircleActor> circleActors = new List<CircleActor>();
+        private List<DoughnutActor> doughnutActors = new List<DoughnutActor>();
 
         public CombatReplay()
         {
@@ -68,6 +69,10 @@ namespace LuckParser.Models.ParseModels
         {
             circleActors.Add(circleActor);
         }
+        public void addDoughnutActor(DoughnutActor doughnutActor)
+        {
+            doughnutActors.Add(doughnutActor);
+        }
 
         public void setStatus(List<Tuple<long, long>> down, List<Tuple<long, long>> dead, List<Tuple<long, long>> dc)
         {
@@ -91,6 +96,11 @@ namespace LuckParser.Models.ParseModels
         public List<CircleActor> getCircleActors()
         {
             return circleActors;
+        }
+
+        public List<DoughnutActor> getDoughnutActors()
+        {
+            return doughnutActors;
         }
 
         public List<Tuple<long, long>> getDead()

--- a/LuckParser/Models/ParseModels/CombatReplay/CombatReplay.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/CombatReplay.cs
@@ -17,6 +17,7 @@ namespace LuckParser.Models.ParseModels
         //status
         private List<Tuple<long, long>> dead = new List<Tuple<long, long>>();
         private List<Tuple<long, long>> down = new List<Tuple<long, long>>();
+        private List<Tuple<long, long>> dc = new List<Tuple<long, long>>();
         // dps
         private List<int> dps = new List<int>();
         private List<int> dps10s = new List<int>();
@@ -68,10 +69,11 @@ namespace LuckParser.Models.ParseModels
             circleActors.Add(circleActor);
         }
 
-        public void setStatus(List<Tuple<long, long>> down, List<Tuple<long, long>> dead)
+        public void setStatus(List<Tuple<long, long>> down, List<Tuple<long, long>> dead, List<Tuple<long, long>> dc)
         {
             this.down = down;
             this.dead = dead;
+            this.dc = dc;
         }
 
         public void trim(long start, long end)
@@ -101,6 +103,11 @@ namespace LuckParser.Models.ParseModels
             return down;
         }
 
+        public List<Tuple<long, long>> getDC()
+        {
+            return dc;
+        }
+
         public void addBoon(long id, int value)
         {
             List<int> ll;
@@ -122,7 +129,7 @@ namespace LuckParser.Models.ParseModels
             return icon;
         }
 
-        public void pollingRate(int rate, long fightDuration)
+        public void pollingRate(int rate, long fightDuration, bool forceInterpolate)
         {
             if (positions.Count == 0)
             {
@@ -130,7 +137,7 @@ namespace LuckParser.Models.ParseModels
                 end = -1;
                 return;
             }
-            else if (positions.Count == 1)
+            else if (positions.Count == 1 && !forceInterpolate)
             {
                 velocities = null;
                 return;
@@ -195,6 +202,30 @@ namespace LuckParser.Models.ParseModels
         public List<Point3D> getPositions()
         {
             return positions;
+        }
+
+        public List<Point3D> getActivePositions()
+        {
+            List<Point3D> activePositions = new List<Point3D>(positions);
+            for (var i = 0; i < activePositions.Count; i++)
+            {
+                Point3D cur = activePositions[i];
+                foreach (Tuple<long, long> status in dead)
+                {
+                    if (cur.time >= status.Item1 && cur.time <= status.Item2)
+                    {
+                        activePositions[i] = null;
+                    }
+                }
+                foreach (Tuple<long, long> status in dc)
+                {
+                    if (cur.time >= status.Item1 && cur.time <= status.Item2)
+                    {
+                        activePositions[i] = null;
+                    }
+                }
+            }        
+            return activePositions;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/PhaseData.cs
+++ b/LuckParser/Models/ParseModels/PhaseData.cs
@@ -1,10 +1,13 @@
-﻿namespace LuckParser.Models.ParseModels
+﻿using System.Collections.Generic;
+
+namespace LuckParser.Models.ParseModels
 {
     public class PhaseData
     {
         private long start;
         private long end;
         private string name;
+        private List<long> redirection = new List<long>();
 
         public PhaseData(long start, long end)
         {
@@ -20,6 +23,16 @@
         public string getName()
         {
             return name;
+        }
+
+        public void addRedirection(long agent)
+        {
+            redirection.Add(agent);
+        }
+
+        public List<long> getRedirection()
+        {
+            return redirection;
         }
 
         public long getDuration(string format = "ms")

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -90,7 +90,7 @@ namespace LuckParser.Models.ParseModels
             }
             return condi_presence[phase_index];
         }
-        public void initCombatReplay(ParsedLog log, int pollingRate, bool trim = false)
+        public void initCombatReplay(ParsedLog log, int pollingRate, bool trim, bool forceInterpolate)
         {
             if (log.getMovementData().Count == 0)
             {
@@ -101,7 +101,7 @@ namespace LuckParser.Models.ParseModels
             {
                 replay = new CombatReplay();
                 setMovements(log);
-                replay.pollingRate(pollingRate, log.getBossData().getAwareDuration());
+                replay.pollingRate(pollingRate, log.getBossData().getAwareDuration(), forceInterpolate);
                 setCombatReplayIcon(log);
                 if (trim)
                 {

--- a/LuckParser/Models/ParseModels/Players/Boss.cs
+++ b/LuckParser/Models/ParseModels/Players/Boss.cs
@@ -86,7 +86,7 @@ namespace LuckParser.Models.ParseModels
             foreach (AgentItem a in aList)
             {
                 Mob mob = new Mob(a);
-                mob.initCombatReplay(log, pollingRate, true);
+                mob.initCombatReplay(log, pollingRate, true, false);
                 thrashMobs.Add(mob);
             }
         }

--- a/LuckParser/Models/ParseModels/Players/Mob.cs
+++ b/LuckParser/Models/ParseModels/Players/Mob.cs
@@ -38,23 +38,23 @@ namespace LuckParser.Models.ParseModels
             switch (ParseEnum.getThrashIDS(agent.getID()))
             {
                 case ParseEnum.ThrashIDS.BlueGuardian:
-                    replay.addCircleActor(new FollowingCircle(false, 0, 1500, lifespan, "rgba(0, 0, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 1500, lifespan, "rgba(0, 0, 255, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.GreenGuardian:
-                    replay.addCircleActor(new FollowingCircle(false, 0, 1500, lifespan, "rgba(0, 255, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 1500, lifespan, "rgba(0, 255, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.RedGuardian:
-                    replay.addCircleActor(new FollowingCircle(false, 0, 1500, lifespan, "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 1500, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Seekers:
-                    replay.addCircleActor(new FollowingCircle(false, 0, 180, lifespan, "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 180, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.ChargedSoul:
-                    replay.addCircleActor(new FollowingCircle(false, 0, 220, lifespan, "rgba(255, 150, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 220, lifespan, "rgba(255, 150, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Spirit:
                 case ParseEnum.ThrashIDS.Spirit2:
-                    replay.addCircleActor(new FollowingCircle(true, 0, 180, lifespan, "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 180, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Olson:
                 case ParseEnum.ThrashIDS.Engul:
@@ -64,32 +64,32 @@ namespace LuckParser.Models.ParseModels
                 case ParseEnum.ThrashIDS.Jessica:
                 case ParseEnum.ThrashIDS.Galletta:
                 case ParseEnum.ThrashIDS.Ianim:
-                    replay.addCircleActor(new FollowingCircle(false, 0, 600, lifespan, "rgba(255, 0, 0, 0.5)"));
-                    replay.addCircleActor(new FollowingCircle(true, 0, 400, lifespan, "rgba(0, 125, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 600, lifespan, "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 400, lifespan, "rgba(0, 125, 255, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Messenger:
-                    replay.addCircleActor(new FollowingCircle(true, 0, 180, lifespan, "rgba(255, 125, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 180, lifespan, "rgba(255, 125, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Scythe:
-                    replay.addCircleActor(new FollowingCircle(true, 0, 80, lifespan, "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 80, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Tornado:
-                    replay.addCircleActor(new FollowingCircle(true, 0, 90, lifespan, "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 90, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.IcePatch:
-                    replay.addCircleActor(new FollowingCircle(true, 0, 200, lifespan, "rgba(0, 0, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 200, lifespan, "rgba(0, 0, 255, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Storm:
-                    replay.addCircleActor(new FollowingCircle(false, 0, 260, lifespan, "rgba(0, 80, 255, 0.5)"));
+                    replay.addCircleActor(new CircleActor(false, 0, 260, lifespan, "rgba(0, 80, 255, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Oil:
-                    replay.addCircleActor(new FollowingCircle(true, 0, 240, lifespan, "rgba(0, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 240, lifespan, "rgba(0, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.Echo:
-                    replay.addCircleActor(new FollowingCircle(true, 0, 120, lifespan, "rgba(255, 0, 0, 0.5)"));
+                    replay.addCircleActor(new CircleActor(true, 0, 120, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.TormentedDead:
-                    replay.addCircleActor(new ImmobileCircle(true,0,400,new Tuple<int, int>(end,end+60000), "rgba(255, 0, 0, 0.5)",replay.getPositions().Last()));
+                    replay.addCircleActor(new CircleActor(true,0,400,new Tuple<int, int>(end,end+60000), "rgba(255, 0, 0, 0.5)",replay.getPositions().Last()));
                     break;
             }
         }

--- a/LuckParser/Models/ParseModels/Players/Mob.cs
+++ b/LuckParser/Models/ParseModels/Players/Mob.cs
@@ -89,6 +89,10 @@ namespace LuckParser.Models.ParseModels
                     replay.addCircleActor(new CircleActor(true, 0, 120, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
                 case ParseEnum.ThrashIDS.TormentedDead:
+                    if (replay.getPositions().Count == 0)
+                    {
+                        break;
+                    }
                     replay.addCircleActor(new CircleActor(true,0,400,new Tuple<int, int>(end,end+60000), "rgba(255, 0, 0, 0.5)",replay.getPositions().Last()));
                     break;
             }

--- a/LuckParser/Models/ParseModels/Players/Player.cs
+++ b/LuckParser/Models/ParseModels/Players/Player.cs
@@ -274,9 +274,12 @@ namespace LuckParser.Models.ParseModels
             List<CombatItem> status = log.getCombatData().getStates(getInstid(), ParseEnum.StateChange.ChangeDown, log.getBossData().getFirstAware(), log.getBossData().getLastAware());
             status.AddRange(log.getCombatData().getStates(getInstid(), ParseEnum.StateChange.ChangeUp, log.getBossData().getFirstAware(), log.getBossData().getLastAware()));
             status.AddRange(log.getCombatData().getStates(getInstid(), ParseEnum.StateChange.ChangeDead, log.getBossData().getFirstAware(), log.getBossData().getLastAware()));
+            status.AddRange(log.getCombatData().getStates(getInstid(), ParseEnum.StateChange.Spawn, log.getBossData().getFirstAware(), log.getBossData().getLastAware()));
+            status.AddRange(log.getCombatData().getStates(getInstid(), ParseEnum.StateChange.Despawn, log.getBossData().getFirstAware(), log.getBossData().getLastAware()));
             status = status.OrderBy(x => x.getTime()).ToList();
             List<Tuple<long, long>> dead = new List<Tuple<long, long>>();
             List<Tuple<long, long>> down = new List<Tuple<long, long>>();
+            List<Tuple<long, long>> dc = new List<Tuple<long, long>>();
             for (var i = 0; i < status.Count -1;i++)
             {
                 CombatItem cur = status[i];
@@ -287,6 +290,9 @@ namespace LuckParser.Models.ParseModels
                 } else if (cur.isStateChange() == ParseEnum.StateChange.ChangeDead)
                 {
                     dead.Add(new Tuple<long, long>(cur.getTime() - log.getBossData().getFirstAware(), next.getTime() - log.getBossData().getFirstAware()));
+                } else if (cur.isStateChange() == ParseEnum.StateChange.Despawn)
+                {
+                    dc.Add(new Tuple<long, long>(cur.getTime() - log.getBossData().getFirstAware(), next.getTime() - log.getBossData().getFirstAware()));
                 }
             }
             // check last value
@@ -301,8 +307,12 @@ namespace LuckParser.Models.ParseModels
                 {
                     dead.Add(new Tuple<long, long>(cur.getTime() - log.getBossData().getFirstAware(), log.getBossData().getAwareDuration()));
                 }
+                else if (cur.isStateChange() == ParseEnum.StateChange.Despawn)
+                {
+                    dc.Add(new Tuple<long, long>(cur.getTime() - log.getBossData().getFirstAware(), log.getBossData().getAwareDuration()));
+                }
             }
-            replay.setStatus(down, dead);
+            replay.setStatus(down, dead, dc);
             // Boss related stuff
             log.getBossData().getBossBehavior().getAdditionalPlayerData(replay, this, log);
         }


### PR DESCRIPTION
Improvements:
- added phases to statistics
- improved some mechanics sizes on combat replay
- combat replay supports doughnut type actors now, still missing link type
- added Xera's Fury, Zealous Benediction, Outer Vortex Slash, Gorseval's Rampage (the size of that can be wrong, still looking into it) to combat replay. 

@baaron4 regarding you stacking distance dev, I've made some changes to combat replay to better accomodate your intentions and reduce the number of tests you have to do:
- Players and bosses will always have the same quantity of positions by forcing the interpolation (adds and other stuff can still have only one position when tracked)
- Combat replay was already tracking downs and deads (in setAdditionalData in Player.cs), added dc to that list
- Implemented a getActivePositions() to Combat replay that return the list of positions with nulls when the player was dead or dc

Is that okay with you?