### PR TITLE
Typo fix (thrash->trash)

### DIFF
--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -1022,7 +1022,7 @@ namespace LuckParser.Controllers
 
         private static void WriteCombatReplaySecondaryClass(StreamWriter sw, ParsedLog log, CombatReplayMap map, int pollingRate)
         {
-            // thrash mobs
+            // trash mobs
             sw.Write("var secondaryActor = function(imgSrc, start, end) {" +
                     "this.pos = [];" +
                     "this.start = start;" +
@@ -1039,8 +1039,8 @@ namespace LuckParser.Controllers
                         "pixelSize,pixelSize);" +
                     "}" +
                 "};");
-            // create thrash mobs
-            foreach (Mob mob in log.Boss.ThrashMobs)
+            // create trash mobs
+            foreach (Mob mob in log.Boss.TrashMobs)
             {
                 sw.Write("{");
                 sw.Write("var p = new secondaryActor('" + mob.CombatReplay.GetIcon() + "'," + mob.CombatReplay.GetTimeOffsets().Item1 / pollingRate + "," + mob.CombatReplay.GetTimeOffsets().Item2 / pollingRate + ");");
@@ -1111,7 +1111,7 @@ namespace LuckParser.Controllers
                         "}" +
                     "}" +
                 "};");
-            foreach (Mob mob in log.Boss.ThrashMobs)
+            foreach (Mob mob in log.Boss.TrashMobs)
             {
                 CombatReplay replay = mob.CombatReplay;
                 foreach(CircleActor a in replay.GetCircleActors())
@@ -1192,7 +1192,7 @@ namespace LuckParser.Controllers
                         "}" +
                     "}" +
                 "};");
-            foreach (Mob mob in log.Boss.ThrashMobs)
+            foreach (Mob mob in log.Boss.TrashMobs)
             {
                 CombatReplay replay = mob.CombatReplay;
                 foreach (DoughnutActor a in replay.GetDoughnutActors())
@@ -1270,7 +1270,7 @@ namespace LuckParser.Controllers
                                 "value.draw(ctx,timeToUse,20);"+
                             "}" +
                         "});");
-                    // draw thrash mobs
+                    // draw trash mobs
                     sw.Write("secondaryData.forEach(function(value,key,map) {" +
                             "value.draw(ctx,timeToUse,28);"+
                         "});");

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -43,9 +43,9 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public virtual List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public virtual List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>();
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>();
             return ids;
         }
 

--- a/LuckParser/Models/BossLogic/Cairn.cs
+++ b/LuckParser/Models/BossLogic/Cairn.cs
@@ -42,10 +42,10 @@ namespace LuckParser.Models
                             Tuple.Create(11774, 4480, 14078, 5376));
         }
         
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: needs doughnuts (wave) and facing information (sword)
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>();
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>();
             return ids;
         }
 

--- a/LuckParser/Models/BossLogic/Deimos.cs
+++ b/LuckParser/Models/BossLogic/Deimos.cs
@@ -89,15 +89,15 @@ namespace LuckParser.Models
             {
                 PhaseData phase = phases[i];
                 phase.Name = namesDeiSplit[i - offsetDei];
-                List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+                List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Thief,
-                        ParseEnum.ThrashIDS.Drunkard,
-                        ParseEnum.ThrashIDS.Gambler,
-                        ParseEnum.ThrashIDS.GamblerClones,
-                        ParseEnum.ThrashIDS.GamblerReal,
+                        ParseEnum.TrashIDS.Thief,
+                        ParseEnum.TrashIDS.Drunkard,
+                        ParseEnum.TrashIDS.Gambler,
+                        ParseEnum.TrashIDS.GamblerClones,
+                        ParseEnum.TrashIDS.GamblerReal,
                     };
-                List<AgentItem> clones = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetThrashIDS(x.ID))).ToList();
+                List<AgentItem> clones = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetTrashIDS(x.ID))).ToList();
                 foreach (AgentItem a in clones)
                 {
                     long agentStart = a.FirstAware - log.FightData.FightStart;
@@ -112,19 +112,19 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: facing information (slam)
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Saul,
-                        ParseEnum.ThrashIDS.Thief,
-                        ParseEnum.ThrashIDS.Drunkard,
-                        ParseEnum.ThrashIDS.Gambler,
-                        ParseEnum.ThrashIDS.GamblerClones,
-                        ParseEnum.ThrashIDS.GamblerReal,
-                        ParseEnum.ThrashIDS.Greed,
-                        ParseEnum.ThrashIDS.Pride
+                        ParseEnum.TrashIDS.Saul,
+                        ParseEnum.TrashIDS.Thief,
+                        ParseEnum.TrashIDS.Drunkard,
+                        ParseEnum.TrashIDS.Gambler,
+                        ParseEnum.TrashIDS.GamblerClones,
+                        ParseEnum.TrashIDS.GamblerReal,
+                        ParseEnum.TrashIDS.Greed,
+                        ParseEnum.TrashIDS.Pride
                     };
             List<CastLog> mindCrush = cls.Where(x => x.SkillId == 37613).ToList();
             foreach (CastLog c in mindCrush)

