### PR TITLE
Added log dir watcher and auto-parsing

### DIFF
--- a/LuckParser/App.config
+++ b/LuckParser/App.config
@@ -103,6 +103,15 @@
             <setting name="SkipFailedTrys" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="AutoAdd" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="AutoParse" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="AutoAddPath" serializeAs="String">
+                <value />
+            </setting>
         </LuckParser.Properties.Settings>
     </userSettings>
 </configuration>

--- a/LuckParser/MainForm.Designer.cs
+++ b/LuckParser/MainForm.Designer.cs
@@ -146,7 +146,7 @@
             this.logFileWatcher.EnableRaisingEvents = true;
             this.logFileWatcher.IncludeSubdirectories = true;
             this.logFileWatcher.SynchronizingObject = this;
-            this.logFileWatcher.Created += new System.IO.FileSystemEventHandler(this.logFileWatcher_Created);
+            this.logFileWatcher.Created += new System.IO.FileSystemEventHandler(this.LogFileWatcher_Created);
             // 
             // VersionLabel
             // 

--- a/LuckParser/MainForm.Designer.cs
+++ b/LuckParser/MainForm.Designer.cs
@@ -37,13 +37,16 @@
             this.btnSettings = new System.Windows.Forms.Button();
             this.btnClear = new System.Windows.Forms.Button();
             this.dgvFiles = new System.Windows.Forms.DataGridView();
-            this.gridRowBindingSource = new System.Windows.Forms.BindingSource(this.components);
+            this.ButtonState = new System.Windows.Forms.DataGridViewButtonColumn();
+            this.logFileWatcher = new System.IO.FileSystemWatcher();
+            this.VersionLabel = new System.Windows.Forms.Label();
+            this.labWatchingDir = new System.Windows.Forms.Label();
             this.locationDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.statusDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.ButtonState = new System.Windows.Forms.DataGridViewButtonColumn();
+            this.gridRowBindingSource = new System.Windows.Forms.BindingSource(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.dgvFiles)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.logFileWatcher)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.gridRowBindingSource)).BeginInit();
-            this.VersionLabel = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // openFileDialog1
@@ -131,9 +134,40 @@
             this.dgvFiles.DragDrop += new System.Windows.Forms.DragEventHandler(this.DgvFilesDragDrop);
             this.dgvFiles.DragEnter += new System.Windows.Forms.DragEventHandler(this.DgvFilesDragEnter);
             // 
-            // gridRowBindingSource
+            // ButtonState
             // 
-            this.gridRowBindingSource.DataSource = typeof(LuckParser.GridRow);
+            this.ButtonState.DataPropertyName = "ButtonText";
+            this.ButtonState.HeaderText = "";
+            this.ButtonState.Name = "ButtonState";
+            this.ButtonState.ReadOnly = true;
+            // 
+            // logFileWatcher
+            // 
+            this.logFileWatcher.EnableRaisingEvents = true;
+            this.logFileWatcher.IncludeSubdirectories = true;
+            this.logFileWatcher.SynchronizingObject = this;
+            this.logFileWatcher.Created += new System.IO.FileSystemEventHandler(this.logFileWatcher_Created);
+            // 
+            // VersionLabel
+            // 
+            this.VersionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.VersionLabel.AutoSize = true;
+            this.VersionLabel.Location = new System.Drawing.Point(16, 357);
+            this.VersionLabel.Name = "VersionLabel";
+            this.VersionLabel.Size = new System.Drawing.Size(29, 13);
+            this.VersionLabel.TabIndex = 17;
+            this.VersionLabel.Text = "V1.3";
+            // 
+            // labWatchingDir
+            // 
+            this.labWatchingDir.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.labWatchingDir.AutoEllipsis = true;
+            this.labWatchingDir.Location = new System.Drawing.Point(16, 312);
+            this.labWatchingDir.Name = "labWatchingDir";
+            this.labWatchingDir.Size = new System.Drawing.Size(504, 13);
+            this.labWatchingDir.TabIndex = 18;
+            this.labWatchingDir.Text = "Watching log dir";
             // 
             // locationDataGridViewTextBoxColumn
             // 
