### PR TITLE
Performance

### DIFF
--- a/LuckParser/Controllers/GraphHelper.cs
+++ b/LuckParser/Controllers/GraphHelper.cs
@@ -55,7 +55,7 @@ namespace LuckParser.Controllers
             {
                 dmgListFull[totalTime] = totalDamage;
             }
-            CombatReplay replay = p.GetCombatReplay();
+            /*CombatReplay replay = p.GetCombatReplay();
             if (replay != null && dstid == 0 && phaseIndex == 0)
             {
                 foreach (int i in replay.GetTimes())
@@ -73,7 +73,7 @@ namespace LuckParser.Controllers
                         replay.AddDPS30s((int)Math.Round(1000 * (dmgListFull[i] - dmgListFull[limitId]) / (i - limitId)));
                     }
                 }
-            }
+            }*/
             dmgList.Add(new Point(0, 0));
             dmgList10s.Add(new Point(0, 0));
             dmgList30s.Add(new Point(0, 0));

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -91,7 +91,7 @@ namespace LuckParser.Models
         protected static List<CombatItem> GetFilteredList(ParsedLog log, long skillID, ushort instid)
         {
             bool needStart = true;
-            List<CombatItem> main = log.GetBoonData().Where(x => x.SkillID == skillID && ((x.DstInstid == instid && x.IsBuffRemove == ParseEnum.BuffRemove.None) || (x.SrcInstid == instid && x.IsBuffRemove != ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> main = log.GetBoonData(skillID).Where(x => ((x.DstInstid == instid && x.IsBuffRemove == ParseEnum.BuffRemove.None) || (x.SrcInstid == instid && x.IsBuffRemove != ParseEnum.BuffRemove.None))).ToList();
             List<CombatItem> filtered = new List<CombatItem>();
             for (int i = 0; i < main.Count; i++)
             {

--- a/LuckParser/Models/BossLogic/Cairn.cs
+++ b/LuckParser/Models/BossLogic/Cairn.cs
@@ -51,7 +51,7 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // shared agony
-            List<CombatItem> agony = log.GetBoonData().Where(x => x.SkillID == 38049 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> agony = log.GetBoonData(38049).Where(x => (x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None)).ToList();
             foreach (CombatItem c in agony)
             {
                 int agonyStart = (int)(c.Time - log.GetBossData().GetFirstAware());

--- a/LuckParser/Models/BossLogic/Deimos.cs
+++ b/LuckParser/Models/BossLogic/Deimos.cs
@@ -46,7 +46,7 @@ namespace LuckParser.Models
             long fightDuration = log.GetBossData().GetAwareDuration();
             List<PhaseData> phases = GetInitialPhase(log);
             // Determined + additional data on inst change
-            CombatItem invulDei = log.GetBoonData().Find(x => x.SkillID == 762 && x.IsBuffRemove == ParseEnum.BuffRemove.None && x.DstInstid == boss.GetInstid());
+            CombatItem invulDei = log.GetBoonData(762).Find(x => x.IsBuffRemove == ParseEnum.BuffRemove.None && x.DstInstid == boss.GetInstid());
             if (invulDei != null)
             {
                 end = invulDei.Time - log.GetBossData().GetFirstAware();

--- a/LuckParser/Models/BossLogic/Dhuum.cs
+++ b/LuckParser/Models/BossLogic/Dhuum.cs
@@ -72,7 +72,7 @@ namespace LuckParser.Models
             }
             else
             {
-                CombatItem invulDhuum = log.GetBoonData().FirstOrDefault(x => x.SkillID == 762 && x.IsBuffRemove != ParseEnum.BuffRemove.None && x.SrcInstid == boss.GetInstid() && x.Time > 115000 + log.GetBossData().GetFirstAware());
+                CombatItem invulDhuum = log.GetBoonData(762).FirstOrDefault(x => x.IsBuffRemove != ParseEnum.BuffRemove.None && x.SrcInstid == boss.GetInstid() && x.Time > 115000 + log.GetBossData().GetFirstAware());
                 if (invulDhuum != null)
                 {
                     end = invulDhuum.Time - log.GetBossData().GetFirstAware();
@@ -152,7 +152,7 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // spirit transform
-            List<CombatItem> spiritTransform = log.GetBoonData().Where(x => x.DstInstid == p.GetInstid() && x.SkillID == 46950 && x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
+            List<CombatItem> spiritTransform = log.GetBoonData(46950).Where(x => x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
             foreach (CombatItem c in spiritTransform)
             {
                 int duration = 15000;
@@ -161,7 +161,7 @@ namespace LuckParser.Models
                 {
                     duration = 30000;
                 }
-                CombatItem removedBuff = log.GetBoonData().FirstOrDefault(x => x.SrcInstid == p.GetInstid() && x.SkillID == 48281 && x.IsBuffRemove == ParseEnum.BuffRemove.All && x.Time > c.Time && x.Time < c.Time + duration);
+                CombatItem removedBuff = log.GetBoonData(48281).FirstOrDefault(x => x.SrcInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.All && x.Time > c.Time && x.Time < c.Time + duration);
                 int end = start + duration;
                 if (removedBuff != null)
                 {

--- a/LuckParser/Models/BossLogic/FractalLogic.cs
+++ b/LuckParser/Models/BossLogic/FractalLogic.cs
@@ -61,7 +61,7 @@ namespace LuckParser.Models
         protected void SetSuccessOnCombatExit(CombatData combatData, LogData logData, BossData bossData, int combatExitCount)
         {
             int combatExits = combatData.Count(x => x.SrcInstid == bossData.GetInstid() && x.IsStateChange == ParseEnum.StateChange.ExitCombat);
-            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData(bossData.GetInstid()).LastOrDefault(x => x.Value > 0);
             if (combatExits == combatExitCount && lastDamageTaken != null)
             {
                 logData.SetBossKill(true);
@@ -73,7 +73,7 @@ namespace LuckParser.Models
         {
             // check reward
             CombatItem reward = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.Reward);
-            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData(bossData.GetInstid()).LastOrDefault(x => x.Value > 0);
             if (lastDamageTaken != null)
             {
                 if (reward != null && lastDamageTaken.Time - reward.Time < 100)

--- a/LuckParser/Models/BossLogic/Golem.cs
+++ b/LuckParser/Models/BossLogic/Golem.cs
@@ -30,7 +30,7 @@ namespace LuckParser.Models
                     bossData.SetFirstAware(enterCombat.Time);
                 }
             }
-            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && (x.Value > 0 || x.BuffDmg > 0));
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData(bossData.GetInstid()).LastOrDefault(x => x.Value > 0 || x.BuffDmg > 0);
             if (lastDamageTaken != null)
             {
                 bossData.SetLastAware(lastDamageTaken.Time);

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -60,7 +60,7 @@ namespace LuckParser.Models
             }
             // add burn phases
             int offset = phases.Count;
-            List<CombatItem> orbItems = log.GetBoonData().Where(x => x.DstInstid == boss.GetInstid() && x.SkillID == 35096).ToList();
+            List<CombatItem> orbItems = log.GetBoonData(35096).Where(x => x.DstInstid == boss.GetInstid()).ToList();
             // Get number of orbs and filter the list
             List<CombatItem> orbItemsFiltered = new List<CombatItem>();
             Dictionary<long, int> orbs = new Dictionary<long, int>();

--- a/LuckParser/Models/BossLogic/Matthias.cs
+++ b/LuckParser/Models/BossLogic/Matthias.cs
@@ -100,7 +100,7 @@ namespace LuckParser.Models
                         ParseEnum.ThrashIDS.Storm
                     };
             List<CastLog> humanShield = cls.Where(x => x.GetID() == 34468).ToList();
-            List<int> humanShieldRemoval = log.GetBoonData().Where(x => x.SkillID == 34518 && x.IsBuffRemove == ParseEnum.BuffRemove.All).Select(x => (int)(x.Time - log.GetBossData().GetFirstAware())).Distinct().ToList();
+            List<int> humanShieldRemoval = log.GetBoonData(34518).Where(x => x.IsBuffRemove == ParseEnum.BuffRemove.All).Select(x => (int)(x.Time - log.GetBossData().GetFirstAware())).Distinct().ToList();
             for (var i = 0; i < humanShield.Count; i++)
             {
                 var shield = humanShield[i];
@@ -114,7 +114,7 @@ namespace LuckParser.Models
                 }
             }
             List<CastLog> aboShield = cls.Where(x => x.GetID() == 34510).ToList();
-            List<int> aboShieldRemoval = log.GetBoonData().Where(x => x.SkillID == 34376 && x.IsBuffRemove == ParseEnum.BuffRemove.All).Select(x => (int)(x.Time - log.GetBossData().GetFirstAware())).Distinct().ToList();
+            List<int> aboShieldRemoval = log.GetBoonData(34376).Where(x => x.IsBuffRemove == ParseEnum.BuffRemove.All).Select(x => (int)(x.Time - log.GetBossData().GetFirstAware())).Distinct().ToList();
             for (var i = 0; i < aboShield.Count; i++)
             {
                 var shield = aboShield[i];
@@ -201,7 +201,7 @@ namespace LuckParser.Models
                 }
             }
             // Bombs
-            List<CombatItem> zealousBenediction = log.GetBoonData().Where(x => x.SkillID == 34511 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> zealousBenediction = log.GetBoonData(34511).Where(x => (x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None)).ToList();
             foreach (CombatItem c in zealousBenediction)
             {
                 int zealousStart = (int)(c.Time - log.GetBossData().GetFirstAware()) ;

--- a/LuckParser/Models/BossLogic/Sabetha.cs
+++ b/LuckParser/Models/BossLogic/Sabetha.cs
@@ -110,7 +110,7 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // timed bombs
-            List<CombatItem> timedBombs = log.GetBoonData().Where(x => x.SkillID == 31485 && (x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None)).ToList();
+            List<CombatItem> timedBombs = log.GetBoonData(31485).Where(x => x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
             foreach (CombatItem c in timedBombs)
             {
                 int start = (int)(c.Time - log.GetBossData().GetFirstAware());

--- a/LuckParser/Models/BossLogic/Samarog.cs
+++ b/LuckParser/Models/BossLogic/Samarog.cs
@@ -110,7 +110,7 @@ namespace LuckParser.Models
                         ParseEnum.ThrashIDS.Rigom,
                         ParseEnum.ThrashIDS.Guldhem
                     };
-            List<CombatItem> brutalize = log.GetBoonData().Where(x => x.SkillID == 38226 && x.IsBuffRemove != ParseEnum.BuffRemove.Manual).ToList();
+            List<CombatItem> brutalize = log.GetBoonData(38226).Where(x => x.IsBuffRemove != ParseEnum.BuffRemove.Manual).ToList();
             int brutStart = 0;
             foreach (CombatItem c in brutalize)
             {
@@ -130,7 +130,7 @@ namespace LuckParser.Models
         public override void GetAdditionalPlayerData(CombatReplay replay, Player p, ParsedLog log)
         {
             // big bomb
-            List<CombatItem> bigbomb = log.GetBoonData().Where(x => x.SkillID == 37966 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> bigbomb = log.GetBoonData(37966).Where(x => (x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None)).ToList();
             foreach (CombatItem c in bigbomb)
             {
                 int bigStart = (int)(c.Time - log.GetBossData().GetFirstAware());
@@ -139,7 +139,7 @@ namespace LuckParser.Models
                 replay.AddCircleActor(new CircleActor(true, bigEnd, 300, new Tuple<int, int>(bigStart, bigEnd), "rgba(150, 80, 0, 0.2)"));
             }
             // small bomb
-            List<CombatItem> smallbomb = log.GetBoonData().Where(x => x.SkillID == 38247 && ((x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None))).ToList();
+            List<CombatItem> smallbomb = log.GetBoonData(38247).Where(x => (x.DstInstid == p.GetInstid() && x.IsBuffRemove == ParseEnum.BuffRemove.None)).ToList();
             foreach (CombatItem c in smallbomb)
             {
                 int smallStart = (int)(c.Time - log.GetBossData().GetFirstAware());

--- a/LuckParser/Models/BossLogic/Skorvald.cs
+++ b/LuckParser/Models/BossLogic/Skorvald.cs
@@ -58,7 +58,7 @@ namespace LuckParser.Models
         {
             // check reward
             CombatItem reward = combatData.LastOrDefault(x => x.IsStateChange == ParseEnum.StateChange.Reward);
-            CombatItem lastDamageTaken = combatData.GetDamageTakenData().LastOrDefault(x => x.DstInstid == bossData.GetInstid() && x.Value > 0);
+            CombatItem lastDamageTaken = combatData.GetDamageTakenData(bossData.GetInstid()).LastOrDefault(x => x.Value > 0);
             if (lastDamageTaken != null)
             {
                 if (reward != null && lastDamageTaken.Time - reward.Time < 100)

--- a/LuckParser/Models/BossLogic/Xera.cs
+++ b/LuckParser/Models/BossLogic/Xera.cs
@@ -49,7 +49,11 @@ namespace LuckParser.Models
             // split happened
             if (boss.GetPhaseData().Count == 1)
             {
-                CombatItem invulXera = log.GetBoonData().Find(x => x.DstInstid == boss.GetInstid() && (x.SkillID == 762 || x.SkillID == 34113));
+                CombatItem invulXera = log.GetBoonData(762).Find(x => x.DstInstid == boss.GetInstid());
+                if (invulXera == null)
+                {
+                    invulXera = log.GetBoonData(34113).Find(x => x.DstInstid == boss.GetInstid());
+                }
                 long end = invulXera.Time - log.GetBossData().GetFirstAware();
                 phases.Add(new PhaseData(start, end));
                 start = boss.GetPhaseData()[0] - log.GetBossData().GetFirstAware();

--- a/LuckParser/Models/DataModels/ParsedLog.cs
+++ b/LuckParser/Models/DataModels/ParsedLog.cs
@@ -74,30 +74,60 @@ namespace LuckParser.Models.DataModels
             return _combatData;
         }
 
-        public List<CombatItem> GetBoonData()
+        public Dictionary<long, List<CombatItem>> GetBoonData()
         {
             return _combatData.GetBoonData();
         }
 
-        public List<CombatItem> GetDamageData()
+        public List<CombatItem> GetBoonData(long key)
+        {
+            return _combatData.GetBoonData(key);
+        }
+
+        public Dictionary<ushort, List<CombatItem>> GetDamageData()
         {
             return _combatData.GetDamageData();
         }
 
-        public List<CombatItem> GetCastData()
+        public List<CombatItem> GetDamageData(ushort key)
+        {
+            return _combatData.GetDamageData(key);
+        }
+
+        public Dictionary<ushort, List<CombatItem>> GetCastData()
         {
             return _combatData.GetCastData();
         }
 
-        public List<CombatItem> GetDamageTakenData()
+        public List<CombatItem> GetCastData(ushort key)
+        {
+            return _combatData.GetCastData(key);
+        }
+
+        public Dictionary<long, List<CombatItem>> GetCastDataById()
+        {
+            return _combatData.GetCastDataById();
+        }
+        public List<CombatItem> GetCastDataById(long key)
+        {
+            return _combatData.GetCastDataById(key);
+        }
+
+        public Dictionary<ushort, List<CombatItem>> GetDamageTakenData()
         {
             return _combatData.GetDamageTakenData();
+        }
+
+        public List<CombatItem> GetDamageTakenData(ushort key)
+        {
+            return _combatData.GetDamageTakenData(key);
         }
 
         public bool IsBenchmarkMode()
         {
             return _bossData.GetBossBehavior().GetMode() == BossLogic.ParseMode.Golem;
         }
+
 
         /*public List<CombatItem> getHealingData()
         {
@@ -109,9 +139,14 @@ namespace LuckParser.Models.DataModels
             return _combatData.getHealingReceivedData();
         }*/
 
-        public List<CombatItem> GetMovementData()
+        public Dictionary<ushort, List<CombatItem>> GetMovementData()
         {
             return _combatData.GetMovementData();
-        }     
+        }
+
+        public List<CombatItem> GetMovementData(ushort key)
+        {
+            return _combatData.GetMovementData(key);
+        }
     }
 }

--- a/LuckParser/Models/DataModels/ParsedLog.cs
+++ b/LuckParser/Models/DataModels/ParsedLog.cs
@@ -84,6 +84,16 @@ namespace LuckParser.Models.DataModels
             return _combatData.GetBoonData(key);
         }
 
+        public Dictionary<ushort, List<CombatItem>> GetBoonDataByDst()
+        {
+            return _combatData.GetBoonDataByDst();
+        }
+
+        public List<CombatItem> GetBoonDataByDst(ushort key)
+        {
+            return _combatData.GetBoonDataByDst(key);
+        }
+
         public Dictionary<ushort, List<CombatItem>> GetDamageData()
         {
             return _combatData.GetDamageData();

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -8,6 +8,7 @@ namespace LuckParser.Models.ParseModels
     {
         // reduced data
         private Dictionary<long, List<CombatItem>> _boonData;
+        private Dictionary<ushort, List<CombatItem>> _boonDataByDst;
         private Dictionary<ushort, List<CombatItem>> _damageData;
         private Dictionary<ushort, List<CombatItem>> _damageTakenData;
         //private List<CombatItem> _healingData;
@@ -60,7 +61,9 @@ namespace LuckParser.Models.ParseModels
         }
         public void Validate(BossData bossData)
         {
-            _boonData = this.Where(x => x.IsBuff > 0 && (x.IsBuff == 18 || x.BuffDmg == 0 || x.IsBuffRemove != ParseEnum.BuffRemove.None)).GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
+            var boonData = this.Where(x => x.IsBuff > 0 && (x.IsBuff == 18 || x.BuffDmg == 0 || x.IsBuffRemove != ParseEnum.BuffRemove.None));
+            _boonData = boonData.GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
+            _boonDataByDst = boonData.GroupBy(x => x.IsBuffRemove == ParseEnum.BuffRemove.None ? x.DstInstid : x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
 
             _damageData = this.Where(x => x.DstInstid != 0 && x.IsStateChange == ParseEnum.StateChange.Normal && x.IFF == ParseEnum.IFF.Foe && x.IsBuffRemove == ParseEnum.BuffRemove.None &&
                                         ((x.IsBuff == 1 && x.BuffDmg > 0 && x.Value == 0) ||
@@ -93,6 +96,19 @@ namespace LuckParser.Models.ParseModels
         public List<CombatItem> GetBoonData(long key)
         {
             if (_boonData.TryGetValue(key, out List<CombatItem> res))
+            {
+                return res;
+            }
+            return new List<CombatItem>(); ;
+        }
+
+        public Dictionary<ushort, List<CombatItem>> GetBoonDataByDst()
+        {
+            return _boonDataByDst;
+        }
+        public List<CombatItem> GetBoonDataByDst(ushort key)
+        {
+            if (_boonDataByDst.TryGetValue(key, out List<CombatItem> res))
             {
                 return res;
             }

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -7,13 +7,14 @@ namespace LuckParser.Models.ParseModels
     public class CombatData : List<CombatItem>
     {
         // reduced data
-        private List<CombatItem> _boonData;
-        private List<CombatItem> _damageData;
-        private List<CombatItem> _damageTakenData;
+        private Dictionary<long, List<CombatItem>> _boonData;
+        private Dictionary<ushort, List<CombatItem>> _damageData;
+        private Dictionary<ushort, List<CombatItem>> _damageTakenData;
         //private List<CombatItem> _healingData;
         //private List<CombatItem> _healingReceivedData;
-        private List<CombatItem> _castData;
-        private List<CombatItem> _movementData;
+        private Dictionary<ushort,List<CombatItem>> _castData;
+        private Dictionary<long, List<CombatItem>> _castDataById;
+        private Dictionary<ushort, List<CombatItem>> _movementData;
         // Public Methods
 
         public List<CombatItem> GetStates(int srcInstid, ParseEnum.StateChange change, long start, long end)
@@ -59,19 +60,22 @@ namespace LuckParser.Models.ParseModels
         }
         public void Validate(BossData bossData)
         {
-            _boonData = this.Where(x => x.IsBuff > 0 && (x.IsBuff == 18 || x.BuffDmg == 0 || x.IsBuffRemove != ParseEnum.BuffRemove.None)).ToList();
+            _boonData = this.Where(x => x.IsBuff > 0 && (x.IsBuff == 18 || x.BuffDmg == 0 || x.IsBuffRemove != ParseEnum.BuffRemove.None)).GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
 
             _damageData = this.Where(x => x.DstInstid != 0 && x.IsStateChange == ParseEnum.StateChange.Normal && x.IFF == ParseEnum.IFF.Foe && x.IsBuffRemove == ParseEnum.BuffRemove.None &&
                                         ((x.IsBuff == 1 && x.BuffDmg > 0 && x.Value == 0) ||
-                                        (x.IsBuff == 0 && x.Value > 0))).ToList();
+                                        (x.IsBuff == 0 && x.Value > 0))).GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
 
             _damageTakenData = this.Where(x => x.IsStateChange == ParseEnum.StateChange.Normal && x.IsBuffRemove == ParseEnum.BuffRemove.None &&
                                             ((x.IsBuff == 1 && x.BuffDmg >= 0 && x.Value == 0) ||
-                                                (x.IsBuff == 0 && x.Value >= 0))).ToList();
+                                                (x.IsBuff == 0 && x.Value >= 0))).GroupBy(x => x.DstInstid).ToDictionary(x => x.Key, x => x.ToList());
 
-            _castData = this.Where(x => (x.IsStateChange == ParseEnum.StateChange.Normal && x.IsActivation != ParseEnum.Activation.None) || x.IsStateChange == ParseEnum.StateChange.WeaponSwap).ToList();
+            var castData = this.Where(x => (x.IsStateChange == ParseEnum.StateChange.Normal && x.IsActivation != ParseEnum.Activation.None) || x.IsStateChange == ParseEnum.StateChange.WeaponSwap);
 
-            _movementData = (bossData.GetBossBehavior().CanCombatReplay) ? this.Where(x => x.IsStateChange == ParseEnum.StateChange.Position || x.IsStateChange == ParseEnum.StateChange.Velocity).ToList() : new List<CombatItem>();
+            _castData = castData.GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
+            _castDataById = castData.GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
+
+            _movementData = (bossData.GetBossBehavior().CanCombatReplay) ? this.Where(x => x.IsStateChange == ParseEnum.StateChange.Position || x.IsStateChange == ParseEnum.StateChange.Velocity).GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList()) : new Dictionary<ushort, List<CombatItem>>();
 
             /*healing_data = this.Where(x => x.getDstInstid() != 0 && x.isStateChange() == ParseEnum.StateChange.Normal && x.getIFF() == ParseEnum.IFF.Friend && x.isBuffremove() == ParseEnum.BuffRemove.None &&
                                          ((x.isBuff() == 1 && x.getBuffDmg() > 0 && x.getValue() == 0) ||
@@ -82,24 +86,70 @@ namespace LuckParser.Models.ParseModels
                                                 (x.isBuff() == 0 && x.getValue() >= 0))).ToList();*/
         }
         // getters
-        public List<CombatItem> GetBoonData()
+        public Dictionary<long, List<CombatItem>> GetBoonData()
         {
             return _boonData;
         }
+        public List<CombatItem> GetBoonData(long key)
+        {
+            if (_boonData.TryGetValue(key, out List<CombatItem> res))
+            {
+                return res;
+            }
+            return new List<CombatItem>(); ;
+        }
 
-        public List<CombatItem> GetDamageData()
+        public Dictionary<ushort, List<CombatItem>> GetDamageData()
         {
             return _damageData;
         }
+        public List<CombatItem> GetDamageData(ushort key)
+        {
+            if (_damageData.TryGetValue(key, out List<CombatItem> res))
+            {
+                return res;
+            }
+            return new List<CombatItem>(); ;
+        }
 
-        public List<CombatItem> GetCastData()
+        public Dictionary<ushort, List<CombatItem>> GetCastData()
         {
             return _castData;
         }
+        public List<CombatItem> GetCastData(ushort key)
+        {
+            if (_castData.TryGetValue(key, out List<CombatItem> res))
+            {
+                return res;
+            }
+            return new List<CombatItem>(); ;
+        }
 
-        public List<CombatItem> GetDamageTakenData()
+        public Dictionary<long, List<CombatItem>> GetCastDataById()
+        {
+            return _castDataById;
+        }
+        public List<CombatItem> GetCastDataById(long key)
+        {
+            if (_castDataById.TryGetValue(key, out List<CombatItem> res))
+            {
+                return res;
+            }
+            return new List<CombatItem>(); ;
+        }
+
+        public Dictionary<ushort, List<CombatItem>> GetDamageTakenData()
         {
             return _damageTakenData;
+        }
+
+        public List<CombatItem> GetDamageTakenData(ushort key)
+        {
+            if (_damageTakenData.TryGetValue(key, out List<CombatItem> res))
+            {
+                return res;
+            }
+            return new List<CombatItem>(); ;
         }
 
         /*public List<CombatItem> getHealingData()
@@ -112,9 +162,17 @@ namespace LuckParser.Models.ParseModels
             return _healingReceivedData;
         }*/
 
-        public List<CombatItem> GetMovementData()
+        public Dictionary<ushort, List<CombatItem>> GetMovementData()
         {
             return _movementData;
+        }
+        public List<CombatItem> GetMovementData(ushort key)
+        {
+            if (_movementData.TryGetValue(key, out List<CombatItem> res))
+            {
+                return res;
+            }
+            return new List<CombatItem>(); ;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -447,14 +447,14 @@ namespace LuckParser.Models.ParseModels
                     var graphPoints = new List<Point>(capacity: fightDuration + 1);
                     var boonPresence = boonPresencePoints.GetBoonChart();
                     var condiPresence = condiPresencePoints.GetBoonChart();
-                    if (Replay != null && (updateCondiPresence || updateBoonPresence || defIds.Contains(boonid) || offIds.Contains(boonid)))
+                    /*if (Replay != null && (updateCondiPresence || updateBoonPresence || defIds.Contains(boonid) || offIds.Contains(boonid)))
                     {
                         foreach (int time in Replay.GetTimes())
                         {
                             Replay.AddBoon(boonid, simulation.GetBoonStackCount(time));
                         }
 
-                    }
+                    }*/
                     for (int i = 0; i <= fightDuration; i++)
                     {
                         graphPoints.Add(new Point(i, simulation.GetBoonStackCount(1000 * i)));

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -170,9 +170,9 @@ namespace LuckParser.Models.ParseModels
                 }
                 long time = c.Time - timeStart;
                 // don't add buff initial table boons and buffs in non golem mode, for others overstack is irrelevant
-                if (c.IsStateChange == ParseEnum.StateChange.BuffInitial && (log.IsBenchmarkMode() || !tableIds.Contains(c.SkillID)))
+                if (c.IsStateChange == ParseEnum.StateChange.BuffInitial && (log.IsBenchmarkMode() || !tableIds.Contains(boonId)))
                 {
-                    List<BoonLog> loglist = boonMap[c.SkillID];
+                    List<BoonLog> loglist = boonMap[boonId];
                     loglist.Add(new BoonLog(0, 0, long.MaxValue, 0));
                 }
                 else if (c.IsStateChange != ParseEnum.StateChange.BuffInitial && time >= 0 && time < log.GetBossData().GetAwareDuration())
@@ -180,7 +180,7 @@ namespace LuckParser.Models.ParseModels
                     if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                     {
                         ushort src = c.SrcMasterInstid > 0 ? c.SrcMasterInstid : c.SrcInstid;
-                        List<BoonLog> loglist = boonMap[c.SkillID];
+                        List<BoonLog> loglist = boonMap[boonId];
 
                         if (loglist.Count == 0 && c.OverstackValue > 0)
                         {
@@ -188,11 +188,11 @@ namespace LuckParser.Models.ParseModels
                         }
                         loglist.Add(new BoonLog(time, src, c.Value, 0));
                     }
-                    else if (Boon.RemovePermission(c.SkillID, c.IsBuffRemove, c.IFF) && time < log.GetBossData().GetAwareDuration() - 50)
+                    else if (Boon.RemovePermission(boonId, c.IsBuffRemove, c.IFF) && time < log.GetBossData().GetAwareDuration() - 50)
                     {
                         if (c.IsBuffRemove == ParseEnum.BuffRemove.All)//All
                         {
-                            List<BoonLog> loglist = boonMap[c.SkillID];
+                            List<BoonLog> loglist = boonMap[boonId];
                             if (loglist.Count == 0)
                             {
                                 loglist.Add(new BoonLog(0, 0, time, 0));
@@ -214,7 +214,7 @@ namespace LuckParser.Models.ParseModels
                         }
                         else if (c.IsBuffRemove == ParseEnum.BuffRemove.Single)//Single
                         {
-                            List<BoonLog> loglist = boonMap[c.SkillID];
+                            List<BoonLog> loglist = boonMap[boonId];
                             if (loglist.Count == 0)
                             {
                                 loglist.Add(new BoonLog(0, 0, time, 0));
@@ -234,7 +234,7 @@ namespace LuckParser.Models.ParseModels
                         }
                         else if (c.IsBuffRemove == ParseEnum.BuffRemove.Manual)//Manuel
                         {
-                            List<BoonLog> loglist = boonMap[c.SkillID];
+                            List<BoonLog> loglist = boonMap[boonId];
                             if (loglist.Count == 0)
                             {
                                 loglist.Add(new BoonLog(0, 0, time, 0));

--- a/LuckParser/Models/ParseModels/Players/Player.cs
+++ b/LuckParser/Models/ParseModels/Players/Player.cs
@@ -220,8 +220,8 @@ namespace LuckParser.Models.ParseModels
         protected override void SetDamagetakenLogs(ParsedLog log)
         {
             long timeStart = log.GetBossData().GetFirstAware();               
-            foreach (CombatItem c in log.GetDamageTakenData()) {
-                if (Agent.GetInstid() == c.DstInstid && c.Time > log.GetBossData().GetFirstAware() && c.Time < log.GetBossData().GetLastAware()) {//selecting player as target
+            foreach (CombatItem c in log.GetDamageTakenData(Agent.GetInstid())) {
+                if (c.Time > log.GetBossData().GetFirstAware() && c.Time < log.GetBossData().GetLastAware()) {//selecting player as target
                     long time = c.Time - timeStart;
                     AddDamageTakenLog(time, c);
                 }
@@ -229,32 +229,30 @@ namespace LuckParser.Models.ParseModels
         }  
         private void SetConsumablesList(ParsedLog log)
         {
-            List<Boon> foodBoon = Boon.GetFoodList();
-            List<Boon> utilityBoon = Boon.GetUtilityList();
+            List<Boon> consumableList = Boon.GetFoodList();
+            consumableList.AddRange(Boon.GetUtilityList());
             long timeStart = log.GetBossData().GetFirstAware();
             long fightDuration = log.GetBossData().GetLastAware() - timeStart;
-            foreach (CombatItem c in log.GetBoonData())
+            foreach (Boon consumable in consumableList)
             {
-                if ( c.IsBuffRemove != ParseEnum.BuffRemove.None || (c.IsBuff != 18 && c.IsBuff != 1) || Agent.GetInstid() != c.DstInstid)
+                foreach (CombatItem c in log.GetBoonData(consumable.GetID()))
                 {
-                    continue;
-                }
-                var food = foodBoon.FirstOrDefault(x => x.GetID() == c.SkillID);
-                var utility = utilityBoon.FirstOrDefault(x => x.GetID() == c.SkillID);
-                if (food == null && utility == null)
-                {
-                    continue;
-                }
-                long time = 0;
-                if (c.IsBuff != 18)
-                {
-                    time = c.Time - timeStart;
-                }
-                if (time <= fightDuration)
-                {
-                    _consumeList.Add(new Tuple<Boon, long>(food ?? utility, time)); 
+                    if (c.IsBuffRemove != ParseEnum.BuffRemove.None || (c.IsBuff != 18 && c.IsBuff != 1) || Agent.GetInstid() != c.DstInstid)
+                    {
+                        continue;
+                    }
+                    long time = 0;
+                    if (c.IsBuff != 18)
+                    {
+                        time = c.Time - timeStart;
+                    }
+                    if (time <= fightDuration)
+                    {
+                        _consumeList.Add(new Tuple<Boon, long>(consumable, time));
+                    }
                 }
             }
+            
         }
 
         protected override void SetAdditionalCombatReplayData(ParsedLog log, int pollingRate)
@@ -332,7 +330,7 @@ namespace LuckParser.Models.ParseModels
                         toUse = combatData.GetStates(GetInstid(), ParseEnum.StateChange.ChangeDown, start, end);
                         break;
                     case SkillItem.ResurrectId:
-                        toUse = log.GetCastData().Where(x => x.SkillID == SkillItem.ResurrectId && x.SrcInstid == GetInstid() && x.IsActivation.IsCasting()).ToList();
+                        toUse = log.GetCastData(GetInstid()).Where(x => x.SkillID == SkillItem.ResurrectId && x.IsActivation.IsCasting()).ToList();
                         break;
                 }
                 foreach (CombatItem pnt in toUse)
@@ -365,7 +363,7 @@ namespace LuckParser.Models.ParseModels
             foreach (Mechanic mech in playerBoon)
             {
                 Mechanic.SpecialCondition condition = mech.GetSpecialCondition();
-                foreach (CombatItem c in log.GetBoonData())
+                foreach (CombatItem c in log.GetBoonData(mech.GetSkill()))
                 {
                     if (condition != null && !condition(c.Value))
                     {
@@ -373,14 +371,14 @@ namespace LuckParser.Models.ParseModels
                     }
                     if (mech.GetMechType() == Mechanic.MechType.PlayerBoonRemove)
                     {
-                        if (c.SkillID == mech.GetSkill() && c.IsBuffRemove == ParseEnum.BuffRemove.Manual && GetInstid() == c.SrcInstid)
+                        if (c.IsBuffRemove == ParseEnum.BuffRemove.Manual && GetInstid() == c.SrcInstid)
                         {
                             mechData[mech].Add(new MechanicLog(c.Time - start, mech, this));
                         }
                     } else
                     {
 
-                        if (c.SkillID == mech.GetSkill() && c.IsBuffRemove == ParseEnum.BuffRemove.None && GetInstid() == c.DstInstid)
+                        if (c.IsBuffRemove == ParseEnum.BuffRemove.None && GetInstid() == c.DstInstid)
                         {
                             mechData[mech].Add(new MechanicLog(c.Time - start, mech, this));
                             if (mech.GetMechType() == Mechanic.MechType.PlayerOnPlayer)


### PR DESCRIPTION
- Disabled some unused CombatReplay devs (dps info and boon info) -> roughly 8%, will be lost once I start using that dev, but for now it's useless
- Made each sub data sets (boonData, castData, damageData, damageTakenData, movementData) into lookups by srcId except for damageTaken(dstId) and boonData (boonId)
- Created boonDataByDst (srcId for buff remove, dstId otherwise)
- Created castDataById 

Those last 3 points improve performances by roughly 12%.