--- a/LuckParser/Models/BossLogic/Dhuum.cs
+++ b/LuckParser/Models/BossLogic/Dhuum.cs
@@ -103,14 +103,14 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: facing information (pull thingy)
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Echo,
-                        ParseEnum.ThrashIDS.Enforcer,
-                        ParseEnum.ThrashIDS.Messenger
+                        ParseEnum.TrashIDS.Echo,
+                        ParseEnum.TrashIDS.Enforcer,
+                        ParseEnum.TrashIDS.Messenger
                     };
             List<CastLog> deathmark = cls.Where(x => x.SkillId == 48176).ToList();
             CastLog majorSplit = cls.Find(x => x.SkillId == 47396);

--- a/LuckParser/Models/BossLogic/Gorseval.cs
+++ b/LuckParser/Models/BossLogic/Gorseval.cs
@@ -71,7 +71,7 @@ namespace LuckParser.Models
                 phase.Name = namesGorse[i - 1];
                 if (i == 2 || i == 4)
                 {
-                    List<AgentItem> spirits = log.AgentData.NPCAgentList.Where(x => ParseEnum.GetThrashIDS(x.ID) == ParseEnum.ThrashIDS.ChargedSoul).ToList();
+                    List<AgentItem> spirits = log.AgentData.NPCAgentList.Where(x => ParseEnum.GetTrashIDS(x.ID) == ParseEnum.TrashIDS.ChargedSoul).ToList();
                     foreach (AgentItem a in spirits)
                     {
                         long agentStart = a.FirstAware - log.FightData.FightStart;
@@ -86,14 +86,14 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: doughnuts (rampage)
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.ChargedSoul,
-                        ParseEnum.ThrashIDS.EnragedSpirit,
-                        ParseEnum.ThrashIDS.AngeredSpirit
+                        ParseEnum.TrashIDS.ChargedSoul,
+                        ParseEnum.TrashIDS.EnragedSpirit,
+                        ParseEnum.TrashIDS.AngeredSpirit
                     };
             List<CastLog> blooms = cls.Where(x => x.SkillId == 31616).ToList();
             foreach (CastLog c in blooms)

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -114,26 +114,26 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: needs arc circles for blades
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Core,
-                        ParseEnum.ThrashIDS.Jessica,
-                        ParseEnum.ThrashIDS.Olson,
-                        ParseEnum.ThrashIDS.Engul,
-                        ParseEnum.ThrashIDS.Faerla,
-                        ParseEnum.ThrashIDS.Caulle,
-                        ParseEnum.ThrashIDS.Henley,
-                        ParseEnum.ThrashIDS.Galletta,
-                        ParseEnum.ThrashIDS.Ianim,
-                        ParseEnum.ThrashIDS.GreenPhantasm,
-                        ParseEnum.ThrashIDS.InsidiousProjection,
-                        ParseEnum.ThrashIDS.UnstableLeyRift,
-                        ParseEnum.ThrashIDS.RadiantPhantasm,
-                        ParseEnum.ThrashIDS.CrimsonPhantasm,
-                        ParseEnum.ThrashIDS.RetrieverProjection
+                        ParseEnum.TrashIDS.Core,
+                        ParseEnum.TrashIDS.Jessica,
+                        ParseEnum.TrashIDS.Olson,
+                        ParseEnum.TrashIDS.Engul,
+                        ParseEnum.TrashIDS.Faerla,
+                        ParseEnum.TrashIDS.Caulle,
+                        ParseEnum.TrashIDS.Henley,
+                        ParseEnum.TrashIDS.Galletta,
+                        ParseEnum.TrashIDS.Ianim,
+                        ParseEnum.TrashIDS.GreenPhantasm,
+                        ParseEnum.TrashIDS.InsidiousProjection,
+                        ParseEnum.TrashIDS.UnstableLeyRift,
+                        ParseEnum.TrashIDS.RadiantPhantasm,
+                        ParseEnum.TrashIDS.CrimsonPhantasm,
+                        ParseEnum.TrashIDS.RetrieverProjection
                     };
             List<CastLog> magicCharge = cls.Where(x => x.SkillId == 35048).ToList();
             List<CastLog> magicExplode = cls.Where(x => x.SkillId == 34894).ToList();

