### PR TITLE
Maintenance

### DIFF
--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -3292,7 +3292,7 @@ namespace LuckParser.Controllers
                     sw.Write(".card {border:1px solid #9B0000;}");
                     sw.Write("td.composition {width: 120px;border:1px solid #9B0000;}");
                 }
-                if (_log.GetBoss().GetCombatReplay() != null)
+                if (_settings.ParseCombatReplay && _log.GetBossData().GetBossBehavior().CanCombatReplay)
                 {
                     // from W3
                     sw.Write(".slidecontainer {width: 100%;}");
@@ -3426,7 +3426,7 @@ namespace LuckParser.Controllers
                         //    CreateSoloHTML(sw,settingsSnap);
                         //    return;
                         //}
-                        if (phases.Count > 1 || _log.GetBoss().GetCombatReplay() != null)
+                        if (phases.Count > 1 || (_settings.ParseCombatReplay && _log.GetBossData().GetBossBehavior().CanCombatReplay))
                         {
                             sw.Write("<ul class=\"nav nav-tabs\">");
                             {
@@ -3442,7 +3442,7 @@ namespace LuckParser.Controllers
                                             "</a>" +
                                         "</li>");
                                 }
-                                if (_log.GetBoss().GetCombatReplay() != null)
+                                if (_settings.ParseCombatReplay && _log.GetBossData().GetBossBehavior().CanCombatReplay)
                                 {
                                     sw.Write("<li  class=\"nav-item\">" +
                                             "<a class=\"nav-link\" data-toggle=\"tab\" href=\"#replay\">" +
@@ -3823,7 +3823,7 @@ namespace LuckParser.Controllers
                                 sw.Write("</div>");
 
                             }
-                            if (_log.GetBoss().GetCombatReplay() != null)
+                            if (_log.GetBossData().GetBossBehavior().CanCombatReplay)
                             {
                                 sw.Write("<div class=\"tab-pane fade\" id=\"replay\">");
                                 {

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -655,7 +655,29 @@ namespace LuckParser.Controllers
                         _bossData.SetLastAware(lastHoTTime);
                     }
                 }
-            } else
+            }
+            else if (golemMode)
+            {
+                CombatItem pov = _combatData.FirstOrDefault(x => x.IsStateChange == ParseEnum.StateChange.PointOfView);
+                if (pov != null) {
+                    // to make sure that the logging starts when the PoV starts attacking (in case there is a slave with them)
+                    CombatItem enterCombat = _combatData.FirstOrDefault(x => x.SrcAgent == pov.SrcAgent && x.IsStateChange == ParseEnum.StateChange.EnterCombat);
+                    if (enterCombat != null)
+                    {
+                        _bossData.SetLastAware(enterCombat.Time);
+                    }
+                }              
+                CombatItem combatExit = _combatData.FirstOrDefault(x => x.IsStateChange == ParseEnum.StateChange.ExitCombat);
+                if (combatExit != null)
+                {
+                    _bossData.SetLastAware(combatExit.Time);
+                }
+                if (bossHealthOverTime.Count > 0)
+                {
+                    _logData.SetBossKill(bossHealthOverTime.Last().Y < 200);
+                }
+            }
+            else
             {
                 CombatItem killed = _combatData.Find(x => x.SrcInstid == _bossData.GetInstid() && x.IsStateChange.IsDead());
                 if (killed != null)
@@ -665,11 +687,6 @@ namespace LuckParser.Controllers
                 }
             }
 
