### PR TITLE
Settings rework

### DIFF
--- a/LuckParser/App.config
+++ b/LuckParser/App.config
@@ -112,6 +112,9 @@
             <setting name="AutoAddPath" serializeAs="String">
                 <value />
             </setting>
+            <setting name="Outdated" serializeAs="String">
+                <value>True</value>
+            </setting>
         </LuckParser.Properties.Settings>
     </userSettings>
 </configuration>

--- a/LuckParser/ConsoleProgram.cs
+++ b/LuckParser/ConsoleProgram.cs
@@ -11,11 +11,11 @@ namespace LuckParser
 {
     public class ConsoleProgram
     {
-        public ConsoleProgram(string[] args)
+        public ConsoleProgram(IEnumerable<string> logFiles)
         {
             if (Properties.Settings.Default.ParseOneAtATime)
             {
-                foreach (string file in args)
+                foreach (string file in logFiles)
                 {
                     ParseLog(file);
                 }
@@ -24,7 +24,7 @@ namespace LuckParser
             {
                 List<Task> tasks = new List<Task>();
 
-                foreach (string file in args)
+                foreach (string file in logFiles)
                 {
                     tasks.Add(Task.Factory.StartNew(ParseLog, file));
                 }

--- a/LuckParser/CustomSettingsManager.cs
+++ b/LuckParser/CustomSettingsManager.cs
@@ -14,7 +14,7 @@ namespace LuckParser
                 Console.WriteLine("Warning: settings file \"" + filename + "\" not found");
                 return;
             }
-            if (f.Extension == "conf")
+            if (f.Extension == ".conf")
             {
                 ReadConfFile(filename);
                 return;

--- a/LuckParser/CustomSettingsManager.cs
+++ b/LuckParser/CustomSettingsManager.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Configuration;
+using System.IO;
+
+namespace LuckParser
+{
+    static class CustomSettingsManager
+    {
+        public static void ReadConfig(string filename)
+        {
+            FileInfo f = new FileInfo(filename);
+            if (!f.Exists)
+            {
+                Console.WriteLine("Warning: settings file \"" + filename + "\" not found");
+                return;
+            }
+            if (f.Extension == "conf")
+            {
+                ReadConfFile(filename);
+                return;
+            }
+            else
+            {
+                // old code, left for backwards compatibility
+                Console.WriteLine("Warning: using of xml structure custom settings is deprecated. Please use a *.conf file instead.");
+                ReadXmlFile(filename);
+            }
+        }
+
+        private static void ReadXmlFile(string filename)
+        {
+            AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", filename);
+        }
+
+        private static void ReadConfFile(string filename)
+        {
+            using (StreamReader sr = new StreamReader(filename))
+            {
+                string line;
+                while ((line = sr.ReadLine()) != null)
+                {
+                    ProcessSettingsLine(line.Trim());
+                }
+            }
+        }
+
+        private static void ProcessSettingsLine(string line)
+        {
+            if (line.StartsWith("#")) return; // commented out line
+            int equalsPos = line.IndexOf("=");
+            if (equalsPos <= 0)
+            {
+                Console.WriteLine("Warning: invalid setting line \"" + line + "\"");
+                return;
+            }
+            string name = line.Substring(0, equalsPos).Trim();
+            string value = line.Substring(equalsPos + 1).Trim();
+            if (value.StartsWith("\"") && value.EndsWith("\""))
+            {
+                value = value.Trim('\"');
+            }
+            SettingsProperty prop = Properties.Settings.Default.Properties[name];
+            if (prop == null)
+            {
+                Console.WriteLine("Warning: Ignoring unknown setting \"" + name + "\"");
+                return;
+            }
+            Type type = prop.PropertyType;
+            if (type == typeof(Boolean))
+            {
+                if (Boolean.TryParse(value, out bool boolValue))
+                {
+                    Properties.Settings.Default[name] = boolValue;
+                }
+                else if (value == "0" || value == "1")
+                {
+                    Properties.Settings.Default[name] = value == "1";
+                }
+                else
+                {
+                    Console.WriteLine("Warning: Ignoring unreadable boolean value \"" + value + "\" for setting \"" + name + "\"");
+                }
+            }
+            else if (type == typeof(String))
+            {
+                Properties.Settings.Default[name] = value;
+            } else
+            {
+                Console.WriteLine("Warning: Setting \"" + name + "\" of type \"" + type.Name + "\" cannot be processed.");
+            }
+        }
+    }
+}

--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Controllers\ParseHelper.cs" />
     <Compile Include="Controllers\StatisticsCalculator.cs" />
     <Compile Include="Controllers\UploadController.cs" />
+    <Compile Include="CustomSettingsManager.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="GridRow.cs" />
     <Compile Include="MainForm.cs">
@@ -281,6 +282,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="LI.ico" />
+    <None Include="sample.conf">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Resources\theme-cosmo.png" />
     <None Include="Resources\theme-slate.png" />
     <None Include="Resources\combatreplay.js" />

--- a/LuckParser/Program.cs
+++ b/LuckParser/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
@@ -53,6 +54,8 @@ namespace LuckParser
                 Properties.Settings.Default.Outdated = false;
             }
 
+            List<string> logFiles = new List<string>();
+
             Application.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             if (args.Length > 0)
             {
@@ -98,7 +101,7 @@ namespace LuckParser
 
                 if (args.Contains("-c"))
                 {
-                    if (args.Length - parserArgOffset > 2)
+                    if (args.Length - parserArgOffset >= 2)
                     {
                         // Do not access settings before this, else this will not work
                         int argPos = Array.IndexOf(args, "-c");
@@ -115,13 +118,15 @@ namespace LuckParser
                     }
                 }
 
-                string[] parserArgs = new string[args.Length-parserArgOffset];
                 for (int i = parserArgOffset; i < args.Length; i++)
                 {
-                    parserArgs[i - parserArgOffset] = args[i];
+                    logFiles.Add(args[i]);
                 }
+            }
+            if (logFiles.Count > 0)
+            {
                 // Use the application through console 
-                new ConsoleProgram(parserArgs);
+                new ConsoleProgram(logFiles);
                 return 0;
             }
 

--- a/LuckParser/Program.cs
+++ b/LuckParser/Program.cs
@@ -46,6 +46,13 @@ namespace LuckParser
         [STAThread]
         static int Main(string[] args)
         {
+            // Migrate previous settings if version changed
+            if (Properties.Settings.Default.Outdated)
+            {
+                Properties.Settings.Default.Upgrade();
+                Properties.Settings.Default.Outdated = false;
+            }
+
             Application.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             if (args.Length > 0)
             {
@@ -96,7 +103,7 @@ namespace LuckParser
                         // Do not access settings before this, else this will not work
                         int argPos = Array.IndexOf(args, "-c");
 
-                        AppDomain.CurrentDomain.SetData("APP_CONFIG_FILE", args[argPos + 1]);
+                        CustomSettingsManager.ReadConfig(args[argPos + 1]);
 
                         parserArgOffset += 2;
                     }

--- a/LuckParser/Properties/Settings.Designer.cs
+++ b/LuckParser/Properties/Settings.Designer.cs
@@ -9,12 +9,12 @@
 //------------------------------------------------------------------------------
 
 namespace LuckParser.Properties {
-    
-    
+
+
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
-        
+
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
         public static Settings Default {
@@ -428,6 +428,18 @@ namespace LuckParser.Properties {
             }
             set {
                 this["AutoAddPath"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool Outdated {
+            get {
+                return ((bool)(this["Outdated"]));
+            }
+            set {
+                this["Outdated"] = value;
             }
         }
     }

--- a/LuckParser/Properties/Settings.settings
+++ b/LuckParser/Properties/Settings.settings
@@ -104,5 +104,8 @@
     <Setting Name="AutoAddPath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="Outdated" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/LuckParser/sample.conf
+++ b/LuckParser/sample.conf
@@ -1,0 +1,72 @@
+# Sample Configuration
+# 
+# remove "#" to activate a line.
+#
+
+# DPSGraphTotals=true
+
+# ClDPSGraphTotals=false
+
+# PlayerBoonsUniversal=true
+
+# PlayerBoonsImpProf=true
+
+# PlayerBoonsAllProf=true
+
+# PlayerRot=true
+
+# PlayerRotIcons=true
+
+# SaveAtOut=true
+
+# OutLocation=
+
+# EventList=false
+
+# BossSummary=true
+
+# SimpleRotation=true
+
+# ShowAutos=true
+
+# LargeRotIcons=false
+
+# SaveOutHTML=true
+
+# SaveOutCSV=false
+
+# ShowEstimates=false
+
+# ParseOneAtATime=true
+
+# ParsePhases=true
+
+# Show10s=true
+
+# Show30s=true
+
+# LightTheme=false
+
+# ParseCombatReplay=false
+
+# UploadToDPSReports=false
+
+# UploadToDPSReportsRH=false
+
+# UploadToRaidar=false
+
+# SaveOutJSON=false
+
+# IndentJSON=false
+
+# NewHtmlMode=false
+
+# NewHtmlExternalScripts=false
+
+# SkipFailedTrys=false
+
+# AutoAdd=false
+
+# AutoParse=false
+
+# AutoAddPath=


### PR DESCRIPTION
- Settings are not lost anymore on a version change
- the `-c` parameter for custom settings can now be used for UI mode too
- Rewrote how custom settings are handled
    - "old" `*.config` files in xml format still work for backwards compatibility (a deprecated-message is printed to the console). The known errors are still present there.
    - new config file extension `*.conf`
    - file uses a simple `key=value` format similar to many linux programs
    - comment lines start with `#` and are ignored
    - a `sample.conf` with a sample config is shipped along with the .exe
    - invalid lines, or unknown keys are ignored with a message to the console, it is not possible anymore that the program crashes
    - The priority of the settings was changed to custom file > user settings > shipped defaults:
        - Settings in the custom file have the highest priority
        - If a key is not present in the custom file or no custom file is used, user settings created by the settings dialog kick in
        - If no user are present or a key is not present there the app defaults kick in