### PR TITLE
Adapt to arcs new file behavior when creating log files

### DIFF
--- a/LuckParser/MainForm.Designer.cs
+++ b/LuckParser/MainForm.Designer.cs
@@ -147,6 +147,7 @@
             this.logFileWatcher.IncludeSubdirectories = true;
             this.logFileWatcher.SynchronizingObject = this;
             this.logFileWatcher.Created += new System.IO.FileSystemEventHandler(this.LogFileWatcher_Created);
+            this.logFileWatcher.Renamed += new System.IO.RenamedEventHandler(this.LogFileWatcher_Renamed);
             // 
             // VersionLabel
             // 

--- a/LuckParser/MainForm.cs
+++ b/LuckParser/MainForm.cs
@@ -586,11 +586,17 @@ namespace LuckParser
 
         private void LogFileWatcher_Created(object sender, FileSystemEventArgs e)
         {
-            if (e.FullPath.EndsWith(".zip") || e.FullPath.EndsWith(".evtc"))
+            if ((e.FullPath.EndsWith(".zip") && !e.FullPath.EndsWith(".tmp.zip")) || e.FullPath.EndsWith(".evtc"))
             {
                 AddDelayed(e.FullPath);
             }
         }
 
+        private void LogFileWatcher_Renamed(object sender, RenamedEventArgs e)
+        {
+            if (e.OldFullPath.EndsWith(".tmp.zip") && e.FullPath.EndsWith(".zip")) {
+                AddDelayed(e.FullPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
Arc changed its way log files are created from
1.) an *.evtc is written
2.) when done it is zipped to *.evtc.zip
3.) when zip is done the *.evtc is deleted

to 

1.) an *.evtc.tmp is written
2.) when done it is zipped to *.evtc.tmp.zip
3.) the *.evtc.tmp is deleted
4.) when the zip is done it is renamed to *.evtc.zip

currently only file creation events are handled, the last rename event is not registered.
This rename event is added here.