--- a/LuckParser/Models/BossLogic/Matthias.cs
+++ b/LuckParser/Models/BossLogic/Matthias.cs
@@ -92,16 +92,16 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: needs facing information for hadouken
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Spirit,
-                        ParseEnum.ThrashIDS.Spirit2,
-                        ParseEnum.ThrashIDS.IcePatch,
-                        ParseEnum.ThrashIDS.Tornado,
-                        ParseEnum.ThrashIDS.Storm
+                        ParseEnum.TrashIDS.Spirit,
+                        ParseEnum.TrashIDS.Spirit2,
+                        ParseEnum.TrashIDS.IcePatch,
+                        ParseEnum.TrashIDS.Tornado,
+                        ParseEnum.TrashIDS.Storm
                     };
             List<CastLog> humanShield = cls.Where(x => x.SkillId == 34468).ToList();
             List<int> humanShieldRemoval = log.GetBoonData(34518).Where(x => x.IsBuffRemove == ParseEnum.BuffRemove.All).Select(x => (int)(x.Time - log.FightData.FightStart)).Distinct().ToList();

--- a/LuckParser/Models/BossLogic/MursaatOverseer.cs
+++ b/LuckParser/Models/BossLogic/MursaatOverseer.cs
@@ -32,11 +32,11 @@ namespace LuckParser.Models
                             Tuple.Create(11774, 4480, 14078, 5376));
         }      
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Jade
+                        ParseEnum.TrashIDS.Jade
                     };     
             return ids;
         }

--- a/LuckParser/Models/BossLogic/Sabetha.cs
+++ b/LuckParser/Models/BossLogic/Sabetha.cs
@@ -71,13 +71,13 @@ namespace LuckParser.Models
                 phase.Name = namesSab[i - 1];
                 if (i == 2 || i == 4 || i == 6)
                 {
-                    List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+                    List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                       ParseEnum.ThrashIDS.Kernan,
-                       ParseEnum.ThrashIDS.Knuckles,
-                       ParseEnum.ThrashIDS.Karde,
+                       ParseEnum.TrashIDS.Kernan,
+                       ParseEnum.TrashIDS.Knuckles,
+                       ParseEnum.TrashIDS.Karde,
                     };
-                    List<AgentItem> champs = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetThrashIDS(x.ID))).ToList();
+                    List<AgentItem> champs = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetTrashIDS(x.ID))).ToList();
                     foreach (AgentItem a in champs)
                     {
                         long agentStart = a.FirstAware - log.FightData.FightStart;
@@ -92,17 +92,17 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO:facing information (flame wall)
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Kernan,
-                        ParseEnum.ThrashIDS.Knuckles,
-                        ParseEnum.ThrashIDS.Karde,
-                        ParseEnum.ThrashIDS.BanditSapper,
-                        ParseEnum.ThrashIDS.BanditThug,
-                        ParseEnum.ThrashIDS.BanditArsonist
+                        ParseEnum.TrashIDS.Kernan,
+                        ParseEnum.TrashIDS.Knuckles,
+                        ParseEnum.TrashIDS.Karde,
+                        ParseEnum.TrashIDS.BanditSapper,
+                        ParseEnum.TrashIDS.BanditThug,
+                        ParseEnum.TrashIDS.BanditArsonist
                     };
             return ids;
         }

--- a/LuckParser/Models/BossLogic/Samarog.cs
+++ b/LuckParser/Models/BossLogic/Samarog.cs
@@ -88,12 +88,12 @@ namespace LuckParser.Models
                 phase.Name = namesSam[i - 1];
                 if (i == 2 || i == 4)
                 {
-                    List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+                    List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                       ParseEnum.ThrashIDS.Rigom,
-                       ParseEnum.ThrashIDS.Guldhem
+                       ParseEnum.TrashIDS.Rigom,
+                       ParseEnum.TrashIDS.Guldhem
                     };