@@ -151,21 +185,9 @@
             this.statusDataGridViewTextBoxColumn.Name = "statusDataGridViewTextBoxColumn";
             this.statusDataGridViewTextBoxColumn.ReadOnly = true;
             // 
-            // ButtonState
+            // gridRowBindingSource
             // 
-            this.ButtonState.DataPropertyName = "ButtonText";
-            this.ButtonState.HeaderText = "";
-            this.ButtonState.Name = "ButtonState";
-            this.ButtonState.ReadOnly = true;
-            // Version_Label
-            // 
-            this.VersionLabel.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.VersionLabel.AutoSize = true;
-            this.VersionLabel.Location = new System.Drawing.Point(28, 357);
-            this.VersionLabel.Name = "Version_Label";
-            this.VersionLabel.Size = new System.Drawing.Size(29, 13);
-            this.VersionLabel.TabIndex = 17;
-            this.VersionLabel.Text = "V1.3";
+            this.gridRowBindingSource.DataSource = typeof(LuckParser.GridRow);
             // 
             // MainForm
             // 
@@ -173,6 +195,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Menu;
             this.ClientSize = new System.Drawing.Size(696, 375);
+            this.Controls.Add(this.labWatchingDir);
             this.Controls.Add(this.dgvFiles);
             this.Controls.Add(this.VersionLabel);
             this.Controls.Add(this.btnClear);
@@ -185,6 +208,7 @@
             this.Text = "GW2 Elite Insights Parser";
             this.TransparencyKey = System.Drawing.Color.OrangeRed;
             ((System.ComponentModel.ISupportInitialize)(this.dgvFiles)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.logFileWatcher)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.gridRowBindingSource)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -204,6 +228,8 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn statusDataGridViewTextBoxColumn;
         private System.Windows.Forms.DataGridViewButtonColumn ButtonState;
         private System.Windows.Forms.Label VersionLabel;
+        private System.IO.FileSystemWatcher logFileWatcher;
+        private System.Windows.Forms.Label labWatchingDir;
     }
 }
 

--- a/LuckParser/MainForm.cs
+++ b/LuckParser/MainForm.cs
@@ -634,7 +634,7 @@ namespace LuckParser
             }
         }
 
-        private void logFileWatcher_Created(object sender, FileSystemEventArgs e)
+        private void LogFileWatcher_Created(object sender, FileSystemEventArgs e)
         {
             if (e.FullPath.EndsWith(".zip") || e.FullPath.EndsWith(".evtc"))
             {

--- a/LuckParser/MainForm.cs
+++ b/LuckParser/MainForm.cs
@@ -25,7 +25,7 @@ namespace LuckParser
             _logsFiles = new List<string>();
             btnCancel.Enabled = false;
             btnParse.Enabled = false;
-            updateWatchDirectory();
+            UpdateWatchDirectory();
         }
 
         /// <summary>
@@ -601,7 +601,7 @@ namespace LuckParser
             }
         }
 
