### PR TITLE
Boon Graph rework

### DIFF
--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -1672,7 +1672,7 @@ namespace LuckParser.Controllers
                                         if (_statistics.PresentBoons.Count > 0)
                                         {
                                             Dictionary<long, BoonsGraphModel> boonGraphData = p.GetBoonGraphs(_log, phases);
-                                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.GetBoonName() != "Number of Conditions"))
+                                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.BoonName != "Number of Conditions"))
                                             {
                                                 sw.Write("{");
                                                 {
@@ -1682,7 +1682,7 @@ namespace LuckParser.Controllers
 
                                             }
                                             boonGraphData = _log.GetBoss().GetBoonGraphs(_log, phases);
-                                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.GetBoonName() == "Compromised" || x.GetBoonName() == "Unnatural Signet"))
+                                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.BoonName == "Compromised" || x.BoonName == "Unnatural Signet"))
                                             {
                                                 sw.Write("{");
                                                 {
@@ -3102,7 +3102,7 @@ namespace LuckParser.Controllers
                             }
                             //============================================
                             Dictionary<long, BoonsGraphModel> boonGraphData = _log.GetBoss().GetBoonGraphs(_log, phases);
-                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.GetBoonName() != "Number of Boons"))
+                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.BoonName != "Number of Boons"))
                             {
                                 sw.Write("{");
                                 {

--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -1764,7 +1764,7 @@ namespace LuckParser.Controllers
                                                  "}," +
                                                  "legend: { traceorder: 'reversed' }," +
                                                  "hovermode: 'compare'," +
-                                                 "yaxis2: { title: 'Boons', domain: [0.11, 0.50], fixedrange: true }," +
+                                                 "yaxis2: { title: 'Boons', domain: [0.11, 0.50], fixedrange: true, dtick: 1.0,tick0: 0, gridcolor: '#909090', }," +
                                                  "yaxis3: { title: 'DPS', domain: [0.51, 1] },"
                                          );
                                         sw.Write("images: [");

--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -491,7 +491,7 @@ namespace LuckParser.Controllers
         {
             long roundedStart = 1000 * (start / 1000);
             long roundedEnd = 1000 * (end / 1000);
-            List<BoonsGraphModel.Segment> bChart = bgm.GetBoonChart().Where(x => x.End >= roundedStart && x.Start <= roundedEnd).ToList();
+            List<BoonsGraphModel.Segment> bChart = bgm.BoonChart.Where(x => x.End >= roundedStart && x.Start <= roundedEnd).ToList();
             int bChartCount = 0;
             sw.Write("y: [");
             {
@@ -509,7 +509,7 @@ namespace LuckParser.Controllers
                     }
                     bChartCount++;
                 }
-                if (bgm.GetBoonChart().Count == 0)
+                if (bgm.BoonChart.Count == 0)
                 {
                     sw.Write("'0'");
                 }
@@ -534,7 +534,7 @@ namespace LuckParser.Controllers
                     }
                     bChartCount++;
                 }
-                if (bgm.GetBoonChart().Count == 0)
+                if (bgm.BoonChart.Count == 0)
                 {
                     sw.Write("'0'");
                 }
@@ -543,17 +543,13 @@ namespace LuckParser.Controllers
             sw.Write(" yaxis: 'y2'," +
                  " type: 'scatter',");
             //  "legendgroup: '"+Boon.getEnum(bgm.getBoonName()).getPloltyGroup()+"',";
-            if (bgm.GetBoonName() == "Might" || bgm.GetBoonName() == "Quickness")
-            {
-
-            }
-            else
+            if (!(bgm.BoonName == "Might" || bgm.BoonName == "Quickness"))
             {
                 sw.Write(" visible: 'legendonly',");
             }
-            sw.Write(" line: {color:'" + GetLink("Color-" + bgm.GetBoonName()) + "'},");
+            sw.Write(" line: {color:'" + GetLink("Color-" + bgm.BoonName) + "'},");
             sw.Write(" fill: 'tozeroy'," +
-                 " name: \"" + bgm.GetBoonName() + "\"");
+                 " name: \"" + bgm.BoonName + "\"");
         }
 
         public static void WritePlayerTabDPSGraph(StreamWriter sw, string name, List<Point> playerdpsgraphdata, AbstractPlayer p)