-                    List<AgentItem> slaves = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetThrashIDS(x.ID))).ToList();
+                    List<AgentItem> slaves = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetTrashIDS(x.ID))).ToList();
                     foreach (AgentItem a in slaves)
                     {
                         long agentStart = a.FirstAware - log.FightData.FightStart;
@@ -108,13 +108,13 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: facing information (shock wave)
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Rigom,
-                        ParseEnum.ThrashIDS.Guldhem
+                        ParseEnum.TrashIDS.Rigom,
+                        ParseEnum.TrashIDS.Guldhem
                     };
             List<CombatItem> brutalize = log.GetBoonData(38226).Where(x => x.IsBuffRemove != ParseEnum.BuffRemove.Manual).ToList();
             int brutStart = 0;

--- a/LuckParser/Models/BossLogic/Siax.cs
+++ b/LuckParser/Models/BossLogic/Siax.cs
@@ -33,12 +33,12 @@ namespace LuckParser.Models
                             Tuple.Create(11804, 4414, 12444, 5054));
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: needs facing information for hadouken
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Hallucination
+                        ParseEnum.TrashIDS.Hallucination
                     };
             return ids;
         }

--- a/LuckParser/Models/BossLogic/Slothasor.cs
+++ b/LuckParser/Models/BossLogic/Slothasor.cs
@@ -38,15 +38,15 @@ namespace LuckParser.Models
                             Tuple.Create(2688, 11906, 3712, 14210));
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO:facing information (breath)
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
             {
-                ParseEnum.ThrashIDS.Slubling1,
-                ParseEnum.ThrashIDS.Slubling2,
-                ParseEnum.ThrashIDS.Slubling3,
-                ParseEnum.ThrashIDS.Slubling4
+                ParseEnum.TrashIDS.Slubling1,
+                ParseEnum.TrashIDS.Slubling2,
+                ParseEnum.TrashIDS.Slubling3,
+                ParseEnum.TrashIDS.Slubling4
             };
             List<CastLog> sleepy = cls.Where(x => x.SkillId == 34515).ToList();
             foreach (CastLog c in sleepy)

--- a/LuckParser/Models/BossLogic/SoullessHorror.cs
+++ b/LuckParser/Models/BossLogic/SoullessHorror.cs
@@ -40,14 +40,14 @@ namespace LuckParser.Models
                             Tuple.Create(19072, 15484, 20992, 16508));
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: facing information (slashes) and doughnuts for outer circle attack
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                        ParseEnum.ThrashIDS.Scythe,
-                        ParseEnum.ThrashIDS.TormentedDead,
-                        ParseEnum.ThrashIDS.SurgingSoul
+                        ParseEnum.TrashIDS.Scythe,
+                        ParseEnum.TrashIDS.TormentedDead,
+                        ParseEnum.TrashIDS.SurgingSoul
                     };
             List<CastLog> howling = cls.Where(x => x.SkillId == 48662).ToList();
             foreach (CastLog c in howling)

--- a/LuckParser/Models/BossLogic/ValeGuardian.cs
+++ b/LuckParser/Models/BossLogic/ValeGuardian.cs
@@ -79,13 +79,13 @@ namespace LuckParser.Models
                 phase.Name = namesVG[i - 1];
                 if (i == 2 || i == 4)
                 {
-                    List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+                    List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
                     {
-                       ParseEnum.ThrashIDS.BlueGuardian,
-                       ParseEnum.ThrashIDS.GreenGuardian,
-                       ParseEnum.ThrashIDS.RedGuardian
+                       ParseEnum.TrashIDS.BlueGuardian,
+                       ParseEnum.TrashIDS.GreenGuardian,
+                       ParseEnum.TrashIDS.RedGuardian
                     };
-                    List<AgentItem> guardians = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetThrashIDS(x.ID))).ToList();
+                    List<AgentItem> guardians = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetTrashIDS(x.ID))).ToList();
                     foreach (AgentItem a in guardians)
                     {
                         long agentStart = a.FirstAware - log.FightData.FightStart;
@@ -100,14 +100,14 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
             {
-               ParseEnum.ThrashIDS.Seekers,
-               ParseEnum.ThrashIDS.BlueGuardian,
-               ParseEnum.ThrashIDS.GreenGuardian,
-               ParseEnum.ThrashIDS.RedGuardian
+               ParseEnum.TrashIDS.Seekers,
+               ParseEnum.TrashIDS.BlueGuardian,
+               ParseEnum.TrashIDS.GreenGuardian,
+               ParseEnum.TrashIDS.RedGuardian
             };
             List<CastLog> magicStorms = cls.Where(x => x.SkillId == 31419).ToList();
             foreach (CastLog c in magicStorms)

--- a/LuckParser/Models/BossLogic/Xera.cs
+++ b/LuckParser/Models/BossLogic/Xera.cs
@@ -71,16 +71,16 @@ namespace LuckParser.Models
             return phases;
         }
 
