### PR TITLE
Cleanup on BoonToTrack

### DIFF
--- a/LuckParser/Controllers/CSVBuilder.cs
+++ b/LuckParser/Controllers/CSVBuilder.cs
@@ -358,7 +358,7 @@ namespace LuckParser.Controllers
             foreach (Player player in _log.GetPlayerList())
             {
                 Dictionary<long, Statistics.FinalBoonUptime> boons = _statistics.SelfBoons[player][phaseIndex];
-                Dictionary<long, long> boonPresence = player.GetBoonPresence(_log, _statistics.Phases, listToUse, phaseIndex);
+                Dictionary<long, long> boonPresence = player.GetBoonPresence(_log, _statistics.Phases, phaseIndex);
                 double avgBoons = 0.0;
                 foreach (long duration in boonPresence.Values)
                 {
@@ -671,9 +671,7 @@ namespace LuckParser.Controllers
             List<PhaseData> phases = _statistics.Phases;
             long fightDuration = phases[phaseIndex].GetDuration();
             Dictionary<long, Statistics.FinalBossBoon> conditions = _statistics.BossConditions[phaseIndex];
-            List<Boon> boonToTrack = Boon.GetCondiBoonList();
-            boonToTrack.AddRange(Boon.GetBoonList());
-            Dictionary<long, long> condiPresence = boss.GetCondiPresence(_log, phases, boonToTrack, phaseIndex);
+            Dictionary<long, long> condiPresence = boss.GetCondiPresence(_log, phases, phaseIndex);
             double avgCondis = 0.0;
             foreach (long duration in condiPresence.Values)
             {
@@ -684,7 +682,7 @@ namespace LuckParser.Controllers
 
             WriteCell("Name");
             WriteCell("Avg");
-            foreach (Boon boon in Boon.GetCondiBoonList())
+            foreach (Boon boon in _statistics.PresentConditions)
             {
                 if (boon.GetName() == "Retaliation")
                 {
@@ -697,7 +695,7 @@ namespace LuckParser.Controllers
             int count = 0;
             WriteCell(boss.GetCharacter());
             WriteCell(Math.Round(avgCondis, 1).ToString());
-            foreach (Boon boon in Boon.GetCondiBoonList())
+            foreach (Boon boon in _statistics.PresentConditions)
             {
                 if (boon.GetName() == "Retaliation")
                 {
@@ -727,7 +725,7 @@ namespace LuckParser.Controllers
             Dictionary<long, Statistics.FinalBossBoon> conditions = _statistics.BossConditions[phaseIndex];
             WriteCell("Name");
             WriteCell("Avg");
-            foreach (Boon boon in Boon.GetBoonList())
+            foreach (Boon boon in _statistics.PresentBoons)
             {
                 WriteCell(boon.GetName());
             }
@@ -735,7 +733,7 @@ namespace LuckParser.Controllers
             NewLine();
             int count = 0;
             WriteCell(boss.GetCharacter());
-            foreach (Boon boon in Boon.GetBoonList())
+            foreach (Boon boon in _statistics.PresentBoons)
             {
                 if (boon.GetBoonType() == Boon.BoonType.Duration)
                 {
@@ -761,7 +759,7 @@ namespace LuckParser.Controllers
             //bool hasBoons = false;
             int count = 0;
             WriteCell("Name");
-            foreach (Boon boon in Boon.GetCondiBoonList())
+            foreach (Boon boon in _statistics.PresentConditions)
             {
                 if (boon.GetName() == "Retaliation")
                 {
@@ -774,7 +772,7 @@ namespace LuckParser.Controllers
             foreach (Player player in _log.GetPlayerList())
             {
                 WriteCell(player.GetCharacter());
-                foreach (Boon boon in Boon.GetCondiBoonList())
+                foreach (Boon boon in _statistics.PresentConditions)
                 {
                     if (boon.GetName() == "Retaliation")
                     {

--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -253,9 +253,9 @@ namespace LuckParser.Controllers
             sw.Write("</tfoot>");
         }
 
-        public static void WriteDamageDistTableCondi(StreamWriter sw, HashSet<long> usedIDs, List<DamageLog> damageLogs, int finalTotalDamage)
+        public static void WriteDamageDistTableCondi(StreamWriter sw, HashSet<long> usedIDs, List<DamageLog> damageLogs, int finalTotalDamage, List<Boon> presentConditions)
         {
-            foreach (Boon condi in Boon.GetCondiBoonList())
+            foreach (Boon condi in presentConditions)
             {
                 int totaldamage = 0;
                 int mindamage = 0;
@@ -340,7 +340,7 @@ namespace LuckParser.Controllers
                     sw.Write("<td>" + maxdamage + "</td>");
                     sw.Write("<td>" + (casts != -1 ? casts.ToString() : "") + "</td>");
                     sw.Write("<td>" + hits + "</td>");
-                    sw.Write("<td>" + (hpcast < 0 ? hpcast.ToString() : "") + "</td>");
+                    sw.Write("<td>" + (hpcast > 0 ? hpcast.ToString() : "") + "</td>");
 
                     sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + crit + " out of " + hits + " hits\">" + Math.Round(100 * (double)crit / hits, 2) + "%</span></td>");
                     sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + flank + " out of " + hits + " hits\">" + Math.Round(100 * (double)flank / hits, 2) + "%</span></td>");
@@ -362,7 +362,7 @@ namespace LuckParser.Controllers
                     sw.Write("<td>" + maxdamage + "</td>");
                     sw.Write("<td>" + (casts != -1 ? casts.ToString() : "") + "</td>");
                     sw.Write("<td>" + hits + "</td>");
-                    sw.Write("<td>" + (hpcast < 0 ? hpcast.ToString() : "") + "</td>");
+                    sw.Write("<td>" + (hpcast > 0 ? hpcast.ToString() : "") + "</td>");
                     sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + crit + " out of " + hits + " hits\">" + Math.Round(100 * (double)crit / hits,2) + "%</span></td>");
                     sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + flank + " out of " + hits + " hits\">" + Math.Round(100 * (double)flank / hits,2) + "%</span></td>");
                     sw.Write("<td>" + "<span data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + glance + " out of " + hits + " hits\">" + Math.Round(100 * (double)glance / hits,2) + "%</span></td>");

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -224,8 +224,8 @@ namespace LuckParser.Controllers
                     var name = ParseHelper.GetString(stream, 64);
                     if(skillId != 0 && int.TryParse(name, out int n) && n == skillId)
                     {
-                        //was it a known boon?
-                        foreach(Boon b in Boon.GetBoonList())
+                        //was it a known buff?
+                        foreach(Boon b in Boon.GetAll())
                         {
                             if(skillId == b.GetID())
                             {

--- a/LuckParser/Models/DataModels/Statistics.cs
+++ b/LuckParser/Models/DataModels/Statistics.cs
@@ -156,9 +156,9 @@ namespace LuckParser.Models.DataModels
 
         // present buff
         public readonly List<Boon> PresentBoons = new List<Boon>();//Used only for Boon tables
+        public readonly List<Boon> PresentConditions = new List<Boon>();//Used only for Condition tables
         public readonly List<Boon> PresentOffbuffs = new List<Boon>();//Used only for Off Buff tables
         public readonly List<Boon> PresentDefbuffs = new List<Boon>();//Used only for Def Buff tables
-        public readonly Dictionary<long, List<Boon>> PresentPersonnalBuffs = new Dictionary<long, List<Boon>>();//Used only for personnal
 
         //Positions for group
         public List<Point3D> StackCenterPositions;

--- a/LuckParser/Models/ParseModels/Boons/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boons/Boon.cs
@@ -529,6 +529,11 @@ namespace LuckParser.Models.ParseModels
             return _allBoons.Where(x => x.GetName() == name).ToList();
         }
 
+        // get everything
+        public static List<Boon> GetAll()
+        {
+            return _allBoons;
+        }
 
         // Conditions
         public static List<Boon> GetCondiBoonList()

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -9,6 +9,7 @@ namespace LuckParser.Models.ParseModels
     public abstract class AbstractMasterPlayer : AbstractPlayer
     {
         // Boons
+        protected readonly List<Boon> BoonToTrack = new List<Boon>();
         private readonly List<BoonDistribution> _boonDistribution = new List<BoonDistribution>();
         private readonly List<Dictionary<long, long>> _boonPresence = new List<Dictionary<long, long>>();
         private readonly List<Dictionary<long, long>> _condiPresence = new List<Dictionary<long, long>>();
@@ -46,45 +47,49 @@ namespace LuckParser.Models.ParseModels
             }
             return new List<Point>();
         }
-        public BoonDistribution GetBoonDistribution(ParsedLog log, List<PhaseData> phases, List<Boon> toTrack, int phaseIndex)
+        public BoonDistribution GetBoonDistribution(ParsedLog log, List<PhaseData> phases, int phaseIndex)
         {
             if (_boonDistribution.Count == 0)
             {
-                SetBoonDistribution(log, phases, toTrack);
+                SetBoonDistribution(log, phases);
             }
             return _boonDistribution[phaseIndex];
         }
-        public Dictionary<long, BoonsGraphModel> GetBoonGraphs(ParsedLog log, List<PhaseData> phases, List<Boon> toTrack)
+        public Dictionary<long, BoonsGraphModel> GetBoonGraphs(ParsedLog log, List<PhaseData> phases)
         {
             if (_boonDistribution.Count == 0)
             {
-                SetBoonDistribution(log, phases, toTrack);
+                SetBoonDistribution(log, phases);
             }
             return _boonPoints;
         }
-        public Dictionary<long, long> GetBoonPresence(ParsedLog log, List<PhaseData> phases, List<Boon> toTrack, int phaseIndex)
+        public List<Boon> getBoonToTrack()
+        {
+            return BoonToTrack;
+        }
+        public Dictionary<long, long> GetBoonPresence(ParsedLog log, List<PhaseData> phases, int phaseIndex)
         {
             if (_boonDistribution.Count == 0)
             {
-                SetBoonDistribution(log, phases, toTrack);
+                SetBoonDistribution(log, phases);
             }
             return _boonPresence[phaseIndex];
         }
 
-        public Dictionary<long, Dictionary<int, string[]>> GetExtraBoonData(ParsedLog log, List<PhaseData> phases, List<Boon> toTrack)
+        public Dictionary<long, Dictionary<int, string[]>> GetExtraBoonData(ParsedLog log, List<PhaseData> phases)
         {
             if (_boonDistribution.Count == 0)
             {
-                SetBoonDistribution(log, phases, toTrack);
+                SetBoonDistribution(log, phases);
             }
             return _boonExtra;
         }
 
-        public Dictionary<long, long> GetCondiPresence(ParsedLog log, List<PhaseData> phases, List<Boon> toTrack, int phaseIndex)
+        public Dictionary<long, long> GetCondiPresence(ParsedLog log, List<PhaseData> phases, int phaseIndex)
         {
             if (_boonDistribution.Count == 0)
             {
-                SetBoonDistribution(log, phases, toTrack);
+                SetBoonDistribution(log, phases);
             }
             return _condiPresence[phaseIndex];
         }
@@ -132,19 +137,30 @@ namespace LuckParser.Models.ParseModels
             return 0;
         }
 
+        public void SetBoonToTrack(List<List<Boon>> boonToTrack)
+        {
+            if (BoonToTrack.Count > 0)
+            {
+                return;
+            }
+            foreach(List<Boon> lBoon in boonToTrack)
+            {
+                BoonToTrack.AddRange(lBoon);
+            }
+        }
         // private getters
-        private BoonMap GetBoonMap(ParsedLog log, List<Boon> toTrack)
+        private BoonMap GetBoonMap(ParsedLog log, HashSet<long> boonIds, HashSet<long> condiIds, HashSet<long> offIds, HashSet<long> defIds)
         {
             BoonMap boonMap = new BoonMap
             {
-                toTrack
+                BoonToTrack
             };
             // Fill in Boon Map
             long timeStart = log.GetBossData().GetFirstAware();
-            List<long> tableIds = Boon.GetBoonList().Select(x => x.GetID()).ToList();
-            tableIds.AddRange(Boon.GetOffensiveTableList().Select(x => x.GetID()));
-            tableIds.AddRange(Boon.GetDefensiveTableList().Select(x => x.GetID()));
-            tableIds.AddRange(Boon.GetCondiBoonList().Select(x => x.GetID()));
+            HashSet<long> tableIds = new HashSet<long> (boonIds);
+            tableIds.UnionWith(condiIds);
+            tableIds.UnionWith(offIds);
+            tableIds.UnionWith(defIds);
             foreach (CombatItem c in log.GetBoonData())
             {
                 if (!boonMap.ContainsKey(c.SkillID))
@@ -248,6 +264,7 @@ namespace LuckParser.Models.ParseModels
             }
             return boonMap;
         }
+        // private setters
         private void SetMovements(ParsedLog log)
         {
             foreach (CombatItem c in log.GetMovementData())
@@ -270,9 +287,6 @@ namespace LuckParser.Models.ParseModels
                 }
             }
         }
-        protected abstract void SetAdditionalCombatReplayData(ParsedLog log, int pollingRate);
-        protected abstract void SetCombatReplayIcon(ParsedLog log);
-
         private void generateExtraBoonData(ParsedLog log, long boonid, BoonSimulationResult boonSimulation, List<PhaseData> phases)
         {
 
@@ -343,10 +357,13 @@ namespace LuckParser.Models.ParseModels
                     break;
             }
         }
-
-        private void SetBoonDistribution(ParsedLog log, List<PhaseData> phases, List<Boon> toTrack)
+        private void SetBoonDistribution(ParsedLog log, List<PhaseData> phases)
         {
-            BoonMap toUse = GetBoonMap(log, toTrack);
+            HashSet<long> boonIds = new HashSet<long>(Boon.GetBoonList().Select(x => x.GetID()));
+            HashSet<long> condiIds = new HashSet<long>(Boon.GetCondiBoonList().Select(x => x.GetID()));
+            HashSet<long> defIds = new HashSet<long>(Boon.GetDefensiveTableList().Select(x => x.GetID()));
+            HashSet<long> offIds = new HashSet<long>(Boon.GetOffensiveTableList().Select(x => x.GetID()));
+            BoonMap toUse = GetBoonMap(log, boonIds, condiIds, defIds, offIds);
             long dur = log.GetBossData().GetAwareDuration();
             int fightDuration = (int)(dur) / 1000;
             // Init boon/condi presence points
@@ -371,8 +388,7 @@ namespace LuckParser.Models.ParseModels
             }
 
             long death = GetDeath(log, 0, dur) - log.GetBossData().GetFirstAware();
-
-            foreach (Boon boon in toTrack)
+            foreach (Boon boon in BoonToTrack)
             {
                 long boonid = boon.GetID();
                 if (toUse.TryGetValue(boonid, out var logs) && logs.Count != 0)
@@ -393,8 +409,8 @@ namespace LuckParser.Models.ParseModels
                         simulator.Trim(dur);
                     }
                     var simulation = simulator.GetSimulationResult();
-                    var updateBoonPresence = Boon.GetBoonList().Any(x => x.GetID() == boonid);
-                    var updateCondiPresence = boonid != 873 && Boon.GetCondiBoonList().Any(x => x.GetID() == boonid);
+                    var updateBoonPresence = boonIds.Contains(boonid);
+                    var updateCondiPresence = boonid != 873 && condiIds.Contains(boonid);
                     foreach (var simul in simulation.Items)
                     {
                         for (int i = 0; i < phases.Count; i++)
@@ -436,7 +452,7 @@ namespace LuckParser.Models.ParseModels
                     var graphPoints = new List<Point>(capacity: fightDuration + 1);
                     var boonPresence = boonPresencePoints.GetBoonChart();
                     var condiPresence = condiPresencePoints.GetBoonChart();
-                    if (Replay != null && (updateCondiPresence || updateBoonPresence || Boon.GetDefensiveTableList().Any(x => x.GetID() == boonid) || Boon.GetOffensiveTableList().Any(x => x.GetID() == boonid)))
+                    if (Replay != null && (updateCondiPresence || updateBoonPresence || defIds.Contains(boonid) || offIds.Contains(boonid)))
                     {
                         foreach (int time in Replay.GetTimes())
                         {
@@ -483,7 +499,6 @@ namespace LuckParser.Models.ParseModels
                 }
             }
         }
-
         protected override void SetDamageLogs(ParsedLog log)
         {
             long timeStart = log.GetBossData().GetFirstAware();
@@ -562,6 +577,8 @@ namespace LuckParser.Models.ParseModels
                 dictionary.Add(key, value);
             }
         }
-
+        // abstracts
+        protected abstract void SetAdditionalCombatReplayData(ParsedLog log, int pollingRate);
+        protected abstract void SetCombatReplayIcon(ParsedLog log);
     }
 }

--- a/LuckParser/Models/ParseModels/Players/Player.cs
+++ b/LuckParser/Models/ParseModels/Players/Player.cs
@@ -62,6 +62,7 @@ namespace LuckParser.Models.ParseModels
         public int[] GetCleanses(ParsedLog log, long start, long end) {
             long timeStart = log.GetBossData().GetFirstAware();
             int[] cleanse = { 0, 0 };
+            List<Boon> condiList = Boon.GetCondiBoonList();
             foreach (CombatItem c in log.GetCombatList().Where(x=>x.IsStateChange == ParseEnum.StateChange.Normal && x.IsBuff == 1 && x.Time >= (start + timeStart) && x.Time <= (end + timeStart)))
             {
                 if (c.IsActivation == ParseEnum.Activation.None)
@@ -71,7 +72,7 @@ namespace LuckParser.Models.ParseModels
                         long time = c.Time - timeStart;
                         if (time > 0)
                         {
-                            if (Boon.GetCondiBoonList().Exists(x=>x.GetID() == c.SkillID))
+                            if (condiList.Exists(x=>x.GetID() == c.SkillID))
                             {
                                 cleanse[0]++;
                                 cleanse[1] += c.BuffDmg;


### PR DESCRIPTION
BoonToTrack cleanup:
- Removed List<Boon> from the signatures of several methods (GetBoonDistribution, GetBoonPresence, GetCondiPresence, GetBoonGraph) -> that list is now stocked on AbstractMasterPlayer directly, initialized in SetPresentBoons in StatisticsCalculator. Removed PersonalBuffs from Statistics as a consequence.
- Changed Boon.GetXXList() to their statistics.PresentXX equivalent when possible to avoid unnecessary .Where() on the big boon table
- Added PresentConditions to statistics to further help the point above
- Changed some List<Boon> to HashSet<long> in AbstractMasterPlayer as they were used for id lookup only (I did not measure it but we should gain a little on that, as the gazillons .Any() on Lists were replaced by simple .Contains() on HashSets)