--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -489,19 +489,23 @@ namespace LuckParser.Controllers
 
         public static void WritePlayerTabBoonGraph(StreamWriter sw, BoonsGraphModel bgm, long start, long end)
         {
-            List<Point> bChart = bgm.GetBoonChart().Where(x => x.X >= start / 1000 && x.X <= end / 1000).ToList();
+            long roundedStart = 1000 * (start / 1000);
+            long roundedEnd = 1000 * (end / 1000);
+            List<BoonsGraphModel.Segment> bChart = bgm.GetBoonChart().Where(x => x.End >= roundedStart && x.Start <= roundedEnd).ToList();
             int bChartCount = 0;
             sw.Write("y: [");
             {
-                foreach (Point pnt in bChart)
+                foreach (BoonsGraphModel.Segment seg in bChart)
                 {
                     if (bChartCount == bChart.Count - 1)
                     {
-                        sw.Write("'" + pnt.Y + "'");
+                        sw.Write("'" + seg.Value + "',");
+                        sw.Write("'" + seg.Value + "'");
                     }
                     else
                     {
-                        sw.Write("'" + pnt.Y + "',");
+                        sw.Write("'" + seg.Value + "',");
+                        sw.Write("'" + seg.Value + "',");
                     }
                     bChartCount++;
                 }
@@ -514,15 +518,19 @@ namespace LuckParser.Controllers
             sw.Write("x: [");
             {
                 bChartCount = 0;
-                foreach (Point pnt in bChart)
+                foreach (BoonsGraphModel.Segment seg in bChart)
                 {
+                    double segStart = Math.Round(Math.Max(seg.Start - roundedStart, 0) / 1000.0,3);
+                    double segEnd = Math.Round(Math.Min(seg.End - roundedStart, roundedEnd - roundedStart) / 1000.0,3);
                     if (bChartCount == bChart.Count - 1)
                     {
-                        sw.Write("'" + (pnt.X - (int)start / 1000) + "'");
+                        sw.Write("'" + segStart + "',");
+                        sw.Write("'" + segEnd + "'");
                     }
                     else
                     {
-                        sw.Write("'" + (pnt.X - (int)start / 1000) + "',");
+                        sw.Write("'" + segStart + "',");
+                        sw.Write("'" + segEnd + "',");
                     }
                     bChartCount++;
                 }

--- a/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
+++ b/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
@@ -1,28 +1,70 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 
 namespace LuckParser.Models.ParseModels
 {
     public class BoonsGraphModel
     {
+
+        public class Segment
+        {
+            public readonly long Start;
+            public long End { get; set; }
+            public readonly int Value;
+
+            public Segment(long start, long end, int value)
+            {
+                Start = start;
+                End = end;
+                Value = value;
+            }
+
+            public Segment(Segment other)
+            {
+                Start = other.Start;
+                End = other.End;
+                Value = other.Value;
+            }
+        }
+
         private readonly string _boonName;
-        private readonly List<Point> _boonChart = new List<Point>();
+        private readonly List<Segment> _boonChart = new List<Segment>();
 
         // Constructor
         public BoonsGraphModel(string boonName)
         {
             _boonName = boonName;
         }
-        public BoonsGraphModel(string boonName, List<Point> boonChart)
+        public BoonsGraphModel(string boonName, List<Segment> boonChart)
         {
             _boonName = boonName;
-            _boonChart = boonChart;
+            // Fuse segments
+            Segment last = null;
+            foreach(Segment seg in boonChart)
+            {
+                if (last == null)
+                {
+                    _boonChart.Add(new Segment(seg));
+                    last = _boonChart.Last();
+                } else
+                {
+                    if (seg.Value == last.Value)
+                    {
+                        last.End = seg.End;
+                    } else
+                    {
+                        _boonChart.Add(new Segment(seg));
+                        last = _boonChart.Last();
+                    }
+                }
+            }
         }
         //getters
         public string GetBoonName() {
             return _boonName;
         }
-        public List<Point> GetBoonChart()
+        public List<Segment> GetBoonChart()
         {
             return _boonChart;
         }

--- a/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
+++ b/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
@@ -40,10 +40,10 @@ namespace LuckParser.Models.ParseModels
         {
             BoonName = boonName;
             BoonChart = boonChart;
-            FuseChart();
+            FuseSegments();
         }
 
-        public void FuseChart()
+        public void FuseSegments()
         {
             List<Segment> newChart = new List<Segment>();
             Segment last = null;

--- a/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
+++ b/LuckParser/Models/ParseModels/Boons/BoonsGraphModel.cs
@@ -9,9 +9,9 @@ namespace LuckParser.Models.ParseModels
 
         public class Segment
         {
-            public readonly long Start;
+            public long Start { get; set; }
             public long End { get; set; }
-            public readonly int Value;
+            public int Value { get; set; }
 
             public Segment(long start, long end, int value)
             {
@@ -28,45 +28,50 @@ namespace LuckParser.Models.ParseModels
             }
         }
 
-        private readonly string _boonName;
-        private readonly List<Segment> _boonChart = new List<Segment>();
+        public readonly string BoonName;
+        public List<Segment> BoonChart { get; private set; } = new List<Segment>();
 
         // Constructor
         public BoonsGraphModel(string boonName)
         {
-            _boonName = boonName;
+            BoonName = boonName;
         }
         public BoonsGraphModel(string boonName, List<Segment> boonChart)
         {
-            _boonName = boonName;
-            // Fuse segments
+            BoonName = boonName;
+            BoonChart = boonChart;
+            FuseChart();
+        }
+
+        public void FuseChart()
+        {
+            List<Segment> newChart = new List<Segment>();
             Segment last = null;
-            foreach(Segment seg in boonChart)
+            foreach (Segment seg in BoonChart)
             {
+                if (seg.Start == seg.End)
+                {
+                    continue;
+                }
                 if (last == null)
                 {
-                    _boonChart.Add(new Segment(seg));
-                    last = _boonChart.Last();
-                } else
+                    newChart.Add(new Segment(seg));
+                    last = newChart.Last();
+                }
+                else
                 {
                     if (seg.Value == last.Value)
                     {
                         last.End = seg.End;
-                    } else
+                    }
+                    else
                     {
-                        _boonChart.Add(new Segment(seg));
-                        last = _boonChart.Last();
+                        newChart.Add(new Segment(seg));
+                        last = newChart.Last();
                     }
                 }
             }
-        }
-        //getters
-        public string GetBoonName() {
-            return _boonName;
-        }
-        public List<Segment> GetBoonChart()
-        {
-            return _boonChart;
+            BoonChart = newChart;
         }
 
     }

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -511,10 +511,10 @@ namespace LuckParser.Models.ParseModels
                 }
                 if (updateBoonPresence)
                 {
-                    boonPresenceGraph.FuseChart();
+                    boonPresenceGraph.FuseSegments();
                 } else
                 {
-                    condiPresenceGraph.FuseChart();
+                    condiPresenceGraph.FuseSegments();
                 }
             }
             _boonPoints[-2] = boonPresenceGraph;

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItem.cs
@@ -52,6 +52,8 @@ namespace LuckParser.Models.ParseModels
             return Duration;
         }
 