-        public override List<ParseEnum.ThrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
+        public override List<ParseEnum.TrashIDS> GetAdditionalData(CombatReplay replay, List<CastLog> cls, ParsedLog log)
         {
             // TODO: needs facing information for hadouken
-            List<ParseEnum.ThrashIDS> ids = new List<ParseEnum.ThrashIDS>
+            List<ParseEnum.TrashIDS> ids = new List<ParseEnum.TrashIDS>
             {
-                ParseEnum.ThrashIDS.WhiteMantleSeeker1,
-                ParseEnum.ThrashIDS.WhiteMantleSeeker2,
-                ParseEnum.ThrashIDS.WhiteMantleKnight,
-                ParseEnum.ThrashIDS.WhiteMantleBattleMage,
-                ParseEnum.ThrashIDS.ExquisiteConjunction
+                ParseEnum.TrashIDS.WhiteMantleSeeker1,
+                ParseEnum.TrashIDS.WhiteMantleSeeker2,
+                ParseEnum.TrashIDS.WhiteMantleKnight,
+                ParseEnum.TrashIDS.WhiteMantleBattleMage,
+                ParseEnum.TrashIDS.ExquisiteConjunction
             };
             List<CastLog> summon = cls.Where(x => x.SkillId == 34887).ToList();
             foreach (CastLog c in summon)

--- a/LuckParser/Models/DataModels/ParseEnum.cs
+++ b/LuckParser/Models/DataModels/ParseEnum.cs
@@ -118,7 +118,7 @@ namespace LuckParser.Models.DataModels
                 : IFF.Unknown;
         }
 
-        public enum ThrashIDS : ushort
+        public enum TrashIDS : ushort
         {
             // VG
             Seekers = 15426,
@@ -238,9 +238,9 @@ namespace LuckParser.Models.DataModels
             //
             Unknown
         };
-        public static ThrashIDS GetThrashIDS(ushort id)
+        public static TrashIDS GetTrashIDS(ushort id)
         {
-            return Enum.IsDefined(typeof(ThrashIDS), id) ? (ThrashIDS)id : ThrashIDS.Unknown;
+            return Enum.IsDefined(typeof(TrashIDS), id) ? (TrashIDS)id : TrashIDS.Unknown;
         }
 
         public enum BossIDS : ushort

--- a/LuckParser/Models/ParseModels/Players/Boss.cs
+++ b/LuckParser/Models/ParseModels/Players/Boss.cs
@@ -15,7 +15,7 @@ namespace LuckParser.Models.ParseModels
         private List<PhaseData> _phases = new List<PhaseData>();
         public readonly List<long> PhaseData = new List<long>();
         private CombatReplayMap _map;
-        public readonly List<Mob> ThrashMobs = new List<Mob>();
+        public readonly List<Mob> TrashMobs = new List<Mob>();
         private readonly bool _requirePhases;
 
         public List<PhaseData> GetPhases(ParsedLog log)
@@ -66,13 +66,13 @@ namespace LuckParser.Models.ParseModels
 
         protected override void SetAdditionalCombatReplayData(ParsedLog log, int pollingRate)
         {
-            List<ParseEnum.ThrashIDS> ids = log.FightData.Logic.GetAdditionalData(CombatReplay, GetCastLogs(log, 0, log.FightData.FightDuration), log);
-            List<AgentItem> aList = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetThrashIDS(x.ID))).ToList();
+            List<ParseEnum.TrashIDS> ids = log.FightData.Logic.GetAdditionalData(CombatReplay, GetCastLogs(log, 0, log.FightData.FightDuration), log);
+            List<AgentItem> aList = log.AgentData.NPCAgentList.Where(x => ids.Contains(ParseEnum.GetTrashIDS(x.ID))).ToList();
             foreach (AgentItem a in aList)
             {
                 Mob mob = new Mob(a);
                 mob.InitCombatReplay(log, pollingRate, true, false);
-                ThrashMobs.Add(mob);
+                TrashMobs.Add(mob);
             }
         }
 