-            if (golemMode && bossHealthOverTime.Count > 0)
-            {
-                _logData.SetBossKill(bossHealthOverTime.Last().Y < 200);
-                _bossData.SetLastAware(bossHealthOverTime.Last().X + _bossData.GetFirstAware());
-            }
             //players
             if (_playerList.Count == 0)
             {

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -490,18 +490,12 @@ namespace LuckParser.Controllers
             // a hack for buggy golem logs
             if (_bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Golem)
             {
-                AgentItem otherGolem = npcList.Find(x => x.GetID() == 19603);
                 foreach (CombatItem c in _combatData)
                 {
                     // redirect all attacks to the main golem
                     if (c.DstAgent == 0 && c.DstInstid == 0 && c.IsStateChange == ParseEnum.StateChange.Normal && c.IFF == ParseEnum.IFF.Foe && c.IsActivation == ParseEnum.Activation.None)
                     {
                         c.DstAgent = bossAgent.GetAgent();
-                        c.DstInstid = bossAgent.GetInstid();
-                    }
-                    // redirect buff initial to main golem
-                    if (otherGolem != null && c.IsBuff == 18 && c.DstInstid == otherGolem.GetInstid())
-                    {
                         c.DstInstid = bossAgent.GetInstid();
                     }
                 }

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -422,9 +422,6 @@ namespace LuckParser.Controllers
         private void FillMissingData()
         {
             var agentsLookup = _agentData.GetAllAgentsList().ToDictionary(a => a.GetAgent());
-            bool golemMode = _bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Golem;
-            bool raidMode = _bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Raid;
-            bool fractalMode = _bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Fractal;
             // Set Agent instid, firstAware and lastAware
             foreach (CombatItem c in _combatData)
             {
@@ -491,7 +488,7 @@ namespace LuckParser.Controllers
             _boss = new Boss(bossAgent);
             List<Point> bossHealthOverTime = new List<Point>();
             // a hack for buggy golem logs
-            if (golemMode)
+            if (_bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Golem)
             {
                 AgentItem otherGolem = npcList.Find(x => x.GetID() == 19603);
                 foreach (CombatItem c in _combatData)
@@ -642,7 +639,7 @@ namespace LuckParser.Controllers
                         }
                     }
                     List<CombatItem> lp = _combatData.GetStates(playerAgent.GetInstid(), ParseEnum.StateChange.Despawn, _bossData.GetFirstAware(), _bossData.GetLastAware());
-                    Player player = new Player(playerAgent, fractalMode);
+                    Player player = new Player(playerAgent, _bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Fractal);
                     bool skip = false;
                     foreach (Player p in _playerList)
                     {

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -667,7 +667,7 @@ namespace LuckParser.Controllers
                         _bossData.SetLastAware(enterCombat.Time);
                     }
                 }              
-                CombatItem combatExit = _combatData.FirstOrDefault(x => x.IsStateChange == ParseEnum.StateChange.ExitCombat);
+                CombatItem combatExit = _combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.ExitCombat);
                 if (combatExit != null)
                 {
                     _bossData.SetLastAware(combatExit.Time);

--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -567,7 +567,7 @@ namespace LuckParser.Controllers
                 Dictionary<long, Statistics.FinalBoonUptime> final =
                     new Dictionary<long, Statistics.FinalBoonUptime>();
 
-                foreach (Boon boon in player.getBoonToTrack())
+                foreach (Boon boon in player.GetBoonToTrack())
                 {
                     long totalGeneration = 0;
                     long totalOverstack = 0;
@@ -618,7 +618,7 @@ namespace LuckParser.Controllers
                     BoonDistribution selfBoons = player.GetBoonDistribution(_log,_statistics.Phases, phaseIndex);
 
                     long fightDuration = phase.GetEnd() - phase.GetStart();
-                    foreach (Boon boon in player.getBoonToTrack())
+                    foreach (Boon boon in player.GetBoonToTrack())
                     {
                         Statistics.FinalBoonUptime uptime = new Statistics.FinalBoonUptime
                         {
@@ -676,7 +676,7 @@ namespace LuckParser.Controllers
                 PhaseData phase =_statistics.Phases[phaseIndex];
                 long fightDuration = phase.GetDuration();
 
-                foreach (Boon boon in _log.GetBoss().getBoonToTrack())
+                foreach (Boon boon in _log.GetBoss().GetBoonToTrack())
                 {
                     Statistics.FinalBossBoon condition = new Statistics.FinalBossBoon(_log.GetPlayerList());
                     rates[boon.GetID()] = condition;

--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -404,7 +404,7 @@ namespace LuckParser.Controllers
                     final.DodgeCount = combatData.GetSkillCount(instid, SkillItem.DodgeId, start, end) + combatData.GetBuffCount(instid, 40408, start, end);//dodge = 65001 mirage cloak =40408
 
                     //Stack Distance
-                    if (_settings.ParseCombatReplay && _log.GetBoss().GetCombatReplay() != null)
+                    if (_settings.ParseCombatReplay && _log.GetBossData().GetBossBehavior().CanCombatReplay)
                     {
                         if (_statistics.StackCenterPositions == null)
                         {

--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Models\BossLogic\Artsariiv.cs" />
     <Compile Include="Models\BossLogic\Arkk.cs" />
     <Compile Include="Models\BossLogic\FractalLogic.cs" />
+    <Compile Include="Models\BossLogic\RaidLogic.cs" />
     <Compile Include="Models\BossLogic\Skorvald.cs" />
     <Compile Include="Models\BossLogic\Siax.cs" />
     <Compile Include="Models\BossLogic\MAMA.cs" />

--- a/LuckParser/Models/BossLogic/Arkk.cs
+++ b/LuckParser/Models/BossLogic/Arkk.cs
@@ -60,14 +60,7 @@ namespace LuckParser.Models
 
         public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
         {
-            int combatExits = combatData.Count(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange == ParseEnum.StateChange.ExitCombat);
-            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
-            if (combatExits == 3 && lastDamageTaken != null)
-            {
-                logData.SetBossKill(true);
-                bossData.SetLastAware(lastDamageTaken.Time);
-            }
-
+            SetSuccessOnCombatExit(combatData, logData, bossData, 3);
         }
     }
 }

--- a/LuckParser/Models/BossLogic/Arkk.cs
+++ b/LuckParser/Models/BossLogic/Arkk.cs
@@ -2,6 +2,7 @@ using LuckParser.Models.DataModels;
 using LuckParser.Models.ParseModels;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LuckParser.Models
 {
@@ -55,6 +56,18 @@ namespace LuckParser.Models
         public override string GetReplayIcon()
         {
             return "https://i.imgur.com/u6vv8cW.png";
+        }
+
+        public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        {
+            int combatExits = combatData.Count(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange == ParseEnum.StateChange.ExitCombat);
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            if (combatExits == 3 && lastDamageTaken != null)
+            {
+                logData.SetBossKill(true);
+                bossData.SetLastAware(lastDamageTaken.Time);
+            }
+
         }
     }
 }

--- a/LuckParser/Models/BossLogic/Artsariiv.cs
+++ b/LuckParser/Models/BossLogic/Artsariiv.cs
@@ -2,6 +2,7 @@
 using LuckParser.Models.ParseModels;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LuckParser.Models
 {
@@ -35,6 +36,18 @@ namespace LuckParser.Models
         public override string GetReplayIcon()
         {
             return "https://wiki.guildwars2.com/images/b/b4/Artsariiv.jpg";
+        }
+
+        public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        {
+            int combatExits = combatData.Count(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange == ParseEnum.StateChange.ExitCombat);
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            if (combatExits == 3 && lastDamageTaken != null)
+            {
+                logData.SetBossKill(true);
+                bossData.SetLastAware(lastDamageTaken.Time);
+            }
+
         }
     }
 }

--- a/LuckParser/Models/BossLogic/Artsariiv.cs
+++ b/LuckParser/Models/BossLogic/Artsariiv.cs
@@ -40,14 +40,7 @@ namespace LuckParser.Models
 
         public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
         {
-            int combatExits = combatData.Count(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange == ParseEnum.StateChange.ExitCombat);
-            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
-            if (combatExits == 3 && lastDamageTaken != null)
-            {
-                logData.SetBossKill(true);
-                bossData.SetLastAware(lastDamageTaken.Time);
-            }
-
+            SetSuccessOnCombatExit(combatData, logData, bossData, 3);
         }
     }
 }

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -15,10 +15,12 @@ namespace LuckParser.Models
             new Mechanic(-3, "Downs", Mechanic.MechType.PlayerStatus, ParseEnum.BossIDS.Unknown, "symbol:'cross',color:'rgb(255,0,0)',", "Downs",0),
             new Mechanic(SkillItem.ResurrectId, "Resurrect", Mechanic.MechType.PlayerStatus, ParseEnum.BossIDS.Unknown, "symbol:'cross-open',color:'rgb(0,255,255)',", "Res",0)}; //Resurrects (start), Resurrect
         protected ParseMode Mode;
+        public bool CanCombatReplay { get; protected set; }
 
         public BossLogic()
         {
             Mode = ParseMode.Unknown;
+            CanCombatReplay = false;
         }
 
         public virtual CombatReplayMap GetCombatMap()

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -56,7 +56,7 @@ namespace LuckParser.Models
         {
         }
 
-        public virtual void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        protected void SetSuccessByDeath(CombatData combatData, LogData logData, BossData bossData)
         {
             CombatItem killed = combatData.Find(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange.IsDead());
             if (killed != null)
@@ -64,6 +64,11 @@ namespace LuckParser.Models
                 logData.SetBossKill(true);
                 bossData.SetLastAware(killed.Time);
             }
+        }
+
+        public virtual void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        {
+            SetSuccessByDeath(combatData, logData, bossData);
         }
 
         public virtual string GetReplayIcon()

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -56,6 +56,16 @@ namespace LuckParser.Models
         {
         }
 