+        public abstract List<BoonsGraphModel.Segment> ToSegment();
+
         public abstract void SetEnd(long end);
 
         public abstract int GetStack(long end);

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemDuration.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemDuration.cs
@@ -69,5 +69,13 @@ namespace LuckParser.Models.ParseModels
             _overstack += overstack;
             return true;
         }
+
+        public override List<BoonsGraphModel.Segment> ToSegment()
+        {
+            return new List<BoonsGraphModel.Segment>
+            {
+                new BoonsGraphModel.Segment(Start,GetEnd(),1)
+            };
+        }
     }
 }

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemIntensity.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulationItemIntensity.cs
@@ -81,5 +81,24 @@ namespace LuckParser.Models.ParseModels
             }
             return false;
         }
+
+        public override List<BoonsGraphModel.Segment> ToSegment()
+        {
+            if (Duration == _stacks.Min(x => x.GetDuration()))
+            {
+                return new List<BoonsGraphModel.Segment>
+                {
+                    new BoonsGraphModel.Segment(Start,GetEnd(),_stacks.Count)
+                };
+            }
+            long start = Start;
+            List<BoonsGraphModel.Segment> res = new List<BoonsGraphModel.Segment>();
+            foreach ( long end in _stacks.Select(x => x.GetDuration() + Start).Distinct())
+            {
+                res.Add(new BoonsGraphModel.Segment(start,end,GetStack(end)));
+                start = end;
+            }
+            return res;
+        }
     }
 }

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
@@ -35,14 +35,14 @@ namespace LuckParser.Models.ParseModels
         // Fields
         protected readonly List<BoonStackItem> BoonStack;
         protected readonly List<BoonSimulationItem> Simulation = new List<BoonSimulationItem>();
-        private readonly int Capacity;
+        private readonly int _capacity;
         private readonly ParsedLog _log;
         private readonly StackingLogic _logic;
 
         // Constructor
         protected BoonSimulator(int capacity, ParsedLog log, StackingLogic logic)
         {
-            Capacity = capacity;
+            _capacity = capacity;
             BoonStack = new List<BoonStackItem>(capacity);
             _log = log;
             _logic = logic;
@@ -97,7 +97,7 @@ namespace LuckParser.Models.ParseModels
         {
             var toAdd = new BoonStackItem(start, boonDuration, srcinstid, overstack);
             // Find empty slot
-            if (BoonStack.Count < Capacity)
+            if (BoonStack.Count < _capacity)
             {
                 BoonStack.Add(toAdd);
                 _logic.Sort(_log, BoonStack);


### PR DESCRIPTION
- Instead of Point, we use Segment (a new small class)
- The idea is to have a segment for each "constant" part instead of having a fixed polling rate
ex: 25 stacks of might for 5 secs, 24 for 15 sec, 22 for 0.5 sec, 23 for 1 sec
before -> a list of point (5 * 25 + 15 * 24 + 23), the 22 stacks is not seen
now -> a list of segment ( 0 -> 5, 5 -> 20, 20 -> 20.5, 20.5-> 21.5)

This made Number of Boons and Number of Conditions graph a little bit more complicated to compute as nothing is homogenous now.