### PR TITLE
Add sanity check when parsing combat items

### DIFF
--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -410,12 +410,31 @@ namespace LuckParser.Controllers
                 {
                     if(!TryRead(stream, data)) break;
                     ms.Seek(0, SeekOrigin.Begin);
-                    _combatData.Add( _revision > 0 ? ReadCombatItemRev1(reader) : ReadCombatItem(reader));
+                    CombatItem combatItem  = _revision > 0 ? ReadCombatItemRev1(reader) : ReadCombatItem(reader);
+                    if (!IsValid(combatItem)) continue;
+                    _combatData.Add(combatItem);
                 }
             }
             _combatData.RemoveAll(x => x.SrcInstid == 0 && x.DstAgent == 0 && x.SrcAgent == 0 && x.DstInstid == 0 && x.IFF == ParseEnum.IFF.Unknown);
         }
-        
+
+        /// <summary>
+        /// Returns true if the combat item contains valid data and should be used, false otherwise
+        /// </summary>
+        /// <param name="combatItem"></param>
+        /// <returns>true if the combat item is valid</returns>
+        private bool IsValid(CombatItem combatItem)
+        {
+            if (combatItem.IsStateChange == ParseEnum.StateChange.HealthUpdate && combatItem.DstAgent > 20000)
+            {
+                // DstAgent should be boss health % times 100, values higher than 10000 are unlikely. 
+                // If it is more than 200% health ignore this record
+                return false;
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Parses all the data again and link related stuff to each other
         /// </summary>


### PR DESCRIPTION
Fixes strange bosshealth spikes in certain encounter logs.

A single boss health value of several thousand percent is causing this bug.

Added a sanity check method to the parser to filter such records out; the only filter right now are HealthUpdate events with more than 200% (any value above 100% is likely buggy)