+        public virtual void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        {
+            CombatItem killed = combatData.Find(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange.IsDead());
+            if (killed != null)
+            {
+                logData.SetBossKill(true);
+                bossData.SetLastAware(killed.Time);
+            }
+        }
+
         public virtual string GetReplayIcon()
         {
             return "";

--- a/LuckParser/Models/BossLogic/Cairn.cs
+++ b/LuckParser/Models/BossLogic/Cairn.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Cairn : BossLogic
+    public class Cairn : RaidLogic
     {
         public Cairn()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             // (ID, ingame name, Type, BossID, plotly marker, Table header name, ICD, Special condition) // long table hover name, graph legend name

--- a/LuckParser/Models/BossLogic/Deimos.cs
+++ b/LuckParser/Models/BossLogic/Deimos.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Deimos : BossLogic
+    public class Deimos : RaidLogic
     {
         public Deimos()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(37716, "Rapid Decay", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Deimos, "symbol:'circle-open',color:'rgb(0,0,0)',", "Oil","Rapid Decay (Black expanding oil)", "Black Oil",0),

--- a/LuckParser/Models/BossLogic/Dhuum.cs
+++ b/LuckParser/Models/BossLogic/Dhuum.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Dhuum : BossLogic
+    public class Dhuum : RaidLogic
     {
         public Dhuum()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(48172, "Hateful Ephemera", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Dhuum, "symbol:'square',color:'rgb(255,140,0)',", "Glm.dmg","Hateful Ephemera (Golem AoE dmg)", "Golem Dmg",0), 

--- a/LuckParser/Models/BossLogic/FractalLogic.cs
+++ b/LuckParser/Models/BossLogic/FractalLogic.cs
@@ -12,6 +12,7 @@ namespace LuckParser.Models
         protected FractalLogic()
         { 
             Mode = ParseMode.Fractal;
+            CanCombatReplay = true;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(37695, "Flux Bomb", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Unknown, "symbol:'circle',color:'rgb(150,0,255)',size:10,", "FBmb","Flux Bomb application", "Flux Bomb",0),

--- a/LuckParser/Models/BossLogic/FractalLogic.cs
+++ b/LuckParser/Models/BossLogic/FractalLogic.cs
@@ -57,6 +57,17 @@ namespace LuckParser.Models
             return phases;
         }
 
+        protected void SetSuccessOnCombatExit(CombatData combatData, LogData logData, BossData bossData, int combatExitCount)
+        {
+            int combatExits = combatData.Count(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange == ParseEnum.StateChange.ExitCombat);
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            if (combatExits == combatExitCount && lastDamageTaken != null)
+            {
+                logData.SetBossKill(true);
+                bossData.SetLastAware(lastDamageTaken.Time);
+            }
+        }
+
         public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
         {
             // check reward

--- a/LuckParser/Models/BossLogic/FractalLogic.cs
+++ b/LuckParser/Models/BossLogic/FractalLogic.cs
@@ -82,7 +82,7 @@ namespace LuckParser.Models
                 }
                 else
                 {
-                    base.SetSuccess(combatData, logData, bossData);
+                    SetSuccessByDeath(combatData, logData, bossData);
                 }
             }
         }

--- a/LuckParser/Models/BossLogic/FractalLogic.cs
+++ b/LuckParser/Models/BossLogic/FractalLogic.cs
@@ -67,19 +67,11 @@ namespace LuckParser.Models
                 if (reward != null && lastDamageTaken.Time - reward.Time < 100)
                 {
                     logData.SetBossKill(true);
-                    bossData.SetLastAware(Math.Min(lastDamageTaken.Time, reward.Time));
+                    bossData.SetLastAware(reward.Time);
                 }
                 else
                 {
                     base.SetSuccess(combatData, logData, bossData);
-                    if (logData.GetBosskill())
-                    {
-                        bossData.SetLastAware(Math.Min(bossData.GetLastAware(), lastDamageTaken.Time));
-                    } else if (bossData.GetLastAware() - lastDamageTaken.Time > 5000)
-                    {
-                        logData.SetBossKill(true);
-                        bossData.SetLastAware(bossData.GetLastAware());
-                    }
                 }
             }
         }