-        public void updateWatchDirectory()
+        public void UpdateWatchDirectory()
         {
             if (Properties.Settings.Default.AutoAdd)
             {

--- a/LuckParser/MainForm.resx
+++ b/LuckParser/MainForm.resx
@@ -126,6 +126,9 @@
   <metadata name="gridRowBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>157, 17</value>
   </metadata>
+  <metadata name="logFileWatcher.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>333, 17</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>87</value>
   </metadata>

--- a/LuckParser/Properties/Settings.Designer.cs
+++ b/LuckParser/Properties/Settings.Designer.cs
@@ -394,5 +394,41 @@ namespace LuckParser.Properties {
                 this["SkipFailedTrys"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AutoAdd {
+            get {
+                return ((bool)(this["AutoAdd"]));
+            }
+            set {
+                this["AutoAdd"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AutoParse {
+            get {
+                return ((bool)(this["AutoParse"]));
+            }
+            set {
+                this["AutoParse"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string AutoAddPath {
+            get {
+                return ((string)(this["AutoAddPath"]));
+            }
+            set {
+                this["AutoAddPath"] = value;
+            }
+        }
     }
 }

--- a/LuckParser/Properties/Settings.settings
+++ b/LuckParser/Properties/Settings.settings
@@ -95,5 +95,14 @@
     <Setting Name="SkipFailedTrys" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="AutoAdd" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="AutoParse" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="AutoAddPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/LuckParser/SettingsForm.Designer.cs
+++ b/LuckParser/SettingsForm.Designer.cs
@@ -68,6 +68,8 @@
             this.chkHtmlExternalScripts = new System.Windows.Forms.CheckBox();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.chkAutoAdd = new System.Windows.Forms.CheckBox();
+            this.chkAutoParse = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -532,6 +534,8 @@
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.chkAutoAdd);
+            this.tabPage1.Controls.Add(this.chkAutoParse);
             this.tabPage1.Controls.Add(this.chkB_SkipFailedTrys);
             this.tabPage1.Controls.Add(this.groupBox3);
             this.tabPage1.Controls.Add(this.groupBox2);
@@ -544,6 +548,28 @@
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
+            // 
+            // chkAutoAdd
+            // 
+            this.chkAutoAdd.AutoSize = true;
+            this.chkAutoAdd.Location = new System.Drawing.Point(24, 300);
+            this.chkAutoAdd.Name = "chkAutoAdd";
+            this.chkAutoAdd.Size = new System.Drawing.Size(154, 17);
+            this.chkAutoAdd.TabIndex = 40;
+            this.chkAutoAdd.Text = "Automatically add new logs";
+            this.chkAutoAdd.UseVisualStyleBackColor = true;
+            this.chkAutoAdd.CheckedChanged += new System.EventHandler(this.chkAutoAdd_CheckedChanged);
+            // 
+            // chkAutoParse
+            // 
+            this.chkAutoParse.AutoSize = true;
+            this.chkAutoParse.Location = new System.Drawing.Point(24, 324);
+            this.chkAutoParse.Name = "chkAutoParse";
+            this.chkAutoParse.Size = new System.Drawing.Size(171, 17);
+            this.chkAutoParse.TabIndex = 39;
+            this.chkAutoParse.Text = "Automatically parse added files";
+            this.chkAutoParse.UseVisualStyleBackColor = true;
+            this.chkAutoParse.CheckedChanged += new System.EventHandler(this.chkAutoParse_CheckedChanged);
             // 
             // groupBox3
             // 
@@ -908,5 +934,7 @@
         private System.Windows.Forms.Panel panelJson;
         private System.Windows.Forms.PictureBox imgTheme;
         private System.Windows.Forms.CheckBox chkB_SkipFailedTrys;
+        private System.Windows.Forms.CheckBox chkAutoAdd;
+        private System.Windows.Forms.CheckBox chkAutoParse;
     }
 }

--- a/LuckParser/SettingsForm.Designer.cs
+++ b/LuckParser/SettingsForm.Designer.cs
@@ -558,7 +558,7 @@
             this.chkAutoAdd.TabIndex = 40;
             this.chkAutoAdd.Text = "Automatically add new logs";
             this.chkAutoAdd.UseVisualStyleBackColor = true;
-            this.chkAutoAdd.CheckedChanged += new System.EventHandler(this.chkAutoAdd_CheckedChanged);
+            this.chkAutoAdd.CheckedChanged += new System.EventHandler(this.ChkAutoAdd_CheckedChanged);
             // 
             // chkAutoParse
             // 
@@ -569,7 +569,7 @@
             this.chkAutoParse.TabIndex = 39;
             this.chkAutoParse.Text = "Automatically parse added files";
             this.chkAutoParse.UseVisualStyleBackColor = true;
-            this.chkAutoParse.CheckedChanged += new System.EventHandler(this.chkAutoParse_CheckedChanged);
+            this.chkAutoParse.CheckedChanged += new System.EventHandler(this.ChkAutoParse_CheckedChanged);
             // 
             // groupBox3
             // 

--- a/LuckParser/SettingsForm.cs
+++ b/LuckParser/SettingsForm.cs
@@ -1,13 +1,17 @@
 ﻿using LuckParser.Controllers;
 using System;
+using System.IO;
 using System.Windows.Forms;
 
 namespace LuckParser
 {
     public partial class SettingsForm : Form
     {
-        public SettingsForm()
+        private MainForm mainForm;
+
+        public SettingsForm(MainForm mainForm)
         {
+            this.mainForm = mainForm;
             InitializeComponent();
         }
 
@@ -91,6 +95,8 @@ namespace LuckParser
             UploadDRRH_check.Checked = Properties.Settings.Default.UploadToDPSReportsRH;
             UploadRaidar_check.Checked = Properties.Settings.Default.UploadToRaidar;
             chkB_SkipFailedTrys.Checked = Properties.Settings.Default.SkipFailedTrys;
+            chkAutoAdd.Checked = Properties.Settings.Default.AutoAdd;
+            chkAutoParse.Checked = Properties.Settings.Default.AutoParse;
 
             chkHtmlExperimental.Checked = Properties.Settings.Default.NewHtmlMode;
             toolTip1.SetToolTip(chkHtmlExperimental, "Alternative method to build the HTML page.\nThe page is much smaller, and some static CSS and JS scripts are written in an external file.");
@@ -275,6 +281,50 @@ namespace LuckParser
             this.Close();
         }
 
-       
+        private void chkAutoAdd_CheckedChanged(object sender, EventArgs e)
+        {
+            if (chkAutoAdd.Checked && !Properties.Settings.Default.AutoAdd)
+            {
+                String path = Properties.Settings.Default.AutoAddPath;
+                if (String.IsNullOrEmpty(path) || !Directory.Exists(path))
+                {
+                    try
+                    {
+                        path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Guild Wars 2/addons/arcdps/arcdps.cbtlogs");
+                    }
+                    catch (PlatformNotSupportedException)
+                    {
+                        path = null;
+                    }
+                }
+                if (!Directory.Exists(path))
+                {
+                    path = null;
+                }
+
+                using (var fbd = new FolderBrowserDialog())
+                {
+                    fbd.ShowNewFolderButton = false;
+                    fbd.SelectedPath = path;
+                    DialogResult result = fbd.ShowDialog();
+
+                    if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(fbd.SelectedPath))
+                    {
+                        Properties.Settings.Default.AutoAddPath = fbd.SelectedPath;
+                    }
+                    else
+                    {
+                        chkAutoAdd.Checked = false;
+                    }
+                }
+            }
+            Properties.Settings.Default.AutoAdd = chkAutoAdd.Checked;
+            mainForm.updateWatchDirectory();
+        }
+
+        private void chkAutoParse_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.AutoParse = chkAutoParse.Checked;
+        }
     }
 }

--- a/LuckParser/SettingsForm.cs
+++ b/LuckParser/SettingsForm.cs
@@ -281,7 +281,7 @@ namespace LuckParser
             this.Close();
         }
 
-        private void chkAutoAdd_CheckedChanged(object sender, EventArgs e)
+        private void ChkAutoAdd_CheckedChanged(object sender, EventArgs e)
         {
             if (chkAutoAdd.Checked && !Properties.Settings.Default.AutoAdd)
             {
@@ -322,7 +322,7 @@ namespace LuckParser
             mainForm.UpdateWatchDirectory();
         }
 
-        private void chkAutoParse_CheckedChanged(object sender, EventArgs e)
+        private void ChkAutoParse_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.AutoParse = chkAutoParse.Checked;
         }

--- a/LuckParser/SettingsForm.cs
+++ b/LuckParser/SettingsForm.cs
@@ -319,7 +319,7 @@ namespace LuckParser
                 }
             }
             Properties.Settings.Default.AutoAdd = chkAutoAdd.Checked;
-            mainForm.updateWatchDirectory();
+            mainForm.UpdateWatchDirectory();
         }
 
         private void chkAutoParse_CheckedChanged(object sender, EventArgs e)

--- a/LuckParser/SettingsForm.resx
+++ b/LuckParser/SettingsForm.resx
@@ -124,7 +124,7 @@
     <value>186, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>31</value>
+    <value>59</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
I added 2 new settings, "Automatically parse added files" and "Automatically add new logs" (both default to false)
When the first is on parsing starts as soon as files are dropped in, when the 2nd is on every new log file (*.zip or *.evtc) in the gw2 log dir gets added to the list.
Files are added with 3 seconds delay, so the file is completely written and closed (or deleted) when handled.