### PR TITLE
Improve performance

### DIFF
--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Models\ParseModels\GW2API\GW2APISkill.cs" />
     <Compile Include="Models\ParseModels\Simulator\BoonSimulationItemDuration.cs" />
     <Compile Include="Models\ParseModels\Simulator\BoonSimulationItemIntensity.cs" />
+    <Compile Include="Models\ParseModels\Simulator\BoonSimulationResult.cs" />
     <Compile Include="Models\ParseModels\Simulator\BoonSimulator.cs" />
     <Compile Include="Models\ParseModels\Agents\Agent.cs" />
     <Compile Include="Models\ParseModels\Agents\AgentData.cs" />

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationResult.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationResult.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LuckParser.Models.ParseModels
+{
+	public class BoonSimulationResult
+	{
+		private readonly BoonSimulationItem[] boonSimulationItems;
+
+		public IEnumerable<BoonSimulationItem> Items => boonSimulationItems;
+
+		public BoonSimulationResult(IEnumerable<BoonSimulationItem> boonSimulationItems)
+		{
+			this.boonSimulationItems = boonSimulationItems.ToArray();
+		}
+
+		public int GetBoonStackCount(int time)
+		{
+			foreach (var item in boonSimulationItems)
+			{
+				int start = (int) item.getStart();
+				int end = (int) item.getEnd();
+				if (time >= start && time < end)
+				{
+					return item.getStack(time);
+				}
+			}
+
+			return 0;
+		}
+
+		public bool GetEffectPresence(int time)
+		{
+			foreach (var item in boonSimulationItems)
+			{
+				int start = (int) item.getStart();
+				int end = (int) item.getEnd();
+				if (time >= start && time < end)
+				{
+					bool present = item.getItemDuration() > 0;
+					return present;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
@@ -49,9 +49,9 @@ namespace LuckParser.Models.ParseModels
             this.logic = logic;
         }  
 
-        public List<BoonSimulationItem> getSimulationResult()
+        public BoonSimulationResult getSimulationResult()
         {
-            return new List<BoonSimulationItem>(simulation);
+            return new BoonSimulationResult(simulation);
         }
 
         // Abstract Methods


### PR DESCRIPTION
Eliminates creation of many arrays containing data that is never used.
Reduces statistic generation time to ~40% of original, total log generation time is ~53% of original.
(measured on 40 different logs)

I will be waiting with next optimizations until #113 is merged.


Log | ms before | ms after
--- | --- | ---
cairn_20180809-052839	| 3125.7273	| 1209.671
cairn_20180814-040825	| 2989.3941	| 1189.8978
cairn_20180820-201521	| 2599.735	| 903.5929
deimos_20180814-051155	| 7866.6597	| 4847.8236
deimos_20180821-000855	| 8015.6279	| 4957.434
deimos_20180821-214256	| 7427.2353	| 4376.4297
dhuum_20180813-190655	| 7871.3287	| 4116.098
dhuum_20180821-024226	| 8329.4506	| 4641.2335
dhuumcm_20180813-045358	| 6767.771	| 3905.3054
gorseval_20180807-010122	| 5311.1416	| 3256.3671
gorseval_20180813-105556	| 5002.0525	| 3042.1249
gorseval_20180821-203347	| 5620.581	| 3525.8785
kc_20180807-050104	| 6630.1533	| 3656.7936
kc_20180814-033936	| 7865.285	| 4286.3062
kc_20180821-003658	| 7866.6991	| 4706.9761
matt_20180817-054149	| 7604.3816	| 4633.7782
matt_20180821-015030	| 8946.1698	| 5698.6036
matt_20180822-215817	| 11162.7234	| 6650.9134
mo_20180816-203538	| 2469.0889	| 985.4041
mo_20180819-174250	| 2555.6119	| 1038.138
mo_20180820-202322	| 2789.9857	| 1062.2911
sabetha_20180813-112032	| 8019.0085	| 5169.5554
sabetha_20180817-044932	| 8141.6417	| 5172.8875
sabetha_20180821-210426	| 8894.0096	| 5790.8249
samarog_20180814-042916	| 8020.7934	| 4580.1914
samarog_20180816-205700	| 9907.2215	| 6033.1327
samarog_20180820-233933	| 5913.6195	| 3392.5864
sh_20180806-095250	| 5919.9989	| 2464.1291
sh_20180807-212636	| 4404.5792	| 1957.1908
sh_20180814-054151	| 6140.3638	| 2801.3265
sloth_20180817-050944	| 3487.8917	| 1319.1546
sloth_20180821-012528	| 2743.9742	| 1019.0517
sloth_20180822-211108	| 3292.0538	| 1299.7684
vg_20180807-004529	| 4965.2626	| 2862.9547
vg_20180813-103904	| 4954.7067	| 2837.6016
vg_20180820-213803	| 5637.4227	| 3224.5114
xera_20180807-051530	| 4545.9925	| 2481.9023
xera_20180814-040024	| 6532.6101	| 3507.478
xera_20180821-011535	| 4440.4214	| 2253.6172
Average	| 6019.9583	| 3355.3571