--- a/LuckParser/Models/BossLogic/FractalLogic.cs
+++ b/LuckParser/Models/BossLogic/FractalLogic.cs
@@ -64,7 +64,7 @@ namespace LuckParser.Models
             CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
             if (lastDamageTaken != null)
             {
-                if (reward != null && Math.Abs(lastDamageTaken.Time - reward.Time) < 10000)
+                if (reward != null && lastDamageTaken.Time - reward.Time < 100)
                 {
                     logData.SetBossKill(true);
                     bossData.SetLastAware(Math.Min(lastDamageTaken.Time, reward.Time));
@@ -78,7 +78,7 @@ namespace LuckParser.Models
                     } else if (bossData.GetLastAware() - lastDamageTaken.Time > 5000)
                     {
                         logData.SetBossKill(true);
-                        bossData.SetLastAware(lastDamageTaken.Time);
+                        bossData.SetLastAware(bossData.GetLastAware());
                     }
                 }
             }

--- a/LuckParser/Models/BossLogic/Golem.cs
+++ b/LuckParser/Models/BossLogic/Golem.cs
@@ -27,7 +27,7 @@ namespace LuckParser.Models
                 CombatItem enterCombat = combatData.FirstOrDefault(x => x.SrcAgent == pov.SrcAgent && x.IsStateChange == ParseEnum.StateChange.EnterCombat);
                 if (enterCombat != null)
                 {
-                    bossData.SetLastAware(enterCombat.Time);
+                    bossData.SetFirstAware(enterCombat.Time);
                 }
             }
             CombatItem combatExit = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.ExitCombat);

--- a/LuckParser/Models/BossLogic/Golem.cs
+++ b/LuckParser/Models/BossLogic/Golem.cs
@@ -1,6 +1,7 @@
 ﻿using LuckParser.Models.DataModels;
 using LuckParser.Models.ParseModels;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LuckParser.Models
 {
@@ -15,6 +16,29 @@ namespace LuckParser.Models
         {
             List<PhaseData> phases = GetInitialPhase(log);          
             return phases;
-        }     
+        }
+
+        public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        {
+            CombatItem pov = combatData.FirstOrDefault(x => x.IsStateChange == ParseEnum.StateChange.PointOfView);
+            if (pov != null)
+            {
+                // to make sure that the logging starts when the PoV starts attacking (in case there is a slave with them)
+                CombatItem enterCombat = combatData.FirstOrDefault(x => x.SrcAgent == pov.SrcAgent && x.IsStateChange == ParseEnum.StateChange.EnterCombat);
+                if (enterCombat != null)
+                {
+                    bossData.SetLastAware(enterCombat.Time);
+                }
+            }
+            CombatItem combatExit = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.ExitCombat);
+            if (combatExit != null)
+            {
+                bossData.SetLastAware(combatExit.Time);
+            }
+            if (bossData.GetHealthOverTime().Count > 0)
+            {
+                logData.SetBossKill(bossData.GetHealthOverTime().Last().Y < 200);
+            }
+        }
     }
 }

--- a/LuckParser/Models/BossLogic/Golem.cs
+++ b/LuckParser/Models/BossLogic/Golem.cs
@@ -30,10 +30,10 @@ namespace LuckParser.Models
                     bossData.SetFirstAware(enterCombat.Time);
                 }
             }
