### PR TITLE
Further optimizations

### DIFF
--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -2024,8 +2024,8 @@ namespace LuckParser.Controllers
             List<DamageLog> damageToKill = new List<DamageLog>();
             if (down.Count > 0)
             {//went to down state before death
-                damageToDown = damageLogs.Where(x => x.GetTime() < down.Last().GetTime() - start && x.GetDamage() > 0).ToList();
-                damageToKill = damageLogs.Where(x => x.GetTime() > down.Last().GetTime() - start && x.GetTime() < dead.Last().GetTime() - start && x.GetDamage() > 0).ToList();
+                damageToDown = damageLogs.Where(x => x.GetTime() < down.Last().Time - start && x.GetDamage() > 0).ToList();
+                damageToKill = damageLogs.Where(x => x.GetTime() > down.Last().Time - start && x.GetTime() < dead.Last().Time - start && x.GetDamage() > 0).ToList();
                 //Filter last 30k dmg taken
                 int totaldmg = 0;
                 for (int i = damageToDown.Count - 1; i > 0; i--)
@@ -2060,7 +2060,7 @@ namespace LuckParser.Controllers
             }
             else
             {
-                damageToKill = damageLogs.Where(x => x.GetTime() < dead.Last().GetTime() && x.GetDamage() > 0).ToList();
+                damageToKill = damageLogs.Where(x => x.GetTime() < dead.Last().Time && x.GetDamage() > 0).ToList();
                 //Filter last 30k dmg taken
                 int totaldmg = 0;
                 for (int i = damageToKill.Count - 1; i > 0; i--)
@@ -2760,16 +2760,16 @@ namespace LuckParser.Controllers
             {
                 foreach (CombatItem c in _log.GetCombatData())
                 {
-                    if (c.IsStateChange() != ParseEnum.StateChange.Normal)
+                    if (c.IsStateChange != ParseEnum.StateChange.Normal)
                     {
-                        AgentItem agent = _log.GetAgentData().GetAgent(c.GetSrcAgent());
+                        AgentItem agent = _log.GetAgentData().GetAgent(c.SrcAgent);
                         if (agent != null)
                         {
-                            switch (c.IsStateChange())
+                            switch (c.IsStateChange)
                             {
                                 case ParseEnum.StateChange.EnterCombat:
                                     sw.Write("<li class=\"list-group-item d-flex justify-content-between align-items-center\">" +
-                                                   agent.GetName() + " entered combat in" + c.GetDstAgent() + "subgroup" +
+                                                   agent.GetName() + " entered combat in" + c.DstAgent + "subgroup" +
                                                   // " <span class=\"badge badge-primary badge-pill\">14</span>"+
                                                   "</li>");
                                     break;
@@ -2811,7 +2811,7 @@ namespace LuckParser.Controllers
                                     break;
                                 case ParseEnum.StateChange.HealthUpdate:
                                     sw.Write("<li class=\"list-group-item d-flex justify-content-between align-items-center\">" +
-                                                   agent.GetName() + " is at " + c.GetDstAgent() / 100 + "% health" +
+                                                   agent.GetName() + " is at " + c.DstAgent / 100 + "% health" +
                                                   // " <span class=\"badge badge-primary badge-pill\">14</span>"+
                                                   "</li>");
                                     break;
@@ -2829,13 +2829,13 @@ namespace LuckParser.Controllers
                                     break;
                                 case ParseEnum.StateChange.WeaponSwap:
                                     sw.Write("<li class=\"list-group-item d-flex justify-content-between align-items-center\">" +
-                                                   agent.GetName() + " weapon swapped to " + c.GetDstAgent() + "(0/1 water, 4/5 land)" +
+                                                   agent.GetName() + " weapon swapped to " + c.DstAgent + "(0/1 water, 4/5 land)" +
                                                   // " <span class=\"badge badge-primary badge-pill\">14</span>"+
                                                   "</li>");
                                     break;
                                 case ParseEnum.StateChange.MaxHealthUpdate:
                                     sw.Write("<li class=\"list-group-item d-flex justify-content-between align-items-center\">" +
-                                                   agent.GetName() + " max health changed to  " + c.GetDstAgent() +
+                                                   agent.GetName() + " max health changed to  " + c.DstAgent +
                                                   // " <span class=\"badge badge-primary badge-pill\">14</span>"+
                                                   "</li>");
                                     break;

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -413,7 +413,7 @@ namespace LuckParser.Controllers
                     _combatData.Add( _revision > 0 ? ReadCombatItemRev1(reader) : ReadCombatItem(reader));
                 }
             }
-            _combatData.RemoveAll(x => x.GetSrcInstid() == 0 && x.GetDstAgent() == 0 && x.GetSrcAgent() == 0 && x.GetDstInstid() == 0 && x.GetIFF() == ParseEnum.IFF.Unknown);
+            _combatData.RemoveAll(x => x.SrcInstid == 0 && x.DstAgent == 0 && x.SrcAgent == 0 && x.DstInstid == 0 && x.IFF == ParseEnum.IFF.Unknown);
         }
         
         /// <summary>
@@ -428,22 +428,22 @@ namespace LuckParser.Controllers
             // Set Agent instid, firstAware and lastAware
             foreach (CombatItem c in _combatData)
             {
-                if(agentsLookup.TryGetValue(c.GetSrcAgent(), out var a))
+                if(agentsLookup.TryGetValue(c.SrcAgent, out var a))
                 {
-                    if (a.GetInstid() == 0 && c.IsStateChange().IsSpawn())
+                    if (a.GetInstid() == 0 && c.IsStateChange.IsSpawn())
                     {
-                        a.SetInstid(c.GetSrcInstid());
+                        a.SetInstid(c.SrcInstid);
                     }
                     if (a.GetInstid() != 0)
                     {
                         if (a.GetFirstAware() == 0)
                         {
-                            a.SetFirstAware(c.GetTime());
-                            a.SetLastAware(c.GetTime());
+                            a.SetFirstAware(c.Time);
+                            a.SetLastAware(c.Time);
                         }
                         else
                         {
-                            a.SetLastAware(c.GetTime());
+                            a.SetLastAware(c.Time);
                         }
                     }
                 }
@@ -451,12 +451,12 @@ namespace LuckParser.Controllers
 
             foreach (CombatItem c in _combatData)
             {
-                if (c.GetSrcMasterInstid() != 0)
+                if (c.SrcMasterInstid != 0)
                 {
-                    var master = _agentData.GetAllAgentsList().Find(x => x.GetInstid() == c.GetSrcMasterInstid() && x.GetFirstAware() < c.GetTime() && c.GetTime() < x.GetLastAware());
+                    var master = _agentData.GetAllAgentsList().Find(x => x.GetInstid() == c.SrcMasterInstid && x.GetFirstAware() < c.Time && c.Time < x.GetLastAware());
                     if (master != null)
                     {
-                        if(agentsLookup.TryGetValue(c.GetSrcAgent(), out var minion) && minion.GetFirstAware() < c.GetTime() && c.GetTime() < minion.GetLastAware())
+                        if(agentsLookup.TryGetValue(c.SrcAgent, out var minion) && minion.GetFirstAware() < c.Time && c.Time < minion.GetLastAware())
                         {
                             minion.SetMasterAgent(master.GetAgent());
                         }
@@ -497,15 +497,15 @@ namespace LuckParser.Controllers
                 foreach (CombatItem c in _combatData)
                 {
                     // redirect all attacks to the main golem
-                    if (c.GetDstAgent() == 0 && c.GetDstInstid() == 0 && c.IsStateChange() == ParseEnum.StateChange.Normal && c.GetIFF() == ParseEnum.IFF.Foe && c.IsActivation() == ParseEnum.Activation.None)
+                    if (c.DstAgent == 0 && c.DstInstid == 0 && c.IsStateChange == ParseEnum.StateChange.Normal && c.IFF == ParseEnum.IFF.Foe && c.IsActivation == ParseEnum.Activation.None)
                     {
-                        c.SetDstAgent(bossAgent.GetAgent());
-                        c.SetDstInstid(bossAgent.GetInstid());
+                        c.DstAgent = bossAgent.GetAgent();
+                        c.DstInstid = bossAgent.GetInstid();
                     }
                     // redirect buff initial to main golem
-                    if (otherGolem != null && c.IsBuff() == 18 && c.GetDstInstid() == otherGolem.GetInstid())
+                    if (otherGolem != null && c.IsBuff == 18 && c.DstInstid == otherGolem.GetInstid())
                     {
-                        c.SetDstInstid(bossAgent.GetInstid());
+                        c.DstInstid = bossAgent.GetInstid();
                     }
                 }
 
@@ -513,17 +513,17 @@ namespace LuckParser.Controllers
             // Grab values threw combat data
             foreach (CombatItem c in _combatData)
             {
-                if (c.GetSrcInstid() == _bossData.GetInstid() && c.IsStateChange() == ParseEnum.StateChange.MaxHealthUpdate)//max health update
+                if (c.SrcInstid == _bossData.GetInstid() && c.IsStateChange == ParseEnum.StateChange.MaxHealthUpdate)//max health update
                 {
-                    _bossData.SetHealth((int)c.GetDstAgent());
+                    _bossData.SetHealth((int)c.DstAgent);
 
                 }
-                switch(c.IsStateChange())
+                switch(c.IsStateChange)
                 {
                     case ParseEnum.StateChange.PointOfView:
                         if (_logData.GetPOV() == "N/A")//Point of View
                         {
-                            ulong povAgent = c.GetSrcAgent();
+                            ulong povAgent = c.SrcAgent;
                             if(agentsLookup.TryGetValue(povAgent, out var p))
                             {
                                 _logData.SetPOV(p.GetName());
@@ -531,18 +531,18 @@ namespace LuckParser.Controllers
                         }
                         break;
                     case ParseEnum.StateChange.LogStart:
-                        _logData.SetLogStart(c.GetValue());
-                        _bossData.SetFirstAware(c.GetTime());
+                        _logData.SetLogStart(c.Value);
+                        _bossData.SetFirstAware(c.Time);
                         break;
                     case ParseEnum.StateChange.LogEnd:
-                        _logData.SetLogEnd(c.GetValue());
-                        _bossData.SetLastAware(c.GetTime());
+                        _logData.SetLogEnd(c.Value);
+                        _bossData.SetLastAware(c.Time);
                         break;
                     case ParseEnum.StateChange.HealthUpdate:
                         //set health update
-                        if (c.GetSrcInstid() == _bossData.GetInstid())
+                        if (c.SrcInstid == _bossData.GetInstid())
                         {
-                            bossHealthOverTime.Add(new Point ( (int)(c.GetTime() - _bossData.GetFirstAware()), (int)c.GetDstAgent() ));
+                            bossHealthOverTime.Add(new Point ( (int)(c.Time - _bossData.GetFirstAware()), (int)c.DstAgent ));
                         }
                         break;
                 }
@@ -562,20 +562,20 @@ namespace LuckParser.Controllers
                         _bossData.SetLastAware(NPC.GetLastAware());
                         foreach (CombatItem c in _combatData)
                         {
-                            if (c.GetSrcInstid() == xera2Instid)
+                            if (c.SrcInstid == xera2Instid)
                             {
-                                c.SetSrcInstid(_bossData.GetInstid());
-                                c.SetSrcAgent(_bossData.GetAgent());
+                                c.SrcInstid = _bossData.GetInstid();
+                                c.SrcAgent = _bossData.GetAgent();
                             }
-                            if (c.GetDstInstid() == xera2Instid)
+                            if (c.DstInstid == xera2Instid)
                             {
-                                c.SetDstInstid(_bossData.GetInstid());
-                                c.SetDstAgent(_bossData.GetAgent());
+                                c.DstInstid = _bossData.GetInstid();
+                                c.DstAgent = _bossData.GetAgent();
                             }
                             //set health update
-                            if (c.GetSrcInstid() == _bossData.GetInstid() && c.IsStateChange() == ParseEnum.StateChange.HealthUpdate)
+                            if (c.SrcInstid == _bossData.GetInstid() && c.IsStateChange == ParseEnum.StateChange.HealthUpdate)
                             {
-                                bossHealthOverTime.Add(new Point ( (int)(c.GetTime() - _bossData.GetFirstAware()), (int)c.GetDstAgent() ));
+                                bossHealthOverTime.Add(new Point ( (int)(c.Time - _bossData.GetFirstAware()), (int)c.DstAgent ));
                             }
                         }
                         break;
@@ -596,18 +596,18 @@ namespace LuckParser.Controllers
                     //int stop = 0;
                     foreach (CombatItem c in _combatData)
                     {
-                        if (c.GetTime() > oldAware)
+                        if (c.Time > oldAware)
                         {
-                            if (c.GetSrcInstid() == deimos2Instid)
+                            if (c.SrcInstid == deimos2Instid)
                             {
-                                c.SetSrcInstid(_bossData.GetInstid());
-                                c.SetSrcAgent(_bossData.GetAgent());
+                                c.SrcInstid = _bossData.GetInstid();
+                                c.SrcAgent = _bossData.GetAgent();
 
                             }
-                            if (c.GetDstInstid() == deimos2Instid)
+                            if (c.DstInstid == deimos2Instid)
                             {
-                                c.SetDstInstid(_bossData.GetInstid());
-                                c.SetDstAgent(_bossData.GetAgent());
+                                c.DstInstid = _bossData.GetInstid();
+                                c.DstAgent = _bossData.GetAgent();
                             }
                         }
 
@@ -623,35 +623,35 @@ namespace LuckParser.Controllers
                 {
                     13
                 };
-                CombatItem reward = _combatData.Find(x => x.IsStateChange() == ParseEnum.StateChange.Reward && !notRaidRewardsIds.Contains(x.GetValue()));
+                CombatItem reward = _combatData.Find(x => x.IsStateChange == ParseEnum.StateChange.Reward && !notRaidRewardsIds.Contains(x.Value));
                 if (reward != null)
                 {
                     _logData.SetBossKill(true);
-                    _bossData.SetLastAware(reward.GetTime());
+                    _bossData.SetLastAware(reward.Time);
                 }
             } else if (fractalMode) {
-                CombatItem reward = _combatData.Find(x => x.IsStateChange() == ParseEnum.StateChange.Reward);
+                CombatItem reward = _combatData.Find(x => x.IsStateChange == ParseEnum.StateChange.Reward);
                 if (reward != null)
                 {
                     _logData.SetBossKill(true);
-                    _bossData.SetLastAware(reward.GetTime());
+                    _bossData.SetLastAware(reward.Time);
                 } else
                 {
                     // for skorvald, as CM and normal ids are the same
-                    CombatItem killed = _combatData.Find(x => x.GetSrcInstid() == _bossData.GetInstid() && x.IsStateChange().IsDead());
+                    CombatItem killed = _combatData.Find(x => x.SrcInstid == _bossData.GetInstid() && x.IsStateChange.IsDead());
                     if (killed != null)
                     {
                         _logData.SetBossKill(true);
-                        _bossData.SetLastAware(killed.GetTime());
+                        _bossData.SetLastAware(killed.Time);
                     }
                 }
             } else
             {
-                CombatItem killed = _combatData.Find(x => x.GetSrcInstid() == _bossData.GetInstid() && x.IsStateChange().IsDead());
+                CombatItem killed = _combatData.Find(x => x.SrcInstid == _bossData.GetInstid() && x.IsStateChange.IsDead());
                 if (killed != null)
                 {
                     _logData.SetBossKill(true);
-                    _bossData.SetLastAware(killed.GetTime());
+                    _bossData.SetLastAware(killed.Time);
                 }
             }
 
@@ -671,15 +671,15 @@ namespace LuckParser.Controllers
                 {
                     if (playerAgent.GetInstid() == 0)
                     {
-                        CombatItem tst = _combatData.Find(x => x.GetSrcAgent() == playerAgent.GetAgent());
+                        CombatItem tst = _combatData.Find(x => x.SrcAgent == playerAgent.GetAgent());
                         if (tst == null)
                         {
-                            tst = _combatData.Find(x => x.GetDstAgent() == playerAgent.GetAgent());
-                            playerAgent.SetInstid(tst == null ? ushort.MaxValue : tst.GetDstInstid());
+                            tst = _combatData.Find(x => x.DstAgent == playerAgent.GetAgent());
+                            playerAgent.SetInstid(tst == null ? ushort.MaxValue : tst.DstInstid);
                         }
                         else
                         {
-                            playerAgent.SetInstid(tst.GetSrcInstid());
+                            playerAgent.SetInstid(tst.SrcInstid);
                         }
                     }
                     List<CombatItem> lp = _combatData.GetStates(playerAgent.GetInstid(), ParseEnum.StateChange.Despawn, _bossData.GetFirstAware(), _bossData.GetLastAware());
@@ -706,20 +706,20 @@ namespace LuckParser.Controllers
                                 var extraLoginId = extra.GetInstid();
                                 foreach (CombatItem c in _combatData)
                                 {
-                                    if (c.GetSrcInstid() == extraLoginId)
+                                    if (c.SrcInstid == extraLoginId)
                                     {
-                                        c.SetSrcInstid(playerAgent.GetInstid());
+                                        c.SrcInstid = playerAgent.GetInstid();
                                     }
-                                    if (c.GetDstInstid() == extraLoginId)
+                                    if (c.DstInstid == extraLoginId)
                                     {
-                                        c.SetDstInstid(playerAgent.GetInstid());
+                                        c.DstInstid = playerAgent.GetInstid();
                                     }
                                 }
                                 break;
                             }
                         }
 
-                        player.SetDC(lp[0].GetTime());
+                        player.SetDC(lp[0].Time);
                         _playerList.Add(player);
                     }
                     else//didnt dc

--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -472,14 +472,14 @@ namespace LuckParser.Controllers
                     final.Died = 0.0;
                     if (dead.Count > 0)
                     {
-                        final.Died = dead.Last().GetTime() - start;
+                        final.Died = dead.Last().Time - start;
                     }
 
                     List<CombatItem> disconect = combatData.GetStates(instid, ParseEnum.StateChange.Despawn, start, end);
                     final.Dcd = 0.0;
                     if (disconect.Count > 0)
                     {
-                        final.Dcd = disconect.Last().GetTime() - start;
+                        final.Dcd = disconect.Last().Time - start;
                     }
 
                     phaseStats[phaseIndex] = final;
@@ -770,7 +770,7 @@ namespace LuckParser.Controllers
             {//Main boons
                 foreach (Boon boon in Boon.GetBoonList())
                 {
-                    if (combatList.Exists(x => x.GetSkillID() == boon.GetID()))
+                    if (combatList.Exists(x => x.SkillID == boon.GetID()))
                     {
                         _statistics.PresentBoons.Add(boon);
                     }
@@ -780,14 +780,14 @@ namespace LuckParser.Controllers
             {//Important Class specefic boons
                 foreach (Boon boon in Boon.GetOffensiveTableList())
                 {
-                    if (combatList.Exists(x => x.GetSkillID() == boon.GetID()))
+                    if (combatList.Exists(x => x.SkillID == boon.GetID()))
                     {
                         _statistics.PresentOffbuffs.Add(boon);
                     }
                 }
                 foreach (Boon boon in Boon.GetDefensiveTableList())
                 {
-                    if (combatList.Exists(x => x.GetSkillID() == boon.GetID()))
+                    if (combatList.Exists(x => x.SkillID == boon.GetID()))
                     {
                         _statistics.PresentDefbuffs.Add(boon);
                     }
@@ -802,8 +802,8 @@ namespace LuckParser.Controllers
                     List<Boon> notYetFoundBoons = Boon.GetRemainingBuffsList();
                     combatList.ForEach(item =>
                     {
-                        if (item.GetDstInstid() == p.GetInstid()) {
-                            Boon foundBoon = notYetFoundBoons.Find(boon => boon.GetID() == item.GetSkillID());
+                        if (item.DstInstid == p.GetInstid()) {
+                            Boon foundBoon = notYetFoundBoons.Find(boon => boon.GetID() == item.SkillID);
                             if (foundBoon != null)
                             {
                                 notYetFoundBoons.Remove(foundBoon);

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -74,20 +74,20 @@ namespace LuckParser.Models
         protected static List<CombatItem> GetFilteredList(ParsedLog log, long skillID, ushort instid)
         {
             bool needStart = true;
-            List<CombatItem> main = log.GetBoonData().Where(x => x.GetSkillID() == skillID && ((x.GetDstInstid() == instid && x.IsBuffremove() == ParseEnum.BuffRemove.None) || (x.GetSrcInstid() == instid && x.IsBuffremove() != ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> main = log.GetBoonData().Where(x => x.SkillID == skillID && ((x.DstInstid == instid && x.IsBuffRemove == ParseEnum.BuffRemove.None) || (x.SrcInstid == instid && x.IsBuffRemove != ParseEnum.BuffRemove.None))).ToList();
             List<CombatItem> filtered = new List<CombatItem>();
             for (int i = 0; i < main.Count; i++)
             {
                 CombatItem c = main[i];
-                if (needStart && c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (needStart && c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
                     needStart = false;
                     filtered.Add(c);
                 }
-                else if (!needStart && c.IsBuffremove() != ParseEnum.BuffRemove.None)
+                else if (!needStart && c.IsBuffRemove != ParseEnum.BuffRemove.None)
                 {
                     // consider only last remove event before another application
-                    if ((i == main.Count - 1) || (i < main.Count - 1 && main[i + 1].IsBuffremove() == ParseEnum.BuffRemove.None))
+                    if ((i == main.Count - 1) || (i < main.Count - 1 && main[i + 1].IsBuffRemove == ParseEnum.BuffRemove.None))
                     {
                         needStart = true;
                         filtered.Add(c);

--- a/LuckParser/Models/BossLogic/Cairn.cs
+++ b/LuckParser/Models/BossLogic/Cairn.cs
@@ -52,10 +52,10 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // shared agony
-            List<CombatItem> agony = log.GetBoonData().Where(x => x.GetSkillID() == 38049 && ((x.GetDstInstid() == p.GetInstid() && x.IsBuffremove() == ParseEnum.BuffRemove.None))).ToList();        
+            List<CombatItem> agony = log.GetBoonData().Where(x => x.SkillID == 38049 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
             foreach (CombatItem c in agony)
             {
-                int agonyStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                int agonyStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 int agonyEnd = agonyStart + 62000;
                 replay.AddCircleActor(new CircleActor(false, 0, 220, new Tuple<int, int>(agonyStart, agonyEnd), "rgba(255, 0, 0, 0.5)"));
             }
@@ -63,7 +63,7 @@ namespace LuckParser.Models
 
         public override int IsCM(List<CombatItem> clist, int health)
         {
-            return clist.Exists(x => x.GetSkillID() == 38098) ? 1 : 0;
+            return clist.Exists(x => x.SkillID == 38098) ? 1 : 0;
         }
 
         public override string GetReplayIcon()

--- a/LuckParser/Models/BossLogic/Deimos.cs
+++ b/LuckParser/Models/BossLogic/Deimos.cs
@@ -50,10 +50,10 @@ namespace LuckParser.Models
             long fightDuration = log.GetBossData().GetAwareDuration();
             List<PhaseData> phases = GetInitialPhase(log);
             // Determined + additional data on inst change
-            CombatItem invulDei = log.GetBoonData().Find(x => x.GetSkillID() == 762 && x.IsBuffremove() == ParseEnum.BuffRemove.None && x.GetDstInstid() == boss.GetInstid());
+            CombatItem invulDei = log.GetBoonData().Find(x => x.SkillID == 762 && x.IsBuffRemove == ParseEnum.BuffRemove.None && x.DstInstid == boss.GetInstid());
             if (invulDei != null)
             {
-                end = invulDei.GetTime() - log.GetBossData().GetFirstAware();
+                end = invulDei.Time - log.GetBossData().GetFirstAware();
                 phases.Add(new PhaseData(start, end));
                 start = (boss.GetPhaseData().Count == 1 ? boss.GetPhaseData()[0] - log.GetBossData().GetFirstAware() : fightDuration);
                 castLogs.Add(new CastLog(end, -6, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None));
@@ -67,15 +67,15 @@ namespace LuckParser.Models
                 phases[i].SetName("Phase " + i);
             }
             int offsetDei = phases.Count;
-            CombatItem teleport = log.GetCombatList().FirstOrDefault(x => x.GetSkillID() == 38169);
+            CombatItem teleport = log.GetCombatList().FirstOrDefault(x => x.SkillID == 38169);
             int splits = 0;
             while (teleport != null && splits < 3)
             {
-                start = teleport.GetTime() - log.GetBossData().GetFirstAware();
-                CombatItem teleportBack = log.GetCombatList().FirstOrDefault(x => x.GetSkillID() == 38169 && x.GetTime() - log.GetBossData().GetFirstAware() > start + 10000);
+                start = teleport.Time - log.GetBossData().GetFirstAware();
+                CombatItem teleportBack = log.GetCombatList().FirstOrDefault(x => x.SkillID == 38169 && x.Time - log.GetBossData().GetFirstAware() > start + 10000);
                 if (teleportBack != null)
                 {
-                    end = teleportBack.GetTime() - log.GetBossData().GetFirstAware();
+                    end = teleportBack.Time - log.GetBossData().GetFirstAware();
                 }
                 else
                 {
@@ -83,7 +83,7 @@ namespace LuckParser.Models
                 }
                 phases.Add(new PhaseData(start, end));
                 splits++;
-                teleport = log.GetCombatList().FirstOrDefault(x => x.GetSkillID() == 38169 && x.GetTime() - log.GetBossData().GetFirstAware() > end + 10000);
+                teleport = log.GetCombatList().FirstOrDefault(x => x.SkillID == 38169 && x.Time - log.GetBossData().GetFirstAware() > end + 10000);
             }
 
             string[] namesDeiSplit = new [] { "Thief", "Gambler", "Drunkard" };
@@ -150,13 +150,13 @@ namespace LuckParser.Models
             int tpStart = 0;
             foreach (CombatItem c in tpDeimos)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    tpStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    tpStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int tpEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int tpEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
                     replay.AddCircleActor(new CircleActor(true, tpEnd, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
                 }

--- a/LuckParser/Models/BossLogic/Dhuum.cs
+++ b/LuckParser/Models/BossLogic/Dhuum.cs
@@ -73,10 +73,10 @@ namespace LuckParser.Models
             }
             else
             {
-                CombatItem invulDhuum = log.GetBoonData().FirstOrDefault(x => x.GetSkillID() == 762 && x.IsBuffremove() != ParseEnum.BuffRemove.None && x.GetSrcInstid() == boss.GetInstid() && x.GetTime() > 115000 + log.GetBossData().GetFirstAware());
+                CombatItem invulDhuum = log.GetBoonData().FirstOrDefault(x => x.SkillID == 762 && x.IsBuffRemove != ParseEnum.BuffRemove.None && x.SrcInstid == boss.GetInstid() && x.Time > 115000 + log.GetBossData().GetFirstAware());
                 if (invulDhuum != null)
                 {
-                    end = invulDhuum.GetTime() - log.GetBossData().GetFirstAware();
+                    end = invulDhuum.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(start, end));
                     start = end + 1;
                     CastLog shield = castLogs.Find(x => x.GetID() == 47396);
@@ -153,20 +153,20 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // spirit transform
-            List<CombatItem> spiritTransform = log.GetBoonData().Where(x => x.GetDstInstid() == p.GetInstid() && x.GetSkillID() == 46950 && x.IsBuffremove() == ParseEnum.BuffRemove.None).ToList();
+            List<CombatItem> spiritTransform = log.GetBoonData().Where(x => x.DstInstid == p.GetInstid() && x.SkillID == 46950 && x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
             foreach (CombatItem c in spiritTransform)
             {
                 int duration = 15000;
-                int start = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                int start = (int)(c.Time - log.GetBossData().GetFirstAware());
                 if (log.GetBossData().GetHealthOverTime().FirstOrDefault(x => x.X > start).Y < 1050)
                 {
                     duration = 30000;
                 }
-                CombatItem removedBuff = log.GetBoonData().FirstOrDefault(x => x.GetSrcInstid() == p.GetInstid() && x.GetSkillID() == 48281 && x.IsBuffremove() == ParseEnum.BuffRemove.All && x.GetTime() > c.GetTime() && x.GetTime() < c.GetTime() + duration);
+                CombatItem removedBuff = log.GetBoonData().FirstOrDefault(x => x.SrcInstid == p.GetInstid() && x.SkillID == 48281 && x.IsBuffRemove == ParseEnum.BuffRemove.All && x.Time > c.Time && x.Time < c.Time + duration);
                 int end = start + duration;
                 if (removedBuff != null)
                 {
-                    end = (int)(removedBuff.GetTime() - log.GetBossData().GetFirstAware());
+                    end = (int)(removedBuff.Time - log.GetBossData().GetFirstAware());
                 }
                 replay.AddCircleActor(new CircleActor(true, 0, 100, new Tuple<int, int>(start, end), "rgba(0, 50, 200, 0.3)"));
                 replay.AddCircleActor(new CircleActor(true, start + duration, 100, new Tuple<int, int>(start, end), "rgba(0, 50, 200, 0.5)"));
@@ -176,13 +176,13 @@ namespace LuckParser.Models
             int bombDhuumStart = 0;
             foreach (CombatItem c in bombDhuum)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    bombDhuumStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    bombDhuumStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int bombDhuumEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int bombDhuumEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 100, new Tuple<int, int>(bombDhuumStart, bombDhuumEnd), "rgba(80, 180, 0, 0.3)"));
                     replay.AddCircleActor(new CircleActor(true, bombDhuumStart + 13000, 100, new Tuple<int, int>(bombDhuumStart, bombDhuumEnd), "rgba(80, 180, 0, 0.5)"));
                 }

--- a/LuckParser/Models/BossLogic/FractalLogic.cs
+++ b/LuckParser/Models/BossLogic/FractalLogic.cs
@@ -28,9 +28,9 @@ namespace LuckParser.Models
             for (int i = 0; i < invulsBoss.Count; i++)
             {
                 CombatItem c = invulsBoss[i];
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    end = c.GetTime() - log.GetBossData().GetFirstAware();
+                    end = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsBoss.Count - 1)
                     {
@@ -39,7 +39,7 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    start = c.GetTime() - log.GetBossData().GetFirstAware();
+                    start = c.Time - log.GetBossData().GetFirstAware();
                     castLogs.Add(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None));
                 }
             }

--- a/LuckParser/Models/BossLogic/Gorseval.cs
+++ b/LuckParser/Models/BossLogic/Gorseval.cs
@@ -38,13 +38,13 @@ namespace LuckParser.Models
             long fightDuration = log.GetBossData().GetAwareDuration();
             List<PhaseData> phases = GetInitialPhase(log);
             // Ghostly protection check
-            List<CombatItem> invulsGorse = log.GetCombatList().Where(x => x.GetSkillID() == 31790 && x.IsBuffremove() != ParseEnum.BuffRemove.Manual).ToList();
+            List<CombatItem> invulsGorse = log.GetCombatList().Where(x => x.SkillID == 31790 && x.IsBuffRemove != ParseEnum.BuffRemove.Manual).ToList();
             for (int i = 0; i < invulsGorse.Count; i++)
             {
                 CombatItem c = invulsGorse[i];
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    end = c.GetTime() - log.GetBossData().GetFirstAware();
+                    end = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsGorse.Count - 1)
                     {
@@ -53,7 +53,7 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    start = c.GetTime() - log.GetBossData().GetFirstAware();
+                    start = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(end, start));
                     castLogs.Add(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None));
                 }

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -61,25 +61,25 @@ namespace LuckParser.Models
             }
             // add burn phases
             int offset = phases.Count;
-            List<CombatItem> orbItems = log.GetBoonData().Where(x => x.GetDstInstid() == boss.GetInstid() && x.GetSkillID() == 35096).ToList();
+            List<CombatItem> orbItems = log.GetBoonData().Where(x => x.DstInstid == boss.GetInstid() && x.SkillID == 35096).ToList();
             // Get number of orbs and filter the list
             List<CombatItem> orbItemsFiltered = new List<CombatItem>();
             Dictionary<long, int> orbs = new Dictionary<long, int>();
             foreach (CombatItem c in orbItems)
             {
-                long time = c.GetTime() - log.GetBossData().GetFirstAware();
+                long time = c.Time - log.GetBossData().GetFirstAware();
                 if (!orbs.ContainsKey(time))
                 {
                     orbs[time] = 0;
                 }
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
                     orbs[time] = orbs[time] + 1;
                 }
                 if (orbItemsFiltered.Count > 0)
                 {
                     CombatItem last = orbItemsFiltered.Last();
-                    if (last.GetTime() != c.GetTime())
+                    if (last.Time != c.Time)
                     {
                         orbItemsFiltered.Add(c);
                     }
@@ -92,13 +92,13 @@ namespace LuckParser.Models
             }
             foreach (CombatItem c in orbItemsFiltered)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    start = c.GetTime() - log.GetBossData().GetFirstAware();
+                    start = c.Time - log.GetBossData().GetFirstAware();
                 }
                 else
                 {
-                    end = c.GetTime() - log.GetBossData().GetFirstAware();
+                    end = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(start, end));
                 }
             }
@@ -172,13 +172,13 @@ namespace LuckParser.Models
             int xeraFuryStart = 0;
             foreach (CombatItem c in xeraFury)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    xeraFuryStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    xeraFuryStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int xeraFuryEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int xeraFuryEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.2)"));
                     replay.AddCircleActor(new CircleActor(true, xeraFuryEnd, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.4)"));
                 }

--- a/LuckParser/Models/BossLogic/Matthias.cs
+++ b/LuckParser/Models/BossLogic/Matthias.cs
@@ -55,15 +55,15 @@ namespace LuckParser.Models
             long fightDuration = log.GetBossData().GetAwareDuration();
             List<PhaseData> phases = GetInitialPhase(log);
             // Special buff cast check
-            CombatItem heatWave = log.GetCombatList().Find(x => x.GetSkillID() == 34526);
+            CombatItem heatWave = log.GetCombatList().Find(x => x.SkillID == 34526);
             List<long> phaseStarts = new List<long>();
             if (heatWave != null)
             {
-                phaseStarts.Add(heatWave.GetTime() - log.GetBossData().GetFirstAware());
-                CombatItem downPour = log.GetCombatList().Find(x => x.GetSkillID() == 34554);
+                phaseStarts.Add(heatWave.Time - log.GetBossData().GetFirstAware());
+                CombatItem downPour = log.GetCombatList().Find(x => x.SkillID == 34554);
                 if (downPour != null)
                 {
-                    phaseStarts.Add(downPour.GetTime() - log.GetBossData().GetFirstAware());
+                    phaseStarts.Add(downPour.Time - log.GetBossData().GetFirstAware());
                     CastLog abo = castLogs.Find(x => x.GetID() == 34427);
                     if (abo != null)
                     {
@@ -102,7 +102,7 @@ namespace LuckParser.Models
                         ParseEnum.ThrashIDS.Storm
                     };
             List<CastLog> humanShield = cls.Where(x => x.GetID() == 34468).ToList();
-            List<int> humanShieldRemoval = log.GetBoonData().Where(x => x.GetSkillID() == 34518 && x.IsBuffremove() == ParseEnum.BuffRemove.All).Select(x => (int)(x.GetTime() - log.GetBossData().GetFirstAware())).Distinct().ToList();
+            List<int> humanShieldRemoval = log.GetBoonData().Where(x => x.SkillID == 34518 && x.IsBuffRemove == ParseEnum.BuffRemove.All).Select(x => (int)(x.Time - log.GetBossData().GetFirstAware())).Distinct().ToList();
             for (var i = 0; i < humanShield.Count; i++)
             {
                 var shield = humanShield[i];
@@ -116,7 +116,7 @@ namespace LuckParser.Models
                 }
             }
             List<CastLog> aboShield = cls.Where(x => x.GetID() == 34510).ToList();
-            List<int> aboShieldRemoval = log.GetBoonData().Where(x => x.GetSkillID() == 34376 && x.IsBuffremove() == ParseEnum.BuffRemove.All).Select(x => (int)(x.GetTime() - log.GetBossData().GetFirstAware())).Distinct().ToList();
+            List<int> aboShieldRemoval = log.GetBoonData().Where(x => x.SkillID == 34376 && x.IsBuffRemove == ParseEnum.BuffRemove.All).Select(x => (int)(x.Time - log.GetBossData().GetFirstAware())).Distinct().ToList();
             for (var i = 0; i < aboShield.Count; i++)
             {
                 var shield = aboShield[i];
@@ -149,13 +149,13 @@ namespace LuckParser.Models
             int corruptedMatthiasStart = 0;
             foreach (CombatItem c in corruptedMatthias)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    corruptedMatthiasStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    corruptedMatthiasStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int corruptedMatthiasEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int corruptedMatthiasEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(corruptedMatthiasStart, corruptedMatthiasEnd), "rgba(255, 150, 0, 0.5)"));
                     Point3D wellPosition = replay.GetPositions().FirstOrDefault(x => x.Time > corruptedMatthiasEnd);
                     if (wellPosition != null)
@@ -170,13 +170,13 @@ namespace LuckParser.Models
             int wellMatthiasStart = 0;
             foreach (CombatItem c in wellMatthias)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    wellMatthiasStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    wellMatthiasStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int wellMatthiasEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int wellMatthiasEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(false, 0, 120, new Tuple<int, int>(wellMatthiasStart, wellMatthiasEnd), "rgba(150, 255, 80, 0.5)"));
                     replay.AddCircleActor(new CircleActor(true, wellMatthiasStart + 9000, 120, new Tuple<int, int>(wellMatthiasStart, wellMatthiasEnd), "rgba(150, 255, 80, 0.5)"));
                     Point3D wellPosition = replay.GetPositions().FirstOrDefault(x => x.Time > wellMatthiasEnd);
@@ -191,22 +191,22 @@ namespace LuckParser.Models
             int sacrificeMatthiasStart = 0;
             foreach (CombatItem c in sacrificeMatthias)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    sacrificeMatthiasStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    sacrificeMatthiasStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int sacrificeMatthiasEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int sacrificeMatthiasEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 120, new Tuple<int, int>(sacrificeMatthiasStart, sacrificeMatthiasEnd), "rgba(0, 150, 250, 0.2)"));
                     replay.AddCircleActor(new CircleActor(true, sacrificeMatthiasStart + 10000, 120, new Tuple<int, int>(sacrificeMatthiasStart, sacrificeMatthiasEnd), "rgba(0, 150, 250, 0.35)"));
                 }
             }
             // Bombs
-            List<CombatItem> zealousBenediction = log.GetBoonData().Where(x => x.GetSkillID() == 34511 && ((x.GetDstInstid() == p.GetInstid() && x.IsBuffremove() == ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> zealousBenediction = log.GetBoonData().Where(x => x.SkillID == 34511 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
             foreach (CombatItem c in zealousBenediction)
             {
-                int zealousStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware()) ;
+                int zealousStart = (int)(c.Time - log.GetBossData().GetFirstAware()) ;
                 int zealousEnd = zealousStart + 5000;
                 replay.AddCircleActor(new CircleActor(true, 0, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.2)"));
                 replay.AddCircleActor(new CircleActor(true, zealousEnd, 180, new Tuple<int, int>(zealousStart, zealousEnd), "rgba(200, 150, 0, 0.4)"));

--- a/LuckParser/Models/BossLogic/Sabetha.cs
+++ b/LuckParser/Models/BossLogic/Sabetha.cs
@@ -45,9 +45,9 @@ namespace LuckParser.Models
             for (int i = 0; i < invulsSab.Count; i++)
             {
                 CombatItem c = invulsSab[i];
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    end = c.GetTime() - log.GetBossData().GetFirstAware();
+                    end = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsSab.Count - 1)
                     {
@@ -56,7 +56,7 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    start = c.GetTime() - log.GetBossData().GetFirstAware();
+                    start = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(end, start));
                     castLogs.Add(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None));
                 }
@@ -111,10 +111,10 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // timed bombs
-            List<CombatItem> timedBombs = log.GetBoonData().Where(x => x.GetSkillID() == 31485 && (x.GetDstInstid() == p.GetInstid() && x.IsBuffremove() == ParseEnum.BuffRemove.None)).ToList();
+            List<CombatItem> timedBombs = log.GetBoonData().Where(x => x.SkillID == 31485 && (x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None)).ToList();
             foreach (CombatItem c in timedBombs)
             {
-                int start = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                int start = (int)(c.Time - log.GetBossData().GetFirstAware());
                 int end = start + 3000;
                 replay.AddCircleActor(new CircleActor(false, 0, 280, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
                 replay.AddCircleActor(new CircleActor(true, end, 280, new Tuple<int, int>(start, end), "rgba(255, 150, 0, 0.5)"));
@@ -124,13 +124,13 @@ namespace LuckParser.Models
             int sapperStart = 0;
             foreach (CombatItem c in sapperBombs)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    sapperStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    sapperStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int sapperEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware()); replay.AddCircleActor(new CircleActor(false, 0, 180, new Tuple<int, int>(sapperStart, sapperEnd), "rgba(200, 255, 100, 0.5)"));
+                    int sapperEnd = (int)(c.Time - log.GetBossData().GetFirstAware()); replay.AddCircleActor(new CircleActor(false, 0, 180, new Tuple<int, int>(sapperStart, sapperEnd), "rgba(200, 255, 100, 0.5)"));
                     replay.AddCircleActor(new CircleActor(true, sapperStart + 5000, 180, new Tuple<int, int>(sapperStart, sapperEnd), "rgba(200, 255, 100, 0.5)"));
                 }
             }

--- a/LuckParser/Models/BossLogic/Samarog.cs
+++ b/LuckParser/Models/BossLogic/Samarog.cs
@@ -55,9 +55,9 @@ namespace LuckParser.Models
             for (int i = 0; i < invulsSam.Count; i++)
             {
                 CombatItem c = invulsSam[i];
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    end = c.GetTime() - log.GetBossData().GetFirstAware();
+                    end = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsSam.Count - 1)
                     {
@@ -66,7 +66,7 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    start = c.GetTime() - log.GetBossData().GetFirstAware();
+                    start = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(end, start));
                     castLogs.Add(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None));
                 }
@@ -110,17 +110,17 @@ namespace LuckParser.Models
                         ParseEnum.ThrashIDS.Rigom,
                         ParseEnum.ThrashIDS.Guldhem
                     };
-            List<CombatItem> brutalize = log.GetBoonData().Where(x => x.GetSkillID() == 38226 && x.IsBuffremove() != ParseEnum.BuffRemove.Manual).ToList();
+            List<CombatItem> brutalize = log.GetBoonData().Where(x => x.SkillID == 38226 && x.IsBuffRemove != ParseEnum.BuffRemove.Manual).ToList();
             int brutStart = 0;
             foreach (CombatItem c in brutalize)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    brutStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    brutStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int brutEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int brutEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 120, new Tuple<int, int>(brutStart, brutEnd), "rgba(0, 180, 255, 0.3)"));
                 }
             }
@@ -130,19 +130,19 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // big bomb
-            List<CombatItem> bigbomb = log.GetBoonData().Where(x => x.GetSkillID() == 37966 && ((x.GetDstInstid() == p.GetInstid() && x.IsBuffremove() == ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> bigbomb = log.GetBoonData().Where(x => x.SkillID == 37966 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
             foreach (CombatItem c in bigbomb)
             {
-                int bigStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                int bigStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 int bigEnd = bigStart + 6000;
                 replay.AddCircleActor(new CircleActor(true, 0, 300, new Tuple<int, int>(bigStart, bigEnd), "rgba(150, 80, 0, 0.2)"));
                 replay.AddCircleActor(new CircleActor(true, bigEnd, 300, new Tuple<int, int>(bigStart, bigEnd), "rgba(150, 80, 0, 0.2)"));
             }
             // small bomb
-            List<CombatItem> smallbomb = log.GetBoonData().Where(x => x.GetSkillID() == 38247 && ((x.GetDstInstid() == p.GetInstid() && x.IsBuffremove() == ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> smallbomb = log.GetBoonData().Where(x => x.SkillID == 38247 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
             foreach (CombatItem c in smallbomb)
             {
-                int smallStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                int smallStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 int smallEnd = smallStart + 6000;
                 replay.AddCircleActor(new CircleActor(true, 0, 80, new Tuple<int, int>(smallStart, smallEnd), "rgba(80, 150, 0, 0.3)"));
             }
@@ -151,13 +151,13 @@ namespace LuckParser.Models
             int fixatedSamStart = 0;
             foreach (CombatItem c in fixatedSam)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    fixatedSamStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    fixatedSamStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int fixatedSamEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int fixatedSamEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 80, new Tuple<int, int>(fixatedSamStart, fixatedSamEnd), "rgba(255, 80, 255, 0.3)"));
                 }
             }

--- a/LuckParser/Models/BossLogic/Slothasor.cs
+++ b/LuckParser/Models/BossLogic/Slothasor.cs
@@ -77,13 +77,13 @@ namespace LuckParser.Models
             int toDropStart = 0;
             foreach (CombatItem c in poisonToDrop)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    toDropStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    toDropStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int toDropEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware()); replay.AddCircleActor(new CircleActor(false, 0, 180, new Tuple<int, int>(toDropStart, toDropEnd), "rgba(255, 255, 100, 0.5)"));
+                    int toDropEnd = (int)(c.Time - log.GetBossData().GetFirstAware()); replay.AddCircleActor(new CircleActor(false, 0, 180, new Tuple<int, int>(toDropStart, toDropEnd), "rgba(255, 255, 100, 0.5)"));
                     replay.AddCircleActor(new CircleActor(true, toDropStart + 8000, 180, new Tuple<int, int>(toDropStart, toDropEnd), "rgba(255, 255, 100, 0.5)"));
                     Point3D poisonPos = replay.GetPositions().FirstOrDefault(x => x.Time > toDropEnd);
                     if (poisonPos != null)
@@ -97,13 +97,13 @@ namespace LuckParser.Models
             int transfoStart = 0;
             foreach (CombatItem c in slubTrans)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    transfoStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    transfoStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int transfoEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int transfoEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 160, new Tuple<int, int>(transfoStart, transfoEnd), "rgba(0, 80, 255, 0.3)"));
                 }
             }
@@ -112,13 +112,13 @@ namespace LuckParser.Models
             int fixatedSlothStart = 0;
             foreach (CombatItem c in fixatedSloth)
             {
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    fixatedSlothStart = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    fixatedSlothStart = (int)(c.Time - log.GetBossData().GetFirstAware());
                 }
                 else
                 {
-                    int fixatedSlothEnd = (int)(c.GetTime() - log.GetBossData().GetFirstAware());
+                    int fixatedSlothEnd = (int)(c.Time - log.GetBossData().GetFirstAware());
                     replay.AddCircleActor(new CircleActor(true, 0, 120, new Tuple<int, int>(fixatedSlothStart, fixatedSlothEnd), "rgba(255, 80, 255, 0.3)"));
                 }
             }

--- a/LuckParser/Models/BossLogic/SoullessHorror.cs
+++ b/LuckParser/Models/BossLogic/SoullessHorror.cs
@@ -70,7 +70,7 @@ namespace LuckParser.Models
 
         public override int IsCM(List<CombatItem> clist, int health)
         {
-            List<CombatItem> necrosis = clist.Where(x => x.GetSkillID() == 47414 && x.IsBuffremove() == ParseEnum.BuffRemove.None).ToList();
+            List<CombatItem> necrosis = clist.Where(x => x.SkillID == 47414 && x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
             if (necrosis.Count == 0)
             {
                 return 0;
@@ -79,7 +79,7 @@ namespace LuckParser.Models
             Dictionary<ushort, List<CombatItem>> splitNecrosis = new Dictionary<ushort, List<CombatItem>>();
             foreach (CombatItem c in necrosis)
             {
-                ushort inst = c.GetDstInstid();
+                ushort inst = c.DstInstid;
                 if (!splitNecrosis.ContainsKey(inst))
                 {
                     splitNecrosis.Add(inst, new List<CombatItem>());
@@ -92,7 +92,7 @@ namespace LuckParser.Models
             {
                 CombatItem cur = longestNecrosis[i];
                 CombatItem next = longestNecrosis[i + 1];
-                long timeDiff = next.GetTime() - cur.GetTime();
+                long timeDiff = next.Time - cur.Time;
                 if (timeDiff > 1000 && minDiff > timeDiff)
                 {
                     minDiff = timeDiff;

--- a/LuckParser/Models/BossLogic/ValeGuardian.cs
+++ b/LuckParser/Models/BossLogic/ValeGuardian.cs
@@ -51,9 +51,9 @@ namespace LuckParser.Models
             for (int i = 0; i < invulsVG.Count; i++)
             {
                 CombatItem c = invulsVG[i];
-                if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    end = c.GetTime() - log.GetBossData().GetFirstAware();
+                    end = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsVG.Count - 1)
                     {
@@ -62,7 +62,7 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    start = c.GetTime() - log.GetBossData().GetFirstAware();
+                    start = c.Time - log.GetBossData().GetFirstAware();
                     phases.Add(new PhaseData(end, start));
                     castLogs.Add(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None));
                 }

--- a/LuckParser/Models/BossLogic/Xera.cs
+++ b/LuckParser/Models/BossLogic/Xera.cs
@@ -50,8 +50,8 @@ namespace LuckParser.Models
             // split happened
             if (boss.GetPhaseData().Count == 1)
             {
-                CombatItem invulXera = log.GetBoonData().Find(x => x.GetDstInstid() == boss.GetInstid() && (x.GetSkillID() == 762 || x.GetSkillID() == 34113));
-                long end = invulXera.GetTime() - log.GetBossData().GetFirstAware();
+                CombatItem invulXera = log.GetBoonData().Find(x => x.DstInstid == boss.GetInstid() && (x.SkillID == 762 || x.SkillID == 34113));
+                long end = invulXera.Time - log.GetBossData().GetFirstAware();
                 phases.Add(new PhaseData(start, end));
                 start = boss.GetPhaseData()[0] - log.GetBossData().GetFirstAware();
                 castLogs.Add(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None));

--- a/LuckParser/Models/ParseModels/Boons/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boons/Boon.cs
@@ -340,7 +340,7 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Skelk Venom",-1, BoonSource.Thief, BoonType.Intensity, 5, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override, "https://wiki.guildwars2.com/images/7/75/Skelk_Venom.png"),
                 new Boon("Ice Drake Venom",13095, BoonSource.Thief, BoonType.Intensity, 4, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override, "https://wiki.guildwars2.com/images/7/7b/Ice_Drake_Venom.png"),
                 new Boon("Devourer Venom", 13094, BoonSource.Thief, BoonType.Intensity, 2, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override, "https://wiki.guildwars2.com/images/4/4d/Devourer_Venom.png"),
-                new Boon("Skale Venom", 13036, BoonSource.Thief, BoonType.Intensity, 4, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override, "https://wiki.guildwars2.com/images/1/14/Skale_Venom.png"),
+                new Boon("Skale Venom", 13054, BoonSource.Thief, BoonType.Intensity, 4, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override, "https://wiki.guildwars2.com/images/1/14/Skale_Venom.png"),
                 new Boon("Spider Venom",13036, BoonSource.Thief, BoonType.Intensity, 6, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override, "https://wiki.guildwars2.com/images/3/39/Spider_Venom.png"),
                 new Boon("Basilisk Venom", 13133, BoonSource.Thief, BoonType.Intensity, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override, "https://wiki.guildwars2.com/images/3/3a/Basilisk_Venom.png"),
                 //physical
@@ -440,7 +440,7 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Obsidian Flesh",5667, BoonSource.Elementalist, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 //traits
                 new Boon("Harmonious Conduit",31353, BoonSource.Elementalist, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff,RemoveType.None, Logic.Override),
-                new Boon("Fresh Air",31353, BoonSource.Elementalist, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff,RemoveType.None, Logic.Override),
+                new Boon("Fresh Air",34241, BoonSource.Elementalist, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff,RemoveType.None, Logic.Override),
                 new Boon("Soothing Mist", 5587, BoonSource.Elementalist, BoonType.Duration, 1, BoonEnum.DefensiveBuffTable,RemoveType.None, Logic.Override, "https://wiki.guildwars2.com/images/f/f7/Soothing_Mist.png"),
                 new Boon("Lesser Arcane Shield",25579, BoonSource.Elementalist, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Weaver's Prowess",42061, BoonSource.Elementalist, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff,RemoveType.None, Logic.Override),

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -21,8 +21,8 @@ namespace LuckParser.Models.ParseModels
             var list = new List<CombatItem>();
             foreach (var combatItem in this)
             {
-                if (combatItem.GetTime() >= start && combatItem.GetTime() <= end &&
-                    combatItem.GetSrcInstid() == srcInstid && combatItem.IsStateChange() == change)
+                if (combatItem.Time >= start && combatItem.Time <= end &&
+                    combatItem.SrcInstid == srcInstid && combatItem.IsStateChange == change)
                 {
                     list.Add(combatItem);
                 }
@@ -34,11 +34,11 @@ namespace LuckParser.Models.ParseModels
         public int GetSkillCount(int srcInstid, int skillId, long start, long end)
         {
             int count = 0;
-            foreach (CombatItem c in this.Where(x => x.GetTime() >= start && x.GetTime() <= end))
+            foreach (CombatItem c in this.Where(x => x.Time >= start && x.Time <= end))
             {
-                if (c.GetSrcInstid() == srcInstid && c.GetSkillID() == skillId)
+                if (c.SrcInstid == srcInstid && c.SkillID == skillId)
                 {
-                    if (c.IsActivation().IsCasting())
+                    if (c.IsActivation.IsCasting())
                         count++;
                 }
             }
@@ -47,11 +47,11 @@ namespace LuckParser.Models.ParseModels
         public int GetBuffCount(int srcInstid, int skillId, long start, long end)
         {
             int count = 0;
-            foreach (CombatItem c in this.Where(x => x.GetTime() >= start && x.GetTime() <= end))
+            foreach (CombatItem c in this.Where(x => x.Time >= start && x.Time <= end))
             {
-                if (c.GetSrcInstid() == srcInstid && c.GetSkillID() == skillId)
+                if (c.SrcInstid == srcInstid && c.SkillID == skillId)
                 {
-                    if (c.IsBuff() == 1 && c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                    if (c.IsBuff == 1 && c.IsBuffRemove == ParseEnum.BuffRemove.None)
                         count++;
                 }
             }
@@ -59,19 +59,19 @@ namespace LuckParser.Models.ParseModels
         }
         public void Validate(BossData bossData)
         {
-            _boonData = this.Where(x => x.IsBuff() > 0 && (x.IsBuff() == 18 || x.GetBuffDmg() == 0 || x.IsBuffremove() != ParseEnum.BuffRemove.None)).ToList();
+            _boonData = this.Where(x => x.IsBuff > 0 && (x.IsBuff == 18 || x.BuffDmg == 0 || x.IsBuffRemove != ParseEnum.BuffRemove.None)).ToList();
 
-            _damageData = this.Where(x => x.GetDstInstid() != 0 && x.IsStateChange() == ParseEnum.StateChange.Normal && x.GetIFF() == ParseEnum.IFF.Foe && x.IsBuffremove() == ParseEnum.BuffRemove.None &&
-                                        ((x.IsBuff() == 1 && x.GetBuffDmg() > 0 && x.GetValue() == 0) ||
-                                        (x.IsBuff() == 0 && x.GetValue() > 0))).ToList();
+            _damageData = this.Where(x => x.DstInstid != 0 && x.IsStateChange == ParseEnum.StateChange.Normal && x.IFF == ParseEnum.IFF.Foe && x.IsBuffRemove == ParseEnum.BuffRemove.None &&
+                                        ((x.IsBuff == 1 && x.BuffDmg > 0 && x.Value == 0) ||
+                                        (x.IsBuff == 0 && x.Value > 0))).ToList();
 
-            _damageTakenData = this.Where(x => x.IsStateChange() == ParseEnum.StateChange.Normal && x.IsBuffremove() == ParseEnum.BuffRemove.None &&
-                                            ((x.IsBuff() == 1 && x.GetBuffDmg() >= 0 && x.GetValue() == 0) ||
-                                                (x.IsBuff() == 0 && x.GetValue() >= 0))).ToList();
+            _damageTakenData = this.Where(x => x.IsStateChange == ParseEnum.StateChange.Normal && x.IsBuffRemove == ParseEnum.BuffRemove.None &&
+                                            ((x.IsBuff == 1 && x.BuffDmg >= 0 && x.Value == 0) ||
+                                                (x.IsBuff == 0 && x.Value >= 0))).ToList();
 
-            _castData = this.Where(x => (x.IsStateChange() == ParseEnum.StateChange.Normal && x.IsActivation() != ParseEnum.Activation.None) || x.IsStateChange() == ParseEnum.StateChange.WeaponSwap).ToList();
+            _castData = this.Where(x => (x.IsStateChange == ParseEnum.StateChange.Normal && x.IsActivation != ParseEnum.Activation.None) || x.IsStateChange == ParseEnum.StateChange.WeaponSwap).ToList();
 
-            _movementData = (bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Fractal || bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Raid) ? this.Where(x => x.IsStateChange() == ParseEnum.StateChange.Position || x.IsStateChange() == ParseEnum.StateChange.Velocity).ToList() : new List<CombatItem>();
+            _movementData = (bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Fractal || bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Raid) ? this.Where(x => x.IsStateChange == ParseEnum.StateChange.Position || x.IsStateChange == ParseEnum.StateChange.Velocity).ToList() : new List<CombatItem>();
 
             /*healing_data = this.Where(x => x.getDstInstid() != 0 && x.isStateChange() == ParseEnum.StateChange.Normal && x.getIFF() == ParseEnum.IFF.Friend && x.isBuffremove() == ParseEnum.BuffRemove.None &&
                                          ((x.isBuff() == 1 && x.getBuffDmg() > 0 && x.getValue() == 0) ||

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -18,15 +18,17 @@ namespace LuckParser.Models.ParseModels
 
         public List<CombatItem> GetStates(int srcInstid, ParseEnum.StateChange change, long start, long end)
         {
-            List<CombatItem> states = new List<CombatItem>();
-            foreach (CombatItem c in this.Where(x => x.GetTime() >= start && x.GetTime() <= end))
+            var list = new List<CombatItem>();
+            foreach (var combatItem in this)
             {
-                if (c.GetSrcInstid() == srcInstid && c.IsStateChange() == change)
+                if (combatItem.GetTime() >= start && combatItem.GetTime() <= end &&
+                    combatItem.GetSrcInstid() == srcInstid && combatItem.IsStateChange() == change)
                 {
-                    states.Add(c);
+                    list.Add(combatItem);
                 }
             }
-            return states;
+
+            return list;
         }
 
         public int GetSkillCount(int srcInstid, int skillId, long start, long end)

--- a/LuckParser/Models/ParseModels/CombatItem.cs
+++ b/LuckParser/Models/ParseModels/CombatItem.cs
@@ -4,188 +4,57 @@ namespace LuckParser.Models.ParseModels
 {
     public class CombatItem
     {
+        public long Time { get; }
+        public ulong SrcAgent { get; set; }
+        public ulong DstAgent { get; set; }
+        public int Value { get; }
+        public int BuffDmg { get; }
+        public uint OverstackValue { get; }
+        public long SkillID { get; }
+        public ushort SrcInstid { get; set; }
+        public ushort DstInstid { get; set; }
+        public ushort SrcMasterInstid { get; }
+        public ushort DstMasterInstid { get; }
+        public ParseEnum.IFF IFF { get; }
+        public ushort IsBuff { get; }
+        public ParseEnum.Result Result { get; }
+        public ParseEnum.Activation IsActivation { get; }
+        public ParseEnum.BuffRemove IsBuffRemove { get; }
+        public ushort IsNinety { get; }
+        public ushort IsFifty { get; }
+        public ushort IsMoving { get; }
+        public ParseEnum.StateChange IsStateChange { get; }
+        public ushort IsFlanking { get; }
+        public ushort IsShields { get; }
 
-        // Fields
-        private readonly long _time;
-        private ulong _srcAgent;
-        private ulong _dstAgent;
-        private readonly int _value;
-        private readonly int _buffDmg;
-        private readonly uint _overstackValue;
-        private readonly long _skillId;
-        private ushort _srcInstid;
-        private ushort _dstInstid;
-        private readonly ushort _srcMasterInstid;
-        private readonly ushort _dstMasterInstid;
-        private readonly ParseEnum.IFF _iff;
-        private readonly ushort _isBuff;
-        private readonly ParseEnum.Result _result;
-        private readonly ParseEnum.Activation _isActivation;
-        private readonly ParseEnum.BuffRemove _isBuffRemove;
-        private readonly ushort _isNinety;
-        private readonly ushort _isFifty;
-        private readonly ushort _isMoving;
-        private readonly ParseEnum.StateChange _isStateChange;
-        private readonly ushort _isFlanking;
-        private readonly ushort _isShields;
-        // Constructor        
+        // Constructor
         public CombatItem(long time, ulong srcAgent, ulong dstAgent, int value, int buffDmg, uint overstackValue,
                long skillId, ushort srcInstid, ushort dstInstid, ushort srcMasterInstid, ushort dstMasterInstid, ParseEnum.IFF iff, ushort isBuff, ParseEnum.Result result,
                ParseEnum.Activation isActivation, ParseEnum.BuffRemove isBuffRemove, ushort isNinety, ushort isFifty, ushort isMoving,
                ParseEnum.StateChange isStateChange, ushort isFlanking, ushort isShields)
         {
-            _time = time;
-            _srcAgent = srcAgent;
-            _dstAgent = dstAgent;
-            _value = value;
-            _buffDmg = buffDmg;
-            _overstackValue = overstackValue;
-            _skillId = skillId;
-            _srcInstid = srcInstid;
-            _dstInstid = dstInstid;
-            _srcMasterInstid = srcMasterInstid;
-            _dstMasterInstid = dstMasterInstid;
-            _iff = iff;
-            _isBuff = isBuff;
-            _result = result;
-            _isActivation = isActivation;
-            _isBuffRemove = isBuffRemove;
-            _isNinety = isNinety;
-            _isFifty = isFifty;
-            _isMoving = isMoving;
-            _isStateChange = isStateChange;
-            _isFlanking = isFlanking;
-            _isShields = isShields;
-        }
-
-        // Getters
-        public long GetTime()
-        {
-            return _time;
-        }
-
-        public ulong GetSrcAgent()
-        {
-            return _srcAgent;
-        }
-
-        public ulong GetDstAgent()
-        {
-            return _dstAgent;
-        }
-
-        public int GetValue()
-        {
-            return _value;
-        }
-
-        public int GetBuffDmg()
-        {
-            return _buffDmg;
-        }
-
-        public uint GetOverstackValue()
-        {
-            return _overstackValue;
-        }
-
-        public long GetSkillID()
-        {
-            return _skillId;
-        }
-
-        public ushort GetSrcInstid()
-        {
-            return _srcInstid;
-        }
-
-        public ushort GetDstInstid()
-        {
-            return _dstInstid;
-        }
-
-        public ushort GetSrcMasterInstid()
-        {
-            return _srcMasterInstid;
-        }
-
-        public ushort GetDstMasterInstid()
-        {
-            return _dstMasterInstid;
-        }
-
-        public ParseEnum.IFF GetIFF()
-        {
-            return _iff;
-        }
-
-        public ushort IsBuff()
-        {
-            return _isBuff;
-        }
-
-        public ParseEnum.Result GetResult()
-        {
-            return _result;
-        }
-
-        public ParseEnum.Activation IsActivation()
-        {
-            return _isActivation;
-        }
-
-        public ParseEnum.BuffRemove IsBuffremove()
-        {
-            return _isBuffRemove;
-        }
-
-        public ushort IsNinety()
-        {
-            return _isNinety;
-        }
-
-        public ushort IsFifty()
-        {
-            return _isFifty;
-        }
-
-        public ushort IsMoving()
-        {
-            return _isMoving;
-        }
-
-        public ushort IsFlanking()
-        {
-            return _isFlanking;
-        }
-
-        public ParseEnum.StateChange IsStateChange()
-        {
-            return _isStateChange;
-        }
-        public ushort IsShields()
-        {
-            return _isShields;
-        }
-        // Setters
-        public void SetSrcAgent(ulong srcAgent)
-        {
-            _srcAgent = srcAgent;
-        }
-
-        public void SetDstAgent(ulong dstAgent)
-        {
-            _dstAgent = dstAgent;
-        }
-
-        public void SetSrcInstid(ushort srcInstid)
-        {
-            _srcInstid = srcInstid;
-        }
-
-        public void SetDstInstid(ushort dstInstid)
-        {
-            _dstInstid = dstInstid;
+            Time = time;
+            SrcAgent = srcAgent;
+            DstAgent = dstAgent;
+            Value = value;
+            BuffDmg = buffDmg;
+            OverstackValue = overstackValue;
+            SkillID = skillId;
+            SrcInstid = srcInstid;
+            DstInstid = dstInstid;
+            SrcMasterInstid = srcMasterInstid;
+            DstMasterInstid = dstMasterInstid;
+            IFF = iff;
+            IsBuff = isBuff;
+            Result = result;
+            IsActivation = isActivation;
+            IsBuffRemove = isBuffRemove;
+            IsNinety = isNinety;
+            IsFifty = isFifty;
+            IsMoving = isMoving;
+            IsStateChange = isStateChange;
+            IsFlanking = isFlanking;
+            IsShields = isShields;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/Logs/DamageLog.cs
+++ b/LuckParser/Models/ParseModels/Logs/DamageLog.cs
@@ -24,18 +24,18 @@ namespace LuckParser.Models.ParseModels
         protected DamageLog(long time, CombatItem c)
         {
             _time = time;
-            _skillId = c.GetSkillID();
-            _buff = c.IsBuff();
-            _result = c.GetResult();
-            _isNinety = c.IsNinety();
-            _isMoving = c.IsMoving();
-            _isFlanking = c.IsFlanking();
-            _isActivation = c.IsActivation();
-            _srcAgent = c.GetSrcAgent();
-            _srcInstid = c.GetSrcInstid();
-            _isShields = c.IsShields();
-            _dstAgent = c.GetDstAgent();
-            _dstInstid = c.GetDstInstid();
+            _skillId = c.SkillID;
+            _buff = c.IsBuff;
+            _result = c.Result;
+            _isNinety = c.IsNinety;
+            _isMoving = c.IsMoving;
+            _isFlanking = c.IsFlanking;
+            _isActivation = c.IsActivation;
+            _srcAgent = c.SrcAgent;
+            _srcInstid = c.SrcInstid;
+            _isShields = c.IsShields;
+            _dstAgent = c.DstAgent;
+            _dstInstid = c.DstInstid;
 
         }
         // Getters

--- a/LuckParser/Models/ParseModels/Logs/DamageLogCondition.cs
+++ b/LuckParser/Models/ParseModels/Logs/DamageLogCondition.cs
@@ -6,7 +6,7 @@
         // Constructor
         public DamageLogCondition(long time, CombatItem c) : base(time, c)
         {
-            Damage = c.GetBuffDmg();
+            Damage = c.BuffDmg;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/Logs/DamageLogPower.cs
+++ b/LuckParser/Models/ParseModels/Logs/DamageLogPower.cs
@@ -6,7 +6,7 @@
         // Constructor
         public DamageLogPower(long time, CombatItem c) : base(time, c)
         {
-            Damage =  c.GetValue();
+            Damage =  c.Value;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -103,10 +103,10 @@ namespace LuckParser.Models.ParseModels
                 SetCombatReplayIcon(log);
                 if (trim)
                 {
-                    CombatItem test = log.GetCombatList().FirstOrDefault(x => x.GetSrcAgent() == Agent.GetAgent() && (x.IsStateChange().IsDead() || x.IsStateChange().IsDespawn()));
+                    CombatItem test = log.GetCombatList().FirstOrDefault(x => x.SrcAgent == Agent.GetAgent() && (x.IsStateChange.IsDead() || x.IsStateChange.IsDespawn()));
                     if (test != null)
                     {
-                        Replay.Trim(Agent.GetFirstAware() - log.GetBossData().GetFirstAware(), test.GetTime() - log.GetBossData().GetFirstAware());
+                        Replay.Trim(Agent.GetFirstAware() - log.GetBossData().GetFirstAware(), test.Time - log.GetBossData().GetFirstAware());
                     }
                     else
                     {
@@ -124,10 +124,10 @@ namespace LuckParser.Models.ParseModels
         public long GetDeath(ParsedLog log, long start, long end)
         {
             long offset = log.GetBossData().GetFirstAware();
-            CombatItem dead = log.GetCombatList().LastOrDefault(x => x.GetSrcInstid() == Agent.GetInstid() && x.IsStateChange().IsDead() && x.GetTime() >= start + offset && x.GetTime() <= end + offset);
-            if (dead != null && dead.GetTime() > 0)
+            CombatItem dead = log.GetCombatList().LastOrDefault(x => x.SrcInstid == Agent.GetInstid() && x.IsStateChange.IsDead() && x.Time >= start + offset && x.Time <= end + offset);
+            if (dead != null && dead.Time > 0)
             {
-                return dead.GetTime();
+                return dead.Time;
             }
             return 0;
         }
@@ -147,38 +147,38 @@ namespace LuckParser.Models.ParseModels
             tableIds.AddRange(Boon.GetCondiBoonList().Select(x => x.GetID()));
             foreach (CombatItem c in log.GetBoonData())
             {
-                if (!boonMap.ContainsKey(c.GetSkillID()))
+                if (!boonMap.ContainsKey(c.SkillID))
                 {
                     continue;
                 }
-                long time = c.GetTime() - timeStart;
-                ushort dst = c.IsBuffremove() == ParseEnum.BuffRemove.None ? c.GetDstInstid() : c.GetSrcInstid();
+                long time = c.Time - timeStart;
+                ushort dst = c.IsBuffRemove == ParseEnum.BuffRemove.None ? c.DstInstid : c.SrcInstid;
                 if (Agent.GetInstid() == dst)
                 {
                     // don't add buff initial table boons and buffs in non golem mode, for others overstack is irrevelant
-                    if (c.IsStateChange() == ParseEnum.StateChange.BuffInitial && (log.IsBenchmarkMode() || !tableIds.Contains(c.GetSkillID())))
+                    if (c.IsStateChange == ParseEnum.StateChange.BuffInitial && (log.IsBenchmarkMode() || !tableIds.Contains(c.SkillID)))
                     {
-                        List<BoonLog> loglist = boonMap[c.GetSkillID()];
+                        List<BoonLog> loglist = boonMap[c.SkillID];
                         loglist.Add(new BoonLog(0, 0, long.MaxValue, 0));
                     }
                     else if (time >= 0 && time < log.GetBossData().GetAwareDuration())
                     {
-                        if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                        if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                         {
-                            ushort src = c.GetSrcMasterInstid() > 0 ? c.GetSrcMasterInstid() : c.GetSrcInstid();
-                            List<BoonLog> loglist = boonMap[c.GetSkillID()];
+                            ushort src = c.SrcMasterInstid > 0 ? c.SrcMasterInstid : c.SrcInstid;
+                            List<BoonLog> loglist = boonMap[c.SkillID];
 
-                            if (loglist.Count == 0 && c.GetOverstackValue() > 0)
+                            if (loglist.Count == 0 && c.OverstackValue > 0)
                             {
                                 loglist.Add(new BoonLog(0, 0, time, 0));
                             }
-                            loglist.Add(new BoonLog(time, src, c.GetValue(), 0));
+                            loglist.Add(new BoonLog(time, src, c.Value, 0));
                         }
-                        else if (Boon.RemovePermission(c.GetSkillID(), c.IsBuffremove(), c.GetIFF()) && time < log.GetBossData().GetAwareDuration() - 50)
+                        else if (Boon.RemovePermission(c.SkillID, c.IsBuffRemove, c.IFF) && time < log.GetBossData().GetAwareDuration() - 50)
                         {
-                            if (c.IsBuffremove() == ParseEnum.BuffRemove.All)//All
+                            if (c.IsBuffRemove == ParseEnum.BuffRemove.All)//All
                             {
-                                List<BoonLog> loglist = boonMap[c.GetSkillID()];
+                                List<BoonLog> loglist = boonMap[c.SkillID];
                                 if (loglist.Count == 0)
                                 {
                                     loglist.Add(new BoonLog(0, 0, time, 0));
@@ -198,9 +198,9 @@ namespace LuckParser.Models.ParseModels
                                     }
                                 }
                             }
-                            else if (c.IsBuffremove() == ParseEnum.BuffRemove.Single)//Single
+                            else if (c.IsBuffRemove == ParseEnum.BuffRemove.Single)//Single
                             {
-                                List<BoonLog> loglist = boonMap[c.GetSkillID()];
+                                List<BoonLog> loglist = boonMap[c.SkillID];
                                 if (loglist.Count == 0)
                                 {
                                     loglist.Add(new BoonLog(0, 0, time, 0));
@@ -218,9 +218,9 @@ namespace LuckParser.Models.ParseModels
                                     }
                                 }
                             }
-                            else if (c.IsBuffremove() == ParseEnum.BuffRemove.Manual)//Manuel
+                            else if (c.IsBuffRemove == ParseEnum.BuffRemove.Manual)//Manuel
                             {
-                                List<BoonLog> loglist = boonMap[c.GetSkillID()];
+                                List<BoonLog> loglist = boonMap[c.SkillID];
                                 if (loglist.Count == 0)
                                 {
                                     loglist.Add(new BoonLog(0, 0, time, 0));
@@ -252,21 +252,21 @@ namespace LuckParser.Models.ParseModels
         {
             foreach (CombatItem c in log.GetMovementData())
             {
-                if (c.GetSrcInstid() != Agent.GetInstid())
+                if (c.SrcInstid != Agent.GetInstid())
                 {
                     continue;
                 }
-                long time = c.GetTime() - log.GetBossData().GetFirstAware();
-                byte[] xy = BitConverter.GetBytes(c.GetDstAgent());
+                long time = c.Time - log.GetBossData().GetFirstAware();
+                byte[] xy = BitConverter.GetBytes(c.DstAgent);
                 float x = BitConverter.ToSingle(xy, 0);
                 float y = BitConverter.ToSingle(xy, 4);
-                if (c.IsStateChange() == ParseEnum.StateChange.Position)
+                if (c.IsStateChange == ParseEnum.StateChange.Position)
                 {
-                    Replay.AddPosition(new Point3D(x, y, c.GetValue(), time));
+                    Replay.AddPosition(new Point3D(x, y, c.Value, time));
                 }
                 else
                 {
-                    Replay.AddVelocity(new Point3D(x, y, c.GetValue(), time));
+                    Replay.AddVelocity(new Point3D(x, y, c.Value, time));
                 }
             }
         }
@@ -489,9 +489,9 @@ namespace LuckParser.Models.ParseModels
             long timeStart = log.GetBossData().GetFirstAware();
             foreach (CombatItem c in log.GetDamageData())
             {
-                if (Agent.GetInstid() == c.GetSrcInstid() && c.GetTime() > log.GetBossData().GetFirstAware() && c.GetTime() < log.GetBossData().GetLastAware())//selecting player or minion as caster
+                if (Agent.GetInstid() == c.SrcInstid && c.Time > log.GetBossData().GetFirstAware() && c.Time < log.GetBossData().GetLastAware())//selecting player or minion as caster
                 {
-                    long time = c.GetTime() - timeStart;
+                    long time = c.Time - timeStart;
                     AddDamageLog(time, c);
                 }
             }
@@ -508,28 +508,28 @@ namespace LuckParser.Models.ParseModels
             CastLog curCastLog = null;
             foreach (CombatItem c in log.GetCastData())
             {
-                if (!(c.GetTime() > log.GetBossData().GetFirstAware() && c.GetTime() < log.GetBossData().GetLastAware()))
+                if (!(c.Time > log.GetBossData().GetFirstAware() && c.Time < log.GetBossData().GetLastAware()))
                 {
                     continue;
                 }
-                ParseEnum.StateChange state = c.IsStateChange();
+                ParseEnum.StateChange state = c.IsStateChange;
                 if (state == ParseEnum.StateChange.Normal)
                 {
-                    if (Agent.GetInstid() == c.GetSrcInstid())//selecting player as caster
+                    if (Agent.GetInstid() == c.SrcInstid)//selecting player as caster
                     {
-                        if (c.IsActivation().IsCasting())
+                        if (c.IsActivation.IsCasting())
                         {
-                            long time = c.GetTime() - timeStart;
-                            curCastLog = new CastLog(time, c.GetSkillID(), c.GetValue(), c.IsActivation());
+                            long time = c.Time - timeStart;
+                            curCastLog = new CastLog(time, c.SkillID, c.Value, c.IsActivation);
                             CastLogs.Add(curCastLog);
                         }
                         else
                         {
                             if (curCastLog != null)
                             {
-                                if (curCastLog.GetID() == c.GetSkillID())
+                                if (curCastLog.GetID() == c.SkillID)
                                 {
-                                    curCastLog.SetEndStatus(c.GetValue(), c.IsActivation());
+                                    curCastLog.SetEndStatus(c.Value, c.IsActivation);
                                     curCastLog = null;
                                 }
                             }
@@ -539,12 +539,12 @@ namespace LuckParser.Models.ParseModels
                 }
                 else if (state == ParseEnum.StateChange.WeaponSwap)
                 {//Weapon swap
-                    if (Agent.GetInstid() == c.GetSrcInstid())//selecting player as caster
+                    if (Agent.GetInstid() == c.SrcInstid)//selecting player as caster
                     {
-                        if ((int)c.GetDstAgent() == 4 || (int)c.GetDstAgent() == 5)
+                        if ((int)c.DstAgent == 4 || (int)c.DstAgent == 5)
                         {
-                            long time = c.GetTime() - timeStart;
-                            CastLog swapLog = new CastLog(time, -2, (int)c.GetDstAgent(), c.IsActivation());
+                            long time = c.Time - timeStart;
+                            CastLog swapLog = new CastLog(time, -2, (int)c.DstAgent, c.IsActivation);
                             CastLogs.Add(swapLog);
                         }
                     }

--- a/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
@@ -139,17 +139,17 @@ namespace LuckParser.Models.ParseModels
         // privates
         protected void AddDamageLog(long time, CombatItem c)
         {
-            if (c.IsBuffremove() == ParseEnum.BuffRemove.None)
+            if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
             {
-                if (c.IsBuff() == 1 && c.GetBuffDmg() != 0)//condi
+                if (c.IsBuff == 1 && c.BuffDmg != 0)//condi
                 {
                     DamageLogs.Add(new DamageLogCondition(time, c));
                 }
-                else if (c.IsBuff() == 0 && c.GetValue() != 0)//power
+                else if (c.IsBuff == 0 && c.Value != 0)//power
                 {
                     DamageLogs.Add(new DamageLogPower(time, c));
                 }
-                else if (c.GetResult() == ParseEnum.Result.Absorb || c.GetResult() == ParseEnum.Result.Blind || c.GetResult() == ParseEnum.Result.Interrupt)
+                else if (c.Result == ParseEnum.Result.Absorb || c.Result == ParseEnum.Result.Blind || c.Result == ParseEnum.Result.Interrupt)
                 {//Hits that where blinded, invulned, interupts
                     DamageLogs.Add(new DamageLogPower(time, c));
                 }
@@ -158,13 +158,13 @@ namespace LuckParser.Models.ParseModels
         }
         protected void AddDamageTakenLog(long time, CombatItem c)
         {
-            if (c.IsBuff() == 1 && c.GetBuffDmg() != 0)
+            if (c.IsBuff == 1 && c.BuffDmg != 0)
             {
                 //inco,ing condi dmg not working or just not present?
                 // damagetaken.Add(c.getBuffDmg());
                 _damageTakenlogs.Add(new DamageLogCondition(time, c));
             }
-            else if (c.IsBuff() == 0 && c.GetValue() >= 0)
+            else if (c.IsBuff == 0 && c.Value >= 0)
             {
                 _damageTakenlogs.Add(new DamageLogPower(time, c));
 

--- a/LuckParser/Models/ParseModels/Players/Boss.cs
+++ b/LuckParser/Models/ParseModels/Players/Boss.cs
@@ -106,38 +106,38 @@ namespace LuckParser.Models.ParseModels
                 Mechanic.SpecialCondition condition = m.GetSpecialCondition();
                 foreach (CombatItem c in log.GetBoonData())
                 {
-                    if (m.GetSkill() == c.GetSkillID())
+                    if (m.GetSkill() == c.SkillID)
                     {
-                        if (condition != null && !condition(c.GetValue()))
+                        if (condition != null && !condition(c.Value))
                         {
                             continue;
                         }
                         AbstractMasterPlayer amp = null;
-                        if (m.GetMechType() == Mechanic.MechType.EnemyBoon && c.IsBuffremove() == ParseEnum.BuffRemove.None)
+                        if (m.GetMechType() == Mechanic.MechType.EnemyBoon && c.IsBuffRemove == ParseEnum.BuffRemove.None)
                         {
-                            if (c.GetDstInstid() == bossData.GetInstid())
+                            if (c.DstInstid == bossData.GetInstid())
                             {
                                 amp = this;
                             }
                             else
                             {
-                                amp = new Mob(log.GetAgentData().GetAgent(c.GetDstAgent()));
+                                amp = new Mob(log.GetAgentData().GetAgent(c.DstAgent));
                             }
-                        } else if (m.GetMechType() == Mechanic.MechType.EnemyBoonStrip && c.IsBuffremove() == ParseEnum.BuffRemove.Manual)
+                        } else if (m.GetMechType() == Mechanic.MechType.EnemyBoonStrip && c.IsBuffRemove == ParseEnum.BuffRemove.Manual)
                         {
-                            if (c.GetSrcInstid() == bossData.GetInstid())
+                            if (c.SrcInstid == bossData.GetInstid())
                             {
                                 amp = this;
                             }
                             else
                             {
-                                amp = new Mob(log.GetAgentData().GetAgent(c.GetSrcAgent()));
+                                amp = new Mob(log.GetAgentData().GetAgent(c.SrcAgent));
                             }
 
                         }
                         if (amp != null)
                         {
-                            mechData[m].Add(new MechanicLog(c.GetTime() - bossData.GetFirstAware(), m, amp));
+                            mechData[m].Add(new MechanicLog(c.Time - bossData.GetFirstAware(), m, amp));
                         }
                     }
                 }
@@ -150,27 +150,27 @@ namespace LuckParser.Models.ParseModels
                 foreach (CombatItem c in log.GetCastData())
                 {
                     long skill = m.GetSkill();
-                    if (skill == c.GetSkillID())
+                    if (skill == c.SkillID)
                     {
-                        if (condition != null && !condition(c.GetValue()))
+                        if (condition != null && !condition(c.Value))
                         {
                             continue;
                         }
                         AbstractMasterPlayer amp = null;
-                        if ((m.GetMechType() == Mechanic.MechType.EnemyCastStart && c.IsActivation().IsCasting()) || (m.GetMechType() == Mechanic.MechType.EnemyCastEnd && !c.IsActivation().IsCasting()))
+                        if ((m.GetMechType() == Mechanic.MechType.EnemyCastStart && c.IsActivation.IsCasting()) || (m.GetMechType() == Mechanic.MechType.EnemyCastEnd && !c.IsActivation.IsCasting()))
                         {
-                            if (c.GetSrcInstid() == bossData.GetInstid())
+                            if (c.SrcInstid == bossData.GetInstid())
                             {
                                 amp = this;
                             }
                             else
                             {
-                                amp = new DummyPlayer(log.GetAgentData().GetAgent(c.GetSrcAgent()));
+                                amp = new DummyPlayer(log.GetAgentData().GetAgent(c.SrcAgent));
                             }
                         }
                         if (amp != null)
                         {
-                            mechData[m].Add(new MechanicLog(c.GetTime() - bossData.GetFirstAware(), m, amp));
+                            mechData[m].Add(new MechanicLog(c.Time - bossData.GetFirstAware(), m, amp));
                         }
                     }
                 }

--- a/LuckParser/Models/ParseModels/Players/Minion.cs
+++ b/LuckParser/Models/ParseModels/Players/Minion.cs
@@ -17,9 +17,9 @@ namespace LuckParser.Models.ParseModels
             long maxTime = Math.Min(log.GetBossData().GetLastAware(), Agent.GetLastAware());
             foreach (CombatItem c in log.GetDamageData())
             {
-                if (Agent.GetInstid() == c.GetSrcInstid() && c.GetTime() > minTime && c.GetTime() < maxTime)//selecting minion as caster
+                if (Agent.GetInstid() == c.SrcInstid && c.Time > minTime && c.Time < maxTime)//selecting minion as caster
                 {
-                    long time = c.GetTime() - timeStart;
+                    long time = c.Time - timeStart;
                     AddDamageLog(time, c);
                 }
             }
@@ -33,28 +33,28 @@ namespace LuckParser.Models.ParseModels
             long maxTime = Math.Min(log.GetBossData().GetLastAware(), Agent.GetLastAware());
             foreach (CombatItem c in log.GetCastData())
             {
-                if (!(c.GetTime() > minTime && c.GetTime() < maxTime))
+                if (!(c.Time > minTime && c.Time < maxTime))
                 {
                     continue;
                 }
-                ParseEnum.StateChange state = c.IsStateChange();
+                ParseEnum.StateChange state = c.IsStateChange;
                 if (state == ParseEnum.StateChange.Normal)
                 {
-                    if (Agent.GetInstid() == c.GetSrcInstid())//selecting player as caster
+                    if (Agent.GetInstid() == c.SrcInstid)//selecting player as caster
                     {
-                        if (c.IsActivation().IsCasting())
+                        if (c.IsActivation.IsCasting())
                         {
-                            long time = c.GetTime() - timeStart;
-                            curCastLog = new CastLog(time, c.GetSkillID(), c.GetValue(), c.IsActivation());
+                            long time = c.Time - timeStart;
+                            curCastLog = new CastLog(time, c.SkillID, c.Value, c.IsActivation);
                             CastLogs.Add(curCastLog);
                         }
                         else
                         {
                             if (curCastLog != null)
                             {
-                                if (curCastLog.GetID() == c.GetSkillID())
+                                if (curCastLog.GetID() == c.SkillID)
                                 {
-                                    curCastLog.SetEndStatus(c.GetValue(), c.IsActivation());
+                                    curCastLog.SetEndStatus(c.Value, c.IsActivation);
                                     curCastLog = null;
                                 }
                             }

--- a/LuckParser/Models/ParseModels/Players/Player.cs
+++ b/LuckParser/Models/ParseModels/Players/Player.cs
@@ -62,19 +62,19 @@ namespace LuckParser.Models.ParseModels
         public int[] GetCleanses(ParsedLog log, long start, long end) {
             long timeStart = log.GetBossData().GetFirstAware();
             int[] cleanse = { 0, 0 };
-            foreach (CombatItem c in log.GetCombatList().Where(x=>x.IsStateChange() == ParseEnum.StateChange.Normal && x.IsBuff() == 1 && x.GetTime() >= (start + timeStart) && x.GetTime() <= (end + timeStart)))
+            foreach (CombatItem c in log.GetCombatList().Where(x=>x.IsStateChange == ParseEnum.StateChange.Normal && x.IsBuff == 1 && x.Time >= (start + timeStart) && x.Time <= (end + timeStart)))
             {
-                if (c.IsActivation() == ParseEnum.Activation.None)
+                if (c.IsActivation == ParseEnum.Activation.None)
                 {
-                    if ((Agent.GetInstid() == c.GetDstInstid() || Agent.GetInstid() == c.GetDstMasterInstid()) && c.GetIFF() == ParseEnum.IFF.Friend && (c.IsBuffremove() != ParseEnum.BuffRemove.None))
+                    if ((Agent.GetInstid() == c.DstInstid || Agent.GetInstid() == c.DstMasterInstid) && c.IFF == ParseEnum.IFF.Friend && (c.IsBuffRemove != ParseEnum.BuffRemove.None))
                     {
-                        long time = c.GetTime() - timeStart;
+                        long time = c.Time - timeStart;
                         if (time > 0)
                         {
-                            if (Boon.GetCondiBoonList().Exists(x=>x.GetID() == c.GetSkillID()))
+                            if (Boon.GetCondiBoonList().Exists(x=>x.GetID() == c.SkillID))
                             {
                                 cleanse[0]++;
-                                cleanse[1] += c.GetBuffDmg();
+                                cleanse[1] += c.BuffDmg;
                             }
                         }
                     }
@@ -225,8 +225,8 @@ namespace LuckParser.Models.ParseModels
         {
             long timeStart = log.GetBossData().GetFirstAware();               
             foreach (CombatItem c in log.GetDamageTakenData()) {
-                if (Agent.GetInstid() == c.GetDstInstid() && c.GetTime() > log.GetBossData().GetFirstAware() && c.GetTime() < log.GetBossData().GetLastAware()) {//selecting player as target
-                    long time = c.GetTime() - timeStart;
+                if (Agent.GetInstid() == c.DstInstid && c.Time > log.GetBossData().GetFirstAware() && c.Time < log.GetBossData().GetLastAware()) {//selecting player as target
+                    long time = c.Time - timeStart;
                     AddDamageTakenLog(time, c);
                 }
             }
@@ -239,17 +239,17 @@ namespace LuckParser.Models.ParseModels
             long fightDuration = log.GetBossData().GetLastAware() - timeStart;
             foreach (CombatItem c in log.GetBoonData())
             {
-                if ( c.IsBuffremove() != ParseEnum.BuffRemove.None || (c.IsBuff() != 18 && c.IsBuff() != 1) || Agent.GetInstid() != c.GetDstInstid())
+                if ( c.IsBuffRemove != ParseEnum.BuffRemove.None || (c.IsBuff != 18 && c.IsBuff != 1) || Agent.GetInstid() != c.DstInstid)
                 {
                     continue;
                 }
-                var food = foodBoon.FirstOrDefault(x => x.GetID() == c.GetSkillID());
-                var utility = utilityBoon.FirstOrDefault(x => x.GetID() == c.GetSkillID());
+                var food = foodBoon.FirstOrDefault(x => x.GetID() == c.SkillID);
+                var utility = utilityBoon.FirstOrDefault(x => x.GetID() == c.SkillID);
                 if (food == null && utility == null)
                 {
                     continue;
                 }
-                long time = c.GetTime() - timeStart;
+                long time = c.Time - timeStart;
                 if (time <= fightDuration)
                 {
                     _consumeList.Add(new Tuple<Boon, long>(food ?? utility, time)); 
@@ -265,7 +265,7 @@ namespace LuckParser.Models.ParseModels
             status.AddRange(log.GetCombatData().GetStates(GetInstid(), ParseEnum.StateChange.ChangeDead, log.GetBossData().GetFirstAware(), log.GetBossData().GetLastAware()));
             status.AddRange(log.GetCombatData().GetStates(GetInstid(), ParseEnum.StateChange.Spawn, log.GetBossData().GetFirstAware(), log.GetBossData().GetLastAware()));
             status.AddRange(log.GetCombatData().GetStates(GetInstid(), ParseEnum.StateChange.Despawn, log.GetBossData().GetFirstAware(), log.GetBossData().GetLastAware()));
-            status = status.OrderBy(x => x.GetTime()).ToList();
+            status = status.OrderBy(x => x.Time).ToList();
             List<Tuple<long, long>> dead = new List<Tuple<long, long>>();
             List<Tuple<long, long>> down = new List<Tuple<long, long>>();
             List<Tuple<long, long>> dc = new List<Tuple<long, long>>();
@@ -273,32 +273,32 @@ namespace LuckParser.Models.ParseModels
             {
                 CombatItem cur = status[i];
                 CombatItem next = status[i + 1];
-                if (cur.IsStateChange().IsDown())
+                if (cur.IsStateChange.IsDown())
                 {
-                    down.Add(new Tuple<long, long>(cur.GetTime() - log.GetBossData().GetFirstAware(), next.GetTime() - log.GetBossData().GetFirstAware()));
-                } else if (cur.IsStateChange().IsDead())
+                    down.Add(new Tuple<long, long>(cur.Time - log.GetBossData().GetFirstAware(), next.Time - log.GetBossData().GetFirstAware()));
+                } else if (cur.IsStateChange.IsDead())
                 {
-                    dead.Add(new Tuple<long, long>(cur.GetTime() - log.GetBossData().GetFirstAware(), next.GetTime() - log.GetBossData().GetFirstAware()));
-                } else if (cur.IsStateChange().IsDespawn())
+                    dead.Add(new Tuple<long, long>(cur.Time - log.GetBossData().GetFirstAware(), next.Time - log.GetBossData().GetFirstAware()));
+                } else if (cur.IsStateChange.IsDespawn())
                 {
-                    dc.Add(new Tuple<long, long>(cur.GetTime() - log.GetBossData().GetFirstAware(), next.GetTime() - log.GetBossData().GetFirstAware()));
+                    dc.Add(new Tuple<long, long>(cur.Time - log.GetBossData().GetFirstAware(), next.Time - log.GetBossData().GetFirstAware()));
                 }
             }
             // check last value
             if (status.Count > 0)
             {
                 CombatItem cur = status.Last();
-                if (cur.IsStateChange().IsDown())
+                if (cur.IsStateChange.IsDown())
                 {
-                    down.Add(new Tuple<long, long>(cur.GetTime() - log.GetBossData().GetFirstAware(), log.GetBossData().GetAwareDuration()));
+                    down.Add(new Tuple<long, long>(cur.Time - log.GetBossData().GetFirstAware(), log.GetBossData().GetAwareDuration()));
                 }
-                else if (cur.IsStateChange().IsDead())
+                else if (cur.IsStateChange.IsDead())
                 {
-                    dead.Add(new Tuple<long, long>(cur.GetTime() - log.GetBossData().GetFirstAware(), log.GetBossData().GetAwareDuration()));
+                    dead.Add(new Tuple<long, long>(cur.Time - log.GetBossData().GetFirstAware(), log.GetBossData().GetAwareDuration()));
                 }
-                else if (cur.IsStateChange().IsDespawn())
+                else if (cur.IsStateChange.IsDespawn())
                 {
-                    dc.Add(new Tuple<long, long>(cur.GetTime() - log.GetBossData().GetFirstAware(), log.GetBossData().GetAwareDuration()));
+                    dc.Add(new Tuple<long, long>(cur.Time - log.GetBossData().GetFirstAware(), log.GetBossData().GetAwareDuration()));
                 }
             }
             Replay.SetStatus(down, dead, dc);
@@ -332,12 +332,12 @@ namespace LuckParser.Models.ParseModels
                         toUse = combatData.GetStates(GetInstid(), ParseEnum.StateChange.ChangeDown, start, end);
                         break;
                     case 1066:
-                        toUse = log.GetCastData().Where(x => x.GetSkillID() == 1066 && x.GetSrcInstid() == GetInstid() && x.IsActivation().IsCasting()).ToList();
+                        toUse = log.GetCastData().Where(x => x.SkillID == 1066 && x.SrcInstid == GetInstid() && x.IsActivation.IsCasting()).ToList();
                         break;
                 }
                 foreach (CombatItem pnt in toUse)
                 {
-                    mechData[mech].Add(new MechanicLog(pnt.GetTime() - start, mech, this));
+                    mechData[mech].Add(new MechanicLog(pnt.Time - start, mech, this));
                 }
 
             }
@@ -367,25 +367,25 @@ namespace LuckParser.Models.ParseModels
                 Mechanic.SpecialCondition condition = mech.GetSpecialCondition();
                 foreach (CombatItem c in log.GetBoonData())
                 {
-                    if (condition != null && !condition(c.GetValue()))
+                    if (condition != null && !condition(c.Value))
                     {
                         continue;
                     }
                     if (mech.GetMechType() == Mechanic.MechType.PlayerBoonRemove)
                     {
-                        if (c.GetSkillID() == mech.GetSkill() && c.IsBuffremove() == ParseEnum.BuffRemove.Manual && GetInstid() == c.GetSrcInstid())
+                        if (c.SkillID == mech.GetSkill() && c.IsBuffRemove == ParseEnum.BuffRemove.Manual && GetInstid() == c.SrcInstid)
                         {
-                            mechData[mech].Add(new MechanicLog(c.GetTime() - start, mech, this));
+                            mechData[mech].Add(new MechanicLog(c.Time - start, mech, this));
                         }
                     } else
                     {
 
-                        if (c.GetSkillID() == mech.GetSkill() && c.IsBuffremove() == ParseEnum.BuffRemove.None && GetInstid() == c.GetDstInstid())
+                        if (c.SkillID == mech.GetSkill() && c.IsBuffRemove == ParseEnum.BuffRemove.None && GetInstid() == c.DstInstid)
                         {
-                            mechData[mech].Add(new MechanicLog(c.GetTime() - start, mech, this));
+                            mechData[mech].Add(new MechanicLog(c.Time - start, mech, this));
                             if (mech.GetMechType() == Mechanic.MechType.PlayerOnPlayer)
                             {
-                                mechData[mech].Add(new MechanicLog(c.GetTime() - start, mech, log.GetPlayerList().FirstOrDefault(x => x.GetInstid() == c.GetSrcInstid())));
+                                mechData[mech].Add(new MechanicLog(c.Time - start, mech, log.GetPlayerList().FirstOrDefault(x => x.GetInstid() == c.SrcInstid)));
                             }
                         }
                     }


### PR DESCRIPTION
Includes a change for CombatData that changes getters/setters into properties (as that apparently helps the compiler/JIT to optimize it better as well).

Includes a fix for duplicated boon ids from copy-paste mistakes (needed for a dictionary which requires unique skill ids)

Brings down total log processing time to ~83% of original, most improvements are in statistics generation (78% of original time)

Log	| Before (ms)	| GetStates optimized (ms)	|  CombatItem Properties (ms)	|SetPlayerBoons optimized (ms)
--- | --- | --- | --- | ---
cairn_20180809-052839	|1173.479	|1071.3064	|1018.0766	|949.0993
cairn_20180814-040825	|1139.8919	|1055.2094	|996.7005	|920.136
cairn_20180820-201521	|878.209	|813.2028	|774.5726	|713.4486
deimos_20180814-051155	|4420.4371	|4239.8768	|4105.6815	|3793.6144
deimos_20180821-000855	|4823.1289	|4459.9949	|4207.3441	|3851.7822
deimos_20180821-214256	|4242.0258	|3826.7553	|3658.0624	|3380.5514
dhuum_20180813-190655	|3957.9583	|3667.7938	|3460.0617	|3282.447
dhuum_20180821-024226	|4494.3554	|4239.9547	|3984.0434	|3749.703
dhuumcm_20180813-045358	|3771.4957	|3537.7284	|3338.321	|3146.1439
gorseval_20180807-010122	|3203.7422	|2991.9953	|2837.7855	|2682.4804
gorseval_20180813-105556	|2939.3652	|2625.0048	|2538.4232	|2387.4989
gorseval_20180821-203347	|3383.3457	|3118.5756	|3042.4097	|2832.0022
kc_20180807-050104	|3433.8174	|3257.8355	|3125.3202	|2943.1345
kc_20180814-033936	|4125.0955	|3875.1236	|3682.4597	|3458.5667
kc_20180821-003658	|4504.3317	|4169.4485	|3994.2165	|3789.9068
matt_20180817-054149	|4373.1702	|4101.2666	|4039.7088	|3726.8053
matt_20180821-015030	|5471.9062	|5253.6901	|4999.0323	|4696.7011
matt_20180822-215817	|6285.5241	|6020.1077	|5606.4318	|5331.549
mo_20180816-203538	|934.206	|876.6116	|832.6629	|767.2111
mo_20180819-174250	|1021.0612	|962.332	|918.5514	|860.9997
mo_20180820-202322	|1039.2315	|995.2919	|943.3747	|869.7492
sabetha_20180813-112032	|4974.406	|4705.8742	|4422.0585	|4172.7523
sabetha_20180817-044932	|4963.9244	|4760.4706	|4515.0608	|4329.5339
sabetha_20180821-210426	|5452.9707	|5371.0402	|4951.509	|4750.4955
samarog_20180814-042916	|4360.3985	|4236.6957	|3899.5267	|3716.4354
samarog_20180816-205700	|5761.201	|5523.8626	|5239.051	|4950.4988
samarog_20180820-233933	|3193.089	|2997.3576	|2850.615	|2650.6243
sh_20180806-095250	|2411.5156	|2261.6379	|2093.8042	|1940.8359
sh_20180807-212636	|1956.6099	|1820.1641	|1677.3868	|1560.8656
sh_20180814-054151	|2757.4396	|2643.5993	|2470.6831	|2304.6528
sloth_20180817-050944	|1290.0775	|1229.4549	|1127.0108	|1039.3227
sloth_20180821-012528	|988.3265	|906.6352	|863.4733	|794.9065
sloth_20180822-211108	|1280.4036	|1228.9624	|1109.8327	|1025.0684
vg_20180807-004529	|2788.8968	|2634.5437	|2458.1645	|2350.0541
vg_20180813-103904	|2682.627	|2540.6337	|2350.9403	|2232.2122
vg_20180820-213803	|3105.5177	|2940.3016	|2779.1675	|2614.2465
xera_20180807-051530	|2269.3049	|2084.7061	|1982.5673	|1878.2533
xera_20180814-040024	|3342.9901	|3191.0856	|2962.8863	|2802.4343
xera_20180821-011535	|2125.7065	|2039.7104	|1888.7679	|1787.313
Average | 3213.3636 | 3032.7138 | 2865.2755 | 2693.1804