--- a/LuckParser/Models/ParseModels/Players/Mob.cs
+++ b/LuckParser/Models/ParseModels/Players/Mob.cs
@@ -22,60 +22,60 @@ namespace LuckParser.Models.ParseModels
             int start = (int)CombatReplay.GetTimeOffsets().Item1;
             int end = (int)CombatReplay.GetTimeOffsets().Item2;
             Tuple<int, int> lifespan = new Tuple<int, int>(start, end);
-            switch (ParseEnum.GetThrashIDS(Agent.ID))
+            switch (ParseEnum.GetTrashIDS(Agent.ID))
             {
-                case ParseEnum.ThrashIDS.BlueGuardian:
+                case ParseEnum.TrashIDS.BlueGuardian:
                     CombatReplay.AddCircleActor(new CircleActor(false, 0, 1500, lifespan, "rgba(0, 0, 255, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.GreenGuardian:
+                case ParseEnum.TrashIDS.GreenGuardian:
                     CombatReplay.AddCircleActor(new CircleActor(false, 0, 1500, lifespan, "rgba(0, 255, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.RedGuardian:
+                case ParseEnum.TrashIDS.RedGuardian:
                     CombatReplay.AddCircleActor(new CircleActor(false, 0, 1500, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Seekers:
+                case ParseEnum.TrashIDS.Seekers:
                     CombatReplay.AddCircleActor(new CircleActor(false, 0, 180, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.ChargedSoul:
+                case ParseEnum.TrashIDS.ChargedSoul:
                     CombatReplay.AddCircleActor(new CircleActor(false, 0, 220, lifespan, "rgba(255, 150, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Spirit:
-                case ParseEnum.ThrashIDS.Spirit2:
+                case ParseEnum.TrashIDS.Spirit:
+                case ParseEnum.TrashIDS.Spirit2:
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 180, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Olson:
-                case ParseEnum.ThrashIDS.Engul:
-                case ParseEnum.ThrashIDS.Faerla:
-                case ParseEnum.ThrashIDS.Caulle:
-                case ParseEnum.ThrashIDS.Henley:
-                case ParseEnum.ThrashIDS.Jessica:
-                case ParseEnum.ThrashIDS.Galletta:
-                case ParseEnum.ThrashIDS.Ianim:
+                case ParseEnum.TrashIDS.Olson:
+                case ParseEnum.TrashIDS.Engul:
+                case ParseEnum.TrashIDS.Faerla:
+                case ParseEnum.TrashIDS.Caulle:
+                case ParseEnum.TrashIDS.Henley:
+                case ParseEnum.TrashIDS.Jessica:
+                case ParseEnum.TrashIDS.Galletta:
+                case ParseEnum.TrashIDS.Ianim:
                     CombatReplay.AddCircleActor(new CircleActor(false, 0, 600, lifespan, "rgba(255, 0, 0, 0.5)"));
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 400, lifespan, "rgba(0, 125, 255, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Messenger:
+                case ParseEnum.TrashIDS.Messenger:
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 180, lifespan, "rgba(255, 125, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Scythe:
+                case ParseEnum.TrashIDS.Scythe:
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 80, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Tornado:
+                case ParseEnum.TrashIDS.Tornado:
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 90, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.IcePatch:
+                case ParseEnum.TrashIDS.IcePatch:
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 200, lifespan, "rgba(0, 0, 255, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Storm:
+                case ParseEnum.TrashIDS.Storm:
                     CombatReplay.AddCircleActor(new CircleActor(false, 0, 260, lifespan, "rgba(0, 80, 255, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Oil:
+                case ParseEnum.TrashIDS.Oil:
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 240, lifespan, "rgba(0, 0, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.Echo:
+                case ParseEnum.TrashIDS.Echo:
                     CombatReplay.AddCircleActor(new CircleActor(true, 0, 120, lifespan, "rgba(255, 0, 0, 0.5)"));
                     break;
-                case ParseEnum.ThrashIDS.TormentedDead:
+                case ParseEnum.TrashIDS.TormentedDead:
                     if (CombatReplay.GetPositions().Count == 0)
                     {
                         break;
@@ -87,114 +87,114 @@ namespace LuckParser.Models.ParseModels
 
         protected override void SetCombatReplayIcon(ParsedLog log)
         {
-            switch (ParseEnum.GetThrashIDS(Agent.ID))
+            switch (ParseEnum.GetTrashIDS(Agent.ID))
             {
-                case ParseEnum.ThrashIDS.Seekers:
+                case ParseEnum.TrashIDS.Seekers:
                     CombatReplay.SetIcon("https://i.imgur.com/FrPoluz.png");
                     break;
-                case ParseEnum.ThrashIDS.RedGuardian:
+                case ParseEnum.TrashIDS.RedGuardian:
                     CombatReplay.SetIcon("https://i.imgur.com/73Uj4lG.png");
                     break;
-                case ParseEnum.ThrashIDS.BlueGuardian:
+                case ParseEnum.TrashIDS.BlueGuardian:
                     CombatReplay.SetIcon("https://i.imgur.com/6CefnkP.png");
                     break;
-                case ParseEnum.ThrashIDS.GreenGuardian:
+                case ParseEnum.TrashIDS.GreenGuardian:
                     CombatReplay.SetIcon("https://i.imgur.com/nauDVYP.png");
                     break;
-                case ParseEnum.ThrashIDS.Spirit:
-                case ParseEnum.ThrashIDS.Spirit2:
-                case ParseEnum.ThrashIDS.ChargedSoul:
+                case ParseEnum.TrashIDS.Spirit:
+                case ParseEnum.TrashIDS.Spirit2:
+                case ParseEnum.TrashIDS.ChargedSoul:
                     CombatReplay.SetIcon("https://i.imgur.com/sHmksvO.png");
                     break;
-                case ParseEnum.ThrashIDS.Kernan:
+                case ParseEnum.TrashIDS.Kernan:
                     CombatReplay.SetIcon("https://i.imgur.com/WABRQya.png");
                     break;
-                case ParseEnum.ThrashIDS.Knuckles:
+                case ParseEnum.TrashIDS.Knuckles:
                     CombatReplay.SetIcon("https://i.imgur.com/m1y8nJE.png");
                     break;
-                case ParseEnum.ThrashIDS.Karde:
+                case ParseEnum.TrashIDS.Karde:
                     CombatReplay.SetIcon("https://i.imgur.com/3UGyosm.png");
                     break;
-                case ParseEnum.ThrashIDS.Olson:
-                case ParseEnum.ThrashIDS.Engul:
-                case ParseEnum.ThrashIDS.Faerla:
-                case ParseEnum.ThrashIDS.Caulle:
-                case ParseEnum.ThrashIDS.Henley:
-                case ParseEnum.ThrashIDS.Jessica:
-                case ParseEnum.ThrashIDS.Galletta:
-                case ParseEnum.ThrashIDS.Ianim:
+                case ParseEnum.TrashIDS.Olson:
+                case ParseEnum.TrashIDS.Engul:
+                case ParseEnum.TrashIDS.Faerla:
+                case ParseEnum.TrashIDS.Caulle:
+                case ParseEnum.TrashIDS.Henley:
+                case ParseEnum.TrashIDS.Jessica:
+                case ParseEnum.TrashIDS.Galletta:
+                case ParseEnum.TrashIDS.Ianim:
                     CombatReplay.SetIcon("https://i.imgur.com/qeYT1Bf.png");
                     break;
-                case ParseEnum.ThrashIDS.Core:
+                case ParseEnum.TrashIDS.Core:
                     CombatReplay.SetIcon("https://i.imgur.com/yI34iqw.png");
                     break;
-                case ParseEnum.ThrashIDS.Jade:
+                case ParseEnum.TrashIDS.Jade:
                     CombatReplay.SetIcon("https://i.imgur.com/ivtzbSP.png");
                     break;
-                case ParseEnum.ThrashIDS.Guldhem:
+                case ParseEnum.TrashIDS.Guldhem:
                     CombatReplay.SetIcon("https://i.imgur.com/xa7Fefn.png");
                     break;
-                case ParseEnum.ThrashIDS.Rigom:
+                case ParseEnum.TrashIDS.Rigom:
                     CombatReplay.SetIcon("https://i.imgur.com/REcGMBe.png");
                     break;
-                case ParseEnum.ThrashIDS.Saul:
+                case ParseEnum.TrashIDS.Saul:
                     CombatReplay.SetIcon("https://i.imgur.com/ck2IsoS.png");
                     break;
-                case ParseEnum.ThrashIDS.Messenger:
-                case ParseEnum.ThrashIDS.TormentedDead:
+                case ParseEnum.TrashIDS.Messenger:
+                case ParseEnum.TrashIDS.TormentedDead:
                     CombatReplay.SetIcon("https://i.imgur.com/1J2BTFg.png");
                     break;
-                case ParseEnum.ThrashIDS.Scythe:
+                case ParseEnum.TrashIDS.Scythe:
                     CombatReplay.SetIcon("https://i.imgur.com/INCGLIK.png");
                     break;
-                case ParseEnum.ThrashIDS.Enforcer:
+                case ParseEnum.TrashIDS.Enforcer:
                     CombatReplay.SetIcon("https://i.imgur.com/elHjamF.png");
                     break;
-                case ParseEnum.ThrashIDS.Tornado:
+                case ParseEnum.TrashIDS.Tornado:
                     CombatReplay.SetIcon("https://i.imgur.com/e10lZMa.png");
                     break;
-                case ParseEnum.ThrashIDS.IcePatch:
+                case ParseEnum.TrashIDS.IcePatch:
                     CombatReplay.SetIcon("https://i.imgur.com/yxKJ5Yc.png");
                     break;
-                case ParseEnum.ThrashIDS.Storm:
+                case ParseEnum.TrashIDS.Storm:
                     CombatReplay.SetIcon("https://i.imgur.com/9XtNPdw.png");
                     break;
-                case ParseEnum.ThrashIDS.UnstableLeyRift:
+                case ParseEnum.TrashIDS.UnstableLeyRift:
                     CombatReplay.SetIcon("https://i.imgur.com/YXM3igs.png");
                     break;
-                case ParseEnum.ThrashIDS.Tear:
+                case ParseEnum.TrashIDS.Tear:
                     CombatReplay.SetIcon("https://i.imgur.com/N9seps0.png");
                     break;
-                case ParseEnum.ThrashIDS.Oil:
+                case ParseEnum.TrashIDS.Oil:
                     CombatReplay.SetIcon("https://i.imgur.com/DZIl49i.png");
                     break;
-                case ParseEnum.ThrashIDS.InsidiousProjection:
+                case ParseEnum.TrashIDS.InsidiousProjection:
                     CombatReplay.SetIcon("https://i.imgur.com/9EdItBS.png");
                     break;
-                case ParseEnum.ThrashIDS.Pride:
+                case ParseEnum.TrashIDS.Pride:
                     CombatReplay.SetIcon("https://i.imgur.com/ePTXx23.png");
                     break;
-                case ParseEnum.ThrashIDS.SurgingSoul:
+                case ParseEnum.TrashIDS.SurgingSoul:
                     CombatReplay.SetIcon("https://i.imgur.com/k79t7ZA.png");
                     break;
-                case ParseEnum.ThrashIDS.Echo:
+                case ParseEnum.TrashIDS.Echo:
                     CombatReplay.SetIcon("https://i.imgur.com/kcN9ECn.png");
                     break;
-                case ParseEnum.ThrashIDS.CrimsonPhantasm:
+                case ParseEnum.TrashIDS.CrimsonPhantasm:
                     CombatReplay.SetIcon("https://i.imgur.com/zP7Bvb4.png");
                     break;
-                case ParseEnum.ThrashIDS.RadiantPhantasm:
+                case ParseEnum.TrashIDS.RadiantPhantasm:
                     CombatReplay.SetIcon("https://i.imgur.com/O5VWLyY.png");
                     break;
-                case ParseEnum.ThrashIDS.Gambler:
-                case ParseEnum.ThrashIDS.Thief:
-                case ParseEnum.ThrashIDS.Drunkard:
+                case ParseEnum.TrashIDS.Gambler:
+                case ParseEnum.TrashIDS.Thief:
+                case ParseEnum.TrashIDS.Drunkard:
                     CombatReplay.SetIcon("https://i.imgur.com/vINeVU6.png");
                     break;
-                case ParseEnum.ThrashIDS.GamblerClones:
+                case ParseEnum.TrashIDS.GamblerClones:
                     CombatReplay.SetIcon("https://i.imgur.com/zMsBWEx.png");
                     break;
-                case ParseEnum.ThrashIDS.GamblerReal:
+                case ParseEnum.TrashIDS.GamblerReal:
                     CombatReplay.SetIcon("https://i.imgur.com/J6oMITN.png");
                     break;
                 default:
@@ -205,7 +205,7 @@ namespace LuckParser.Models.ParseModels
 
         public void AddMechanics(ParsedLog log)
         {
-            // nothing to do, thrash mob mechanics should be managed by the boss
+            // nothing to do, trash mob mechanics should be managed by the boss
         }
     }
 }


### PR DESCRIPTION
Replaced all occurences of 'Thrash/thrash' by 'Trash/trash' (except in SkillList.txt)