-            CombatItem combatExit = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.ExitCombat);
-            if (combatExit != null)
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && (x.Value > 0 || x.BuffDmg > 0));
+            if (lastDamageTaken != null)
             {
-                bossData.SetLastAware(combatExit.Time);
+                bossData.SetLastAware(lastDamageTaken.Time);
             }
             if (bossData.GetHealthOverTime().Count > 0)
             {

--- a/LuckParser/Models/BossLogic/Gorseval.cs
+++ b/LuckParser/Models/BossLogic/Gorseval.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Gorseval : BossLogic
+    public class Gorseval : RaidLogic
     {
         public Gorseval()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(31875, "Spectral Impact", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Gorseval, "symbol:'hexagram',color:'rgb(255,0,0)',", "Slam","Spectral Impact (KB Slam)", "Slam",4000),

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class KeepConstruct : BossLogic
+    public class KeepConstruct : RaidLogic
     {
         public KeepConstruct()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(34912, "Fixate", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.KeepConstruct, "symbol:'star',color:'rgb(255,0,255)',", "Fixt","Fixated by Statue", "Fixated",0),

--- a/LuckParser/Models/BossLogic/Matthias.cs
+++ b/LuckParser/Models/BossLogic/Matthias.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Matthias : BossLogic
+    public class Matthias : RaidLogic
     {
         public Matthias()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
 

--- a/LuckParser/Models/BossLogic/MursaatOverseer.cs
+++ b/LuckParser/Models/BossLogic/MursaatOverseer.cs
@@ -5,11 +5,10 @@ using System.Collections.Generic;
 
 namespace LuckParser.Models
 {
-    public class MursaatOverseer : BossLogic
+    public class MursaatOverseer : RaidLogic
     {
         public MursaatOverseer()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>()
             {
             new Mechanic(37677, "Soldier's Aura", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.MursaatOverseer, "symbol:'circle-open',color:'rgb(255,0,0)',", "Jade","Jade Soldier's Aura hit", "Jade Aura",0),

--- a/LuckParser/Models/BossLogic/RaidLogic.cs
+++ b/LuckParser/Models/BossLogic/RaidLogic.cs
@@ -1,0 +1,33 @@
+﻿using LuckParser.Models.DataModels;
+using LuckParser.Models.ParseModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LuckParser.Models
+{
+    public abstract class RaidLogic : BossLogic
+    {
+        protected RaidLogic()
+        {
+            Mode = ParseMode.Raid;
+        }
+
+        public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        {
+            // Put non reward stuff in this as we find them
+            HashSet<int> notRaidRewardsIds = new HashSet<int>
+                {
+                    13
+                };
+            CombatItem reward = combatData.Find(x => x.IsStateChange == ParseEnum.StateChange.Reward && !notRaidRewardsIds.Contains(x.Value));
+            if (reward != null)
+            {
+                logData.SetBossKill(true);
+                bossData.SetLastAware(reward.Time);
+            }
+        }
+    }
+}

--- a/LuckParser/Models/BossLogic/RaidLogic.cs
+++ b/LuckParser/Models/BossLogic/RaidLogic.cs
@@ -13,6 +13,7 @@ namespace LuckParser.Models
         protected RaidLogic()
         {
             Mode = ParseMode.Raid;
+            CanCombatReplay = true;
         }
 
         public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)

--- a/LuckParser/Models/BossLogic/Sabetha.cs
+++ b/LuckParser/Models/BossLogic/Sabetha.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Sabetha : BossLogic
+    public class Sabetha : RaidLogic
     {
         public Sabetha()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(34108, "Shell-Shocked", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Sabetha, "symbol:'circle-open',color:'rgb(0,128,0)',", "Lnchd","Shell-Shocked (launched up to cannons)", "Shell-Shocked",0),

--- a/LuckParser/Models/BossLogic/Samarog.cs
+++ b/LuckParser/Models/BossLogic/Samarog.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Samarog : BossLogic
+    public class Samarog : RaidLogic
     {
         public Samarog()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
 

--- a/LuckParser/Models/BossLogic/Skorvald.cs
+++ b/LuckParser/Models/BossLogic/Skorvald.cs
@@ -2,6 +2,7 @@
 using LuckParser.Models.ParseModels;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LuckParser.Models
 {
@@ -51,6 +52,26 @@ namespace LuckParser.Models
         public override string GetReplayIcon()
         {
             return "https://i.imgur.com/IOPAHRE.png";
+        }
+
+        public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
+        {
+            // check reward
+            CombatItem reward = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.Reward); CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            if (reward != null && lastDamageTaken.Time - reward.Time < 100)
+            {
+                logData.SetBossKill(true);
+                bossData.SetLastAware(Math.Min(lastDamageTaken.Time, reward.Time));
+            }
+            else
+            {
+                SetSuccessByDeath(combatData, logData, bossData);
+                if (logData.GetBosskill())
+                {
+                    bossData.SetLastAware(Math.Min(bossData.GetLastAware(), lastDamageTaken.Time));
+                }
+            }
+
         }
     }
 }

--- a/LuckParser/Models/BossLogic/Skorvald.cs
+++ b/LuckParser/Models/BossLogic/Skorvald.cs
@@ -59,17 +59,20 @@ namespace LuckParser.Models
             // check reward
             CombatItem reward = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.Reward);
             CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
-            if (reward != null && lastDamageTaken.Time - reward.Time < 100)
+            if (lastDamageTaken != null)
             {
-                logData.SetBossKill(true);
-                bossData.SetLastAware(Math.Min(lastDamageTaken.Time, reward.Time));
-            }
-            else
-            {
-                SetSuccessByDeath(combatData, logData, bossData);
-                if (logData.GetBosskill())
+                if (reward != null && lastDamageTaken.Time - reward.Time < 100)
                 {
-                    bossData.SetLastAware(Math.Min(bossData.GetLastAware(), lastDamageTaken.Time));
+                    logData.SetBossKill(true);
+                    bossData.SetLastAware(Math.Min(lastDamageTaken.Time, reward.Time));
+                }
+                else
+                {
+                    SetSuccessByDeath(combatData, logData, bossData);
+                    if (logData.GetBosskill())
+                    {
+                        bossData.SetLastAware(Math.Min(bossData.GetLastAware(), lastDamageTaken.Time));
+                    }
                 }
             }
 

--- a/LuckParser/Models/BossLogic/Skorvald.cs
+++ b/LuckParser/Models/BossLogic/Skorvald.cs
@@ -9,7 +9,7 @@ namespace LuckParser.Models
     public class Skorvald : FractalLogic
     {
         public Skorvald()
-        { 
+        {
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(39916, "Combustion Rush", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-left',color:'rgb(255,0,255)',", "Chrg","Combustion Rush", "Charge",0),
@@ -18,7 +18,7 @@ namespace LuckParser.Models
             new Mechanic(39910, "Punishing Kick", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-right-open',color:'rgb(200,0,200)',", "A.Kick","Punishing Kick (Single purple Line, Add)", "Kick (Add)",0),
             new Mechanic(38896, "Punishing Kick", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-right',color:'rgb(200,0,200)',", "Kick","Punishing Kick (Single purple Line)", "Kick",0),
             new Mechanic(39534, "Cranial Cascade", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-right-open',color:'rgb(255,200,0)',", "A.CnKB","Cranial Cascade (3 purple Line Knockback, Add)", "Small Cone KB (Add)",0),
-            new Mechanic(39686, "Cranial Cascade", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-right',color:'rgb(255,200,0)',", "CnKB","Cranial Cascade (3 purple Line Knockback)", "Small Cone KB",0), 
+            new Mechanic(39686, "Cranial Cascade", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-right',color:'rgb(255,200,0)',", "CnKB","Cranial Cascade (3 purple Line Knockback)", "Small Cone KB",0),
             new Mechanic(39845, "Radiant Fury", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'octagon',color:'rgb(255,0,0)',", "BrnCrcl","Radiant Fury (expanding burn circles)", "Expanding Circles",0),
             new Mechanic(38926, "Radiant Fury", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'octagon',color:'rgb(255,0,0)',", "BrnCrcl","Radiant Fury (expanding burn circles)", "Expanding Circles",0),
             new Mechanic(39257, "Focused Anger", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-down',color:'rgb(255,100,0)',", "LCnKB","Focused Anger (Large Cone Overhead Crosshair Knockback)", "Large Cone Knockback",0),
@@ -28,11 +28,11 @@ namespace LuckParser.Models
             new Mechanic(39228, "Solar Cyclone", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'asterisk-open',color:'rgb(140,0,140)',", "Cycln","Solar Cyclone (Circling Knockback)", "KB Cyclone",0),
             new Mechanic(39228, "Solar Cyclone", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'asterisk-open',color:'rgb(140,0,140)',", "Cycln","Solar Cyclone (Circling Knockback)", "KB Cyclone",0),
             new Mechanic(791, "Fear", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Skorvald, "symbol:'square-open',color:'rgb(255,0,0)',", "Eye","Hit by the Overhead Eye Fear", "Eye (Fear)",0,(value=> value == 3000)), //not triggered under stab, still get blinded/damaged, seperate tracking desired?
-            new Mechanic(39131, "Fixate", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Skorvald, "symbol:'star-open',color:'rgb(255,0,255)',", "Blm.Fix","Fixated by Solar Bloom", "Bloom Fixate",0), 
+            new Mechanic(39131, "Fixate", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Skorvald, "symbol:'star-open',color:'rgb(255,0,255)',", "Blm.Fix","Fixated by Solar Bloom", "Bloom Fixate",0),
             new Mechanic(39491, "Explode", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'circle',color:'rgb(255,200,0)',", "Blm.Exp","Hit by Solar Bloom Explosion", "Bloom Explosion",0), //shockwave, not damage? (damage is 50% max HP, not tracked)
             new Mechanic(39911, "Spiral Strike", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'circle-open',color:'rgb(0,200,0)',", "SprlStr","Hit after Warp (Jump to Player with overhead bomb)", "Spiral Strike",0),
             new Mechanic(39133, "Wave of Mutilation", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Skorvald, "symbol:'triangle-sw',color:'rgb(0,200,0)',", "KBJmp","Hit by KB Jump (player targeted)", "Knockback jump",0),
-            });         
+            });
         }
 
         public override CombatReplayMap GetCombatMap()
@@ -57,7 +57,8 @@ namespace LuckParser.Models
         public override void SetSuccess(CombatData combatData, LogData logData, BossData bossData)
         {
             // check reward
-            CombatItem reward = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.Reward); CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            CombatItem reward = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.Reward);
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
             if (reward != null && lastDamageTaken.Time - reward.Time < 100)
             {
                 logData.SetBossKill(true);

--- a/LuckParser/Models/BossLogic/Slothasor.cs
+++ b/LuckParser/Models/BossLogic/Slothasor.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Slothasor : BossLogic
+    public class Slothasor : RaidLogic
     {
         public Slothasor()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(34479, "Tantrum", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Slothasor, "symbol:'circle-open',color:'rgb(255,200,0)',", "Tntrm","Tantrum (Triple Circles after Ground slamming)", "Tantrum",0), 

--- a/LuckParser/Models/BossLogic/SoullessHorror.cs
+++ b/LuckParser/Models/BossLogic/SoullessHorror.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class SoullessHorror : BossLogic
+    public class SoullessHorror : RaidLogic
     {
         public SoullessHorror()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
 

--- a/LuckParser/Models/BossLogic/ValeGuardian.cs
+++ b/LuckParser/Models/BossLogic/ValeGuardian.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class ValeGuardian : BossLogic
+    public class ValeGuardian : RaidLogic
     {
         public ValeGuardian()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
             new Mechanic(31860, "Unstable Magic Spike", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.ValeGuardian, "symbol:'circle',color:'rgb(0,0,255)',", "G.TP","Unstable Magic Spike (Green Guard Teleport)","Green Guard TP",500),

--- a/LuckParser/Models/BossLogic/Xera.cs
+++ b/LuckParser/Models/BossLogic/Xera.cs
@@ -6,11 +6,10 @@ using System.Linq;
 
 namespace LuckParser.Models
 {
-    public class Xera : BossLogic
+    public class Xera : RaidLogic
     {
         public Xera()
         {
-            Mode = ParseMode.Raid;
             MechanicList.AddRange(new List<Mechanic>
             {
 

--- a/LuckParser/Models/DataModels/ParseEnum.cs
+++ b/LuckParser/Models/DataModels/ParseEnum.cs
@@ -90,6 +90,7 @@ namespace LuckParser.Models.DataModels
             Position        = 19,
             Velocity        = 20,
             Rotation        = 21,
+            TeamChange      = 22,
             Unknown
         };
 

--- a/LuckParser/Models/ParseModels/Boons/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boons/Boon.cs
@@ -301,9 +301,9 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Storm Spirit", 50381, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.DefensiveBuffTable,RemoveType.None, Logic.Override, "https://wiki.guildwars2.com/images/thumb/2/25/Storm_Spirit.png/30px-Storm_Spirit.png"),
                 //skills
                 new Boon("Attack of Opportunity",12574, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Call of the Wild",36781, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Strength of the pack!",12554, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Sick 'Em!",33902, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
+                new Boon("Call of the Wild",36781, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
+                new Boon("Strength of the pack!",12554, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
+                new Boon("Sick 'Em!",33902, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
                 new Boon("Sharpening Stones",12536, BoonSource.Ranger, BoonType.Intensity, 10, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Ancestral Grace", 31584, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Glyph of Empowerment", 31803, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.OffensiveBuffTable,RemoveType.None, Logic.Override, "https://wiki.guildwars2.com/images/thumb/f/f0/Glyph_of_Empowerment.png/33px-Glyph_of_Empowerment.png"),
@@ -319,7 +319,7 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Opening Strike",13988, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Quick Draw",29703, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Light on your feet",30673, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Natural Mender",30449, BoonSource.Ranger, BoonType.Intensity, 10, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
+                new Boon("Natural Mender",30449, BoonSource.Ranger, BoonType.Intensity, 10, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
                 new Boon("Lingering Light",32248, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Deadly",44932, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Ferocious",41720, BoonSource.Ranger, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
@@ -369,7 +369,7 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Signet of Midnight",10233, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Signet of Humility",30739, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 //skills
-                new Boon("Distortion",10243, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
+                new Boon("Distortion",10243, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
                 new Boon("Blur", 10335 , BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Mirror",10357, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Echo",29664, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
@@ -378,11 +378,11 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Time Echo",29582, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 new Boon("Time Anchored",30136, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
                 //traits
-                new Boon("Fencer's Finesse", 30426 , BoonSource.Mesmer, BoonType.Intensity, 10, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Illusionary Defense",49099, BoonSource.Mesmer, BoonType.Intensity, 5, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Compunding Power",49058, BoonSource.Mesmer, BoonType.Intensity, 5, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Phantasmal Force", 44691 , BoonSource.Mesmer, BoonType.Intensity, 25, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
-                new Boon("Mirage Cloak",40408, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),
+                new Boon("Fencer's Finesse", 30426 , BoonSource.Mesmer, BoonType.Intensity, 10, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
+                new Boon("Illusionary Defense",49099, BoonSource.Mesmer, BoonType.Intensity, 5, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
+                new Boon("Compunding Power",49058, BoonSource.Mesmer, BoonType.Intensity, 5, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
+                new Boon("Phantasmal Force", 44691 , BoonSource.Mesmer, BoonType.Intensity, 25, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
+                new Boon("Mirage Cloak",40408, BoonSource.Mesmer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.None, Logic.Override),
                 //NECROMANCER
                 //forms
                 new Boon("Lich Form",10631, BoonSource.Necromancer, BoonType.Duration, 1, BoonEnum.GraphOnlyBuff, RemoveType.Manual, Logic.Override),

--- a/LuckParser/Models/ParseModels/BossData.cs
+++ b/LuckParser/Models/ParseModels/BossData.cs
@@ -216,5 +216,9 @@ namespace LuckParser.Models.ParseModels
                 }
             }
         }
+        public void SetSuccess(CombatData combatData, LogData logData)
+        {
+            _logic.SetSuccess(combatData, logData, this);
+        }
     }
 }

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -71,7 +71,7 @@ namespace LuckParser.Models.ParseModels
 
             _castData = this.Where(x => (x.IsStateChange == ParseEnum.StateChange.Normal && x.IsActivation != ParseEnum.Activation.None) || x.IsStateChange == ParseEnum.StateChange.WeaponSwap).ToList();
 
-            _movementData = (bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Fractal || bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Raid) ? this.Where(x => x.IsStateChange == ParseEnum.StateChange.Position || x.IsStateChange == ParseEnum.StateChange.Velocity).ToList() : new List<CombatItem>();
+            _movementData = (bossData.GetBossBehavior().CanCombatReplay) ? this.Where(x => x.IsStateChange == ParseEnum.StateChange.Position || x.IsStateChange == ParseEnum.StateChange.Velocity).ToList() : new List<CombatItem>();
 
             /*healing_data = this.Where(x => x.getDstInstid() != 0 && x.isStateChange() == ParseEnum.StateChange.Normal && x.getIFF() == ParseEnum.IFF.Friend && x.isBuffremove() == ParseEnum.BuffRemove.None &&
                                          ((x.isBuff() == 1 && x.getBuffDmg() > 0 && x.getValue() == 0) ||

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -63,7 +63,7 @@ namespace LuckParser.Models.ParseModels
             }
             return _boonPoints;
         }
-        public List<Boon> getBoonToTrack()
+        public List<Boon> GetBoonToTrack()
         {
             return BoonToTrack;
         }
@@ -287,7 +287,7 @@ namespace LuckParser.Models.ParseModels
                 }
             }
         }
-        private void generateExtraBoonData(ParsedLog log, long boonid, BoonSimulationResult boonSimulation, List<PhaseData> phases)
+        private void GenerateExtraBoonData(ParsedLog log, long boonid, BoonSimulationResult boonSimulation, List<PhaseData> phases)
         {
 
             switch (boonid)
@@ -446,7 +446,7 @@ namespace LuckParser.Models.ParseModels
                     // Graphs
                     if (requireExtraData)
                     {
-                        generateExtraBoonData(log, boonid, simulation, phases);
+                        GenerateExtraBoonData(log, boonid, simulation, phases);
                     }
                     // Precision is reduced to seconds
                     var graphPoints = new List<Point>(capacity: fightDuration + 1);

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -95,9 +95,9 @@ namespace LuckParser.Models.ParseModels
         }
         public void InitCombatReplay(ParsedLog log, int pollingRate, bool trim, bool forceInterpolate)
         {
-            if (log.GetMovementData().Count == 0)
+            if (!log.GetBossData().GetBossBehavior().CanCombatReplay)
             {
-                // no movement data, old arc version
+                // no combat replay support on boss
                 return;
             }
             if (Replay == null)
@@ -108,10 +108,10 @@ namespace LuckParser.Models.ParseModels
                 SetCombatReplayIcon(log);
                 if (trim)
                 {
-                    CombatItem test = log.GetCombatList().FirstOrDefault(x => x.SrcAgent == Agent.GetAgent() && (x.IsStateChange.IsDead() || x.IsStateChange.IsDespawn()));
-                    if (test != null)
+                    CombatItem despawnCheck = log.GetCombatList().FirstOrDefault(x => x.SrcAgent == Agent.GetAgent() && (x.IsStateChange.IsDead() || x.IsStateChange.IsDespawn()));
+                    if (despawnCheck != null)
                     {
-                        Replay.Trim(Agent.GetFirstAware() - log.GetBossData().GetFirstAware(), test.Time - log.GetBossData().GetFirstAware());
+                        Replay.Trim(Agent.GetFirstAware() - log.GetBossData().GetFirstAware(), despawnCheck.Time - log.GetBossData().GetFirstAware());
                     }
                     else
                     {

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
@@ -21,6 +21,7 @@ namespace LuckParser.Models.ParseModels
         }
 
         public abstract long GetDuration(ushort src, long start = 0, long end = 0);
+        public abstract long GetDuration(long start = 0, long end = 0);
 
 
         public long GetStart()

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemDuration.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemDuration.cs
@@ -17,6 +17,14 @@ namespace LuckParser.Models.ParseModels
 
         public override long GetDuration(ushort src, long start = 0, long end = 0)
         {
+            if (src != _src)
+            {
+                return 0;
+            }
+            return GetItemDuration(start, end);
+        }
+        public override long GetDuration(long start = 0, long end = 0)
+        {
             return GetItemDuration(start, end);
         }
         public override void SetEnd(long end)
@@ -40,6 +48,10 @@ namespace LuckParser.Models.ParseModels
 
         public override long GetOverstack(ushort src, long start = 0, long end = 0)
         {
+            if (src != _src)
+            {
+                return 0;
+            }
             if (end > 0 && Duration > 0)
             {
                 long dur = GetItemDuration(start, end);

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemIntensity.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemIntensity.cs
@@ -15,7 +15,7 @@ namespace LuckParser.Models.ParseModels
             {
                 _stacks.Add(new BoonSimulationItemDuration(stack));
             }
-            Duration = _stacks.Max(x => x.GetDuration(0));
+            Duration = _stacks.Max(x => x.GetDuration());
         }
 
         public override void SetEnd(long end)
@@ -24,29 +24,28 @@ namespace LuckParser.Models.ParseModels
             {
                 stack.SetEnd(end);
             }
-            Duration = _stacks.Max(x => x.GetDuration(0));
+            Duration = _stacks.Max(x => x.GetDuration());
         }
 
         public override long GetDuration(ushort src, long start = 0, long end = 0)
         {
             long total = 0;
-            if (src == 0)
+            foreach (BoonSimulationItemDuration stack in _stacks.Where(x => x.GetSrc()[0] == src))
             {
-                foreach (BoonSimulationItemDuration stack in _stacks)
-                {
-                    total += stack.GetDuration(src, start, end);
-                }
-            } else
-            {
-
-                foreach (BoonSimulationItemDuration stack in _stacks.Where(x => x.GetSrc()[0] == src))
-                {
-                    total += stack.GetDuration(src, start, end);
-                }
+                total += stack.GetDuration(src, start, end);
             }
             return total;
         }
-        
+        public override long GetDuration(long start = 0, long end = 0)
+        {
+            long total = 0;
+            foreach (BoonSimulationItemDuration stack in _stacks)
+            {
+                total += stack.GetDuration(start, end);
+            }
+            return total;
+        }
+
         public override List<ushort> GetSrc()
         {
             return _stacks.Select(x => x.GetSrc()[0]).Distinct().ToList();
@@ -60,20 +59,9 @@ namespace LuckParser.Models.ParseModels
         public override long GetOverstack(ushort src, long start = 0, long end = 0)
         {
             long total = 0;
-            if (src == 0)
+            foreach (BoonSimulationItemDuration stack in _stacks.Where(x => x.GetSrc()[0] == src))
             {
-                foreach (BoonSimulationItemDuration stack in _stacks)
-                {
-                    total += stack.GetOverstack(src, start, end);
-                }
-            }
-            else
-            {
-
-                foreach (BoonSimulationItemDuration stack in _stacks.Where(x => x.GetSrc()[0] == src))
-                {
-                    total += stack.GetOverstack(src, start, end);
-                }
+                total += stack.GetOverstack(src, start, end);
             }
             return total;
         }

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
@@ -72,7 +72,7 @@ namespace LuckParser.Models.ParseModels
                     break;
                 }
             }
-            Simulation.RemoveAll(x => x.GetDuration(0) <= 0);
+            Simulation.RemoveAll(x => x.GetDuration() <= 0);
         }
 
         public void Simulate(List<BoonLog> logs, long fightDuration)
@@ -87,7 +87,7 @@ namespace LuckParser.Models.ParseModels
                 timePrev = timeCur;
             }
             Update(fightDuration - timePrev);
-            Simulation.RemoveAll(x => x.GetDuration(0) <= 0);
+            Simulation.RemoveAll(x => x.GetDuration() <= 0);
             BoonStack.Clear();
         }
 

--- a/LuckParser/Properties/AssemblyInfo.cs
+++ b/LuckParser/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.4.0")]
-[assembly: AssemblyFileVersion("1.6.4.0")]
+[assembly: AssemblyVersion("1.6.5.0")]
+[assembly: AssemblyFileVersion("1.6.5.0")]


### PR DESCRIPTION
- Corrected some BoonRemove permissions (I'll do a pass on that later, I think a better solution can be found, the current method can pose problems on pre-casting stuff)
- Added TeamChange Enum to StateChange
- Corrected some naming violations
- Added CanCombatReplay to BossLogic to give more flexibility on bosses where CombatReplay can be used (instead of just checking fractal or raid)
- Fixed a bug where condition uptimes on golems could be higher than expected

Refactoring:
- Created RaidLogic.cs that each Raid bosses inherits from
- Added SetSuccess method to boss logic

Success Detection:
- BossLogic -> simple death check
- RaidLogic -> bouncy chest check
- GolemLogic -> start time changes to when PoV enters combat (if the event is present) so that the parsing is focused on the PoV (useful for when you have a clone slave with you or naked allies during the bench), end time changes last time golem receives damage (if the event is present), since the movement data addition, the log ends slightly later than before
- FractalLogic -> reward check while also checking the last time the boss received damage
- Arkk, Sko and Art -> specific stuff

To go into more details for the fractal detection:
- We are checking the reward event against the last time the boss received damage as daily login chests and fractal chests have the same id. We except the last damage done to be before the reward event (I've put 100ms instead of 0ms for the diff in case there are some delays)
- 99 CM is fine, from what I see the death event and reward event are basically at the same time (a few ms of difference).
- 100 CM is where the fun's at. 
   - Skorvald -> end time is the last time the boss receives damage when the death event is found without reward
   - Art -> she has 3 CombatExit events when the fight is successful, no need for reward check
  - Ark -> he has 3 CombatExit events when the fight is successful, no need for reward check