### PR TITLE
Maintenance

### DIFF
--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -335,10 +335,10 @@ namespace LuckParser.Controllers
             // 4 bytes: buff_dmg
             int buffDmg = reader.ReadInt32();
 
-            // 2 bytes: overstack_value
+            // 4 bytes: overstack_value
             uint overstackValue = reader.ReadUInt32();
 
-            // 2 bytes: skill_id
+            // 4 bytes: skill_id
             uint skillId = reader.ReadUInt32();
 
             // 2 bytes: src_instid

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -308,14 +308,16 @@ namespace LuckParser.Controllers
 
             // 1 byte: is_flanking
             byte isShields = reader.ReadByte();
-            // 2 bytes: garbage
-            ParseHelper.SafeSkip(reader.BaseStream, 2);
+            // 1 byte: is_flanking
+            byte isOffcycle = reader.ReadByte();
+            // 1 bytes: garbage
+            ParseHelper.SafeSkip(reader.BaseStream, 1);
 
             //save
             // Add combat
             return new CombatItem(time, srcAgent, dstAgent, value, buffDmg, overstackValue, skillId,
                 srcInstid, dstInstid, srcMasterInstid,0, iff, buff, result, isActivation, isBuffRemove,
-                isNinety, isFifty, isMoving, isStateChange, isFlanking, isShields);
+                isNinety, isFifty, isMoving, isStateChange, isFlanking, isShields, isOffcycle);
         }
 
         private static CombatItem ReadCombatItemRev1(BinaryReader reader)
@@ -383,15 +385,17 @@ namespace LuckParser.Controllers
             byte isFlanking = reader.ReadByte();
 
             // 1 byte: is_flanking
-            byte IsShields = reader.ReadByte();
+            byte isShields = reader.ReadByte();
+            // 1 byte: is_flanking
+            byte isOffcycle = reader.ReadByte();
             // 5 bytes: offcycle (?) + garbage
-            ParseHelper.SafeSkip(reader.BaseStream, 5);
+            ParseHelper.SafeSkip(reader.BaseStream, 4);
 
             //save
             // Add combat
             return new CombatItem(time, srcAgent, dstAgent, value, buffDmg, overstackValue, skillId,
                 srcInstid, dstInstid, srcMasterInstid, dstmasterInstid, iff, buff, result, isActivation, isBuffRemove,
-                isNinety, isFifty, isMoving, isStateChange, isFlanking, IsShields);
+                isNinety, isFifty, isMoving, isStateChange, isFlanking, isShields, isOffcycle);
         }
 
         /// <summary>

--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -85,7 +85,7 @@ namespace LuckParser.Controllers
                 double[] health = new double[seconds + 1];
                 int i = 0;
                 double curHealth = 100.0;
-                foreach (Point p in log.Boss.HealthOverTime)
+                foreach (Point p in boss.HealthOverTime)
                 {
                     double hp = p.Y / 100.0;
                     int timeInPhase = 1 + (p.X - (int)_statistics.Phases[0].Start) / 1000;

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -212,7 +212,12 @@ namespace LuckParser.Models
 
         protected void SetSuccessByDeath(ParsedLog log)
         {
-            CombatItem killed = log.CombatData.GetStatesData(ParseEnum.StateChange.ChangeDead).LastOrDefault(x => x.SrcInstid == log.Boss.InstID);
+            Boss mainTarget = Targets.Find(x => x.ID == TriggerID);
+            if (mainTarget == null)
+            {
+                throw new InvalidOperationException("Main target of the fight not found");
+            }
+            CombatItem killed = log.CombatData.GetStatesData(ParseEnum.StateChange.ChangeDead).LastOrDefault(x => x.SrcInstid == mainTarget.InstID);
             if (killed != null)
             {
                 log.LogData.Success = true;

--- a/LuckParser/Models/BossLogic/Deimos.cs
+++ b/LuckParser/Models/BossLogic/Deimos.cs
@@ -108,13 +108,13 @@ namespace LuckParser.Models
                 return phases;
             }
             // Determined + additional data on inst change
-            CombatItem invulDei = log.GetBoonData(762).Find(x => x.IsBuffRemove == ParseEnum.BuffRemove.None && x.DstInstid == log.Boss.InstID);
+            CombatItem invulDei = log.GetBoonData(762).Find(x => x.IsBuffRemove == ParseEnum.BuffRemove.None && x.DstInstid == mainTarget.InstID);
             if (invulDei != null)
             {
                 end = invulDei.Time - log.FightData.FightStart;
                 phases.Add(new PhaseData(start, end));
                 start = (log.FightData.PhaseData.Count == 1 ? log.FightData.PhaseData[0] - log.FightData.FightStart : fightDuration);
-                log.Boss.AddCustomCastLog(new CastLog(end, -6, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
+                mainTarget.AddCustomCastLog(new CastLog(end, -6, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
             }
             if (fightDuration - start > 5000 && start >= phases.Last().End)
             {

--- a/LuckParser/Models/BossLogic/Dhuum.cs
+++ b/LuckParser/Models/BossLogic/Dhuum.cs
@@ -59,8 +59,8 @@ namespace LuckParser.Models
                 return phases;
             }
             // Sometimes the preevent is not in the evtc
-            List<CastLog> castLogs = log.Boss.GetCastLogs(log, 0, log.FightData.FightEnd);
-            List<CastLog> dhuumCast = log.Boss.GetCastLogs(log, 0, 20000);
+            List<CastLog> castLogs = mainTarget.GetCastLogs(log, 0, log.FightData.FightEnd);
+            List<CastLog> dhuumCast = mainTarget.GetCastLogs(log, 0, 20000);
             if (dhuumCast.Count > 0)
             {
                 CastLog shield = castLogs.Find(x => x.SkillId == 47396);
@@ -90,7 +90,7 @@ namespace LuckParser.Models
             }
             else
             {
-                CombatItem invulDhuum = log.GetBoonData(762).FirstOrDefault(x => x.IsBuffRemove != ParseEnum.BuffRemove.None && x.SrcInstid == log.Boss.InstID && x.Time > 115000 + log.FightData.FightStart);
+                CombatItem invulDhuum = log.GetBoonData(762).FirstOrDefault(x => x.IsBuffRemove != ParseEnum.BuffRemove.None && x.SrcInstid == mainTarget.InstID && x.Time > 115000 + log.FightData.FightStart);
                 if (invulDhuum != null)
                 {
                     end = invulDhuum.Time - log.FightData.FightStart;
@@ -231,11 +231,16 @@ namespace LuckParser.Models
             // spirit transform
             CombatReplay replay = p.CombatReplay;
             List<CombatItem> spiritTransform = log.GetBoonData(46950).Where(x => x.DstInstid == p.InstID && x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
+            Boss mainTarget = Targets.Find(x => x.ID == (ushort)ParseEnum.BossIDS.Dhuum);
+            if (mainTarget == null)
+            {
+                throw new InvalidOperationException("Main target of the fight not found");
+            }
             foreach (CombatItem c in spiritTransform)
             {
                 int duration = 15000;
                 int start = (int)(c.Time - log.FightData.FightStart);
-                if (log.Boss.HealthOverTime.FirstOrDefault(x => x.X > start).Y < 1050)
+                if (mainTarget.HealthOverTime.FirstOrDefault(x => x.X > start).Y < 1050)
                 {
                     duration = 30000;
                 }

--- a/LuckParser/Models/BossLogic/Golem.cs
+++ b/LuckParser/Models/BossLogic/Golem.cs
@@ -1,5 +1,6 @@
 ﻿using LuckParser.Models.DataModels;
 using LuckParser.Models.ParseModels;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -57,6 +58,11 @@ namespace LuckParser.Models
 
         public override void SetSuccess(ParsedLog log)
         {
+            Boss mainTarget = Targets.Find(x => x.ID == TriggerID);
+            if (mainTarget == null)
+            {
+                throw new InvalidOperationException("Main target of the fight not found");
+            }
             CombatItem pov = log.CombatData.AllCombatItems.FirstOrDefault(x => x.IsStateChange == ParseEnum.StateChange.PointOfView);
             if (pov != null)
             {
@@ -67,14 +73,14 @@ namespace LuckParser.Models
                     log.FightData.FightStart = enterCombat.Time;
                 }
             }
-            CombatItem lastDamageTaken = log.CombatData.GetDamageTakenData(log.Boss.InstID).LastOrDefault(x => x.Value > 0 || x.BuffDmg > 0);
+            CombatItem lastDamageTaken = log.CombatData.GetDamageTakenData(mainTarget.InstID).LastOrDefault(x => x.Value > 0 || x.BuffDmg > 0);
             if (lastDamageTaken != null)
             {
                 log.FightData.FightEnd = lastDamageTaken.Time;
             }
-            if (log.Boss.HealthOverTime.Count > 0)
+            if (mainTarget.HealthOverTime.Count > 0)
             {
-                log.LogData.Success = log.Boss.HealthOverTime.Last().Y < 200;
+                log.LogData.Success = mainTarget.HealthOverTime.Last().Y < 200;
             }
         }
     }

--- a/LuckParser/Models/BossLogic/Gorseval.cs
+++ b/LuckParser/Models/BossLogic/Gorseval.cs
@@ -63,14 +63,14 @@ namespace LuckParser.Models
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsGorse.Count - 1)
                     {
-                        log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
+                        mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
                     }
                 }
                 else
                 {
                     start = c.Time - log.FightData.FightStart;
                     phases.Add(new PhaseData(end, start));
-                    log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
+                    mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
                 }
             }
             if (fightDuration - start > 5000 && start >= phases.Last().End)
@@ -138,6 +138,11 @@ namespace LuckParser.Models
             {
                 case (ushort)ParseEnum.BossIDS.Gorseval:
                     List<CastLog> blooms = cls.Where(x => x.SkillId == 31616).ToList();
+                    Boss mainTarget = Targets.Find(x => x.ID == (ushort)ParseEnum.BossIDS.Gorseval);
+                    if (mainTarget == null)
+                    {
+                        throw new InvalidOperationException("Main target of the fight not found");
+                    }
                     foreach (CastLog c in blooms)
                     {
                         int start = (int)c.Time;
@@ -149,7 +154,7 @@ namespace LuckParser.Models
                     if (phases.Count > 1)
                     {
                         List<CastLog> rampage = cls.Where(x => x.SkillId == 31834).ToList();
-                        Point3D pos = log.Boss.CombatReplay.Positions.First();
+                        Point3D pos = mainTarget.CombatReplay.Positions.First();
                         foreach (CastLog c in rampage)
                         {
                             int start = (int)c.Time;

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -55,7 +55,7 @@ namespace LuckParser.Models
                 return phases;
             }
             // Main phases
-            List<CastLog> castLogs = log.Boss.GetCastLogs(log, 0, log.FightData.FightEnd);
+            List<CastLog> castLogs = mainTarget.GetCastLogs(log, 0, log.FightData.FightEnd);
             List<CastLog> clsKC = castLogs.Where(x => x.SkillId == 35048).ToList();
             foreach (CastLog cl in clsKC)
             {
@@ -75,7 +75,7 @@ namespace LuckParser.Models
             }
             // add burn phases
             int offset = phases.Count;
-            List<CombatItem> orbItems = log.GetBoonData(35096).Where(x => x.DstInstid == log.Boss.InstID).ToList();
+            List<CombatItem> orbItems = log.GetBoonData(35096).Where(x => x.DstInstid == mainTarget.InstID).ToList();
             // Get number of orbs and filter the list
             start = 0;
             int orbCount = 0;

--- a/LuckParser/Models/BossLogic/Matthias.cs
+++ b/LuckParser/Models/BossLogic/Matthias.cs
@@ -75,11 +75,11 @@ namespace LuckParser.Models
             if (heatWave != null)
             {
                 phaseStarts.Add(heatWave.Time - log.FightData.FightStart);
-                CombatItem downPour = log.GetDamageData(log.Boss.InstID).Find(x => x.SkillID == 34554);
+                CombatItem downPour = log.GetDamageData(mainTarget.InstID).Find(x => x.SkillID == 34554);
                 if (downPour != null)
                 {
                     phaseStarts.Add(downPour.Time - log.FightData.FightStart);
-                    List<CastLog> castLogs = log.Boss.GetCastLogs(log, 0, log.FightData.FightEnd);
+                    List<CastLog> castLogs = mainTarget.GetCastLogs(log, 0, log.FightData.FightEnd);
                     CastLog abo = castLogs.Find(x => x.SkillId == 34427);
                     if (abo != null)
                     {

--- a/LuckParser/Models/BossLogic/Sabetha.cs
+++ b/LuckParser/Models/BossLogic/Sabetha.cs
@@ -53,7 +53,7 @@ namespace LuckParser.Models
                 return phases;
             }
             // Invul check
-            List<CombatItem> invulsSab = GetFilteredList(log, 757, log.Boss.InstID);
+            List<CombatItem> invulsSab = GetFilteredList(log, 757, mainTarget.InstID);
             for (int i = 0; i < invulsSab.Count; i++)
             {
                 CombatItem c = invulsSab[i];
@@ -63,14 +63,14 @@ namespace LuckParser.Models
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsSab.Count - 1)
                     {
-                        log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
+                        mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
                     }
                 }
                 else
                 {
                     start = c.Time - log.FightData.FightStart;
                     phases.Add(new PhaseData(end, start));
-                    log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
+                    mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
                 }
             }
             if (fightDuration - start > 5000 && start >= phases.Last().End)

--- a/LuckParser/Models/BossLogic/Samarog.cs
+++ b/LuckParser/Models/BossLogic/Samarog.cs
@@ -70,7 +70,7 @@ namespace LuckParser.Models
                 return phases;
             }
             // Determined check
-            List<CombatItem> invulsSam = GetFilteredList(log, 762, log.Boss.InstID);         
+            List<CombatItem> invulsSam = GetFilteredList(log, 762, mainTarget.InstID);         
             for (int i = 0; i < invulsSam.Count; i++)
             {
                 CombatItem c = invulsSam[i];
@@ -80,14 +80,14 @@ namespace LuckParser.Models
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsSam.Count - 1)
                     {
-                        log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
+                        mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
                     }
                 }
                 else
                 {
                     start = c.Time - log.FightData.FightStart;
                     phases.Add(new PhaseData(end, start));
-                    log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
+                    mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
                 }
             }
             if (fightDuration - start > 5000 && start >= phases.Last().End)

--- a/LuckParser/Models/BossLogic/Skorvald.cs
+++ b/LuckParser/Models/BossLogic/Skorvald.cs
@@ -100,8 +100,13 @@ namespace LuckParser.Models
         public override void SetSuccess(ParsedLog log)
         {
             // check reward
+            Boss mainTarget = Targets.Find(x => x.ID == (ushort)ParseEnum.BossIDS.Skorvald);
+            if (mainTarget == null)
+            {
+                throw new InvalidOperationException("Main target of the fight not found");
+            }
             CombatItem reward = log.CombatData.GetStatesData(ParseEnum.StateChange.Reward).LastOrDefault();
-            CombatItem lastDamageTaken = log.CombatData.GetDamageTakenData(log.Boss.InstID).LastOrDefault(x => x.Value > 0);
+            CombatItem lastDamageTaken = log.CombatData.GetDamageTakenData(mainTarget.InstID).LastOrDefault(x => x.Value > 0);
             if (lastDamageTaken != null)
             {
                 if (reward != null && lastDamageTaken.Time - reward.Time < 100)

--- a/LuckParser/Models/BossLogic/ValeGuardian.cs
+++ b/LuckParser/Models/BossLogic/ValeGuardian.cs
@@ -72,7 +72,7 @@ namespace LuckParser.Models
                 return phases;
             }
             // Invul check
-            List<CombatItem> invulsVG = GetFilteredList(log, 757, log.Boss.InstID);
+            List<CombatItem> invulsVG = GetFilteredList(log, 757, mainTarget.InstID);
             for (int i = 0; i < invulsVG.Count; i++)
             {
                 CombatItem c = invulsVG[i];
@@ -82,14 +82,14 @@ namespace LuckParser.Models
                     phases.Add(new PhaseData(start, end));
                     if (i == invulsVG.Count - 1)
                     {
-                        log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
+                        mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(fightDuration - end), ParseEnum.Activation.None, (int)(fightDuration - end), ParseEnum.Activation.None), log);
                     }
                 }
                 else
                 {
                     start = c.Time - log.FightData.FightStart;
                     phases.Add(new PhaseData(end, start));
-                    log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
+                    mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
                 }
             }
             if (fightDuration - start > 5000 && start >= phases.Last().End)

--- a/LuckParser/Models/BossLogic/Xera.cs
+++ b/LuckParser/Models/BossLogic/Xera.cs
@@ -64,15 +64,15 @@ namespace LuckParser.Models
             // split happened
             if (log.FightData.PhaseData.Count == 1)
             {
-                CombatItem invulXera = log.GetBoonData(762).Find(x => x.DstInstid == log.Boss.InstID);
+                CombatItem invulXera = log.GetBoonData(762).Find(x => x.DstInstid == mainTarget.InstID);
                 if (invulXera == null)
                 {
-                    invulXera = log.GetBoonData(34113).Find(x => x.DstInstid == log.Boss.InstID);
+                    invulXera = log.GetBoonData(34113).Find(x => x.DstInstid == mainTarget.InstID);
                 }
                 long end = invulXera.Time - log.FightData.FightStart;
                 phases.Add(new PhaseData(start, end));
                 start = log.FightData.PhaseData[0] - log.FightData.FightStart;
-                log.Boss.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
+                mainTarget.AddCustomCastLog(new CastLog(end, -5, (int)(start - end), ParseEnum.Activation.None, (int)(start - end), ParseEnum.Activation.None), log);
             }
             if (fightDuration - start > 5000 && start >= phases.Last().End)
             {

--- a/LuckParser/Models/ParseModels/Boons/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boons/Boon.cs
@@ -90,7 +90,7 @@ namespace LuckParser.Models.ParseModels
                 new Boon("Protection", 717, BoonSource.Mixed, BoonType.Duration, 5, BoonNature.Boon, Logic.Queue, "https://wiki.guildwars2.com/images/6/6c/Protection.png"),
                 new Boon("Regeneration", 718, BoonSource.Mixed, BoonType.Duration, 5, BoonNature.Boon, Logic.HealingPower, "https://wiki.guildwars2.com/images/5/53/Regeneration.png"),
                 new Boon("Vigor", 726, BoonSource.Mixed, BoonType.Duration, 5, BoonNature.Boon, Logic.Queue, "https://wiki.guildwars2.com/images/f/f4/Vigor.png"),
-                new Boon("Aegis", 743, BoonSource.Mixed, BoonType.Duration, 5, BoonNature.Boon, Logic.Queue, "https://wiki.guildwars2.com/images/e/e5/Aegis.png"),
+                new Boon("Aegis", 743, BoonSource.Mixed, BoonType.Duration, 9, BoonNature.Boon, Logic.Queue, "https://wiki.guildwars2.com/images/e/e5/Aegis.png"),
                 new Boon("Stability", 1122, BoonSource.Mixed, BoonType.Intensity, 25, BoonNature.Boon, Logic.Override, "https://wiki.guildwars2.com/images/a/ae/Stability.png"),
                 new Boon("Swiftness", 719, BoonSource.Mixed, BoonType.Duration, 9, BoonNature.Boon, Logic.Queue, "https://wiki.guildwars2.com/images/a/af/Swiftness.png"),
                 new Boon("Retaliation", 873, BoonSource.Mixed, BoonType.Duration, 5, BoonNature.Boon, Logic.Queue, "https://wiki.guildwars2.com/images/5/53/Retaliation.png"),

--- a/LuckParser/Models/ParseModels/Boons/BoonMap.cs
+++ b/LuckParser/Models/ParseModels/Boons/BoonMap.cs
@@ -42,6 +42,52 @@ namespace LuckParser.Models.ParseModels
             }
             this[boon.ID] = new List<BoonLog>();
         }
+
+        private int CompareApplicationType(BoonLog x, BoonLog y)
+        {
+            if (x.Time < y.Time)
+            {
+                return -1;
+            }
+            else if (x.Time > y.Time)
+            {
+                return 1;
+            }
+            else
+            {
+                if (x.GetType() == typeof(BoonRemovalLog))
+                {
+                    if (y.GetType() == typeof(BoonRemovalLog))
+                    {
+                        return 0;
+                    }
+                    else
+                    {
+                        return 1;
+                    }
+                }
+                else
+                {
+                    if (y.GetType() == typeof(BoonRemovalLog))
+                    {
+                        return -1;
+                    }
+                    else
+                    {
+                        return 0;
+                    }
+                }
+            }
+        }
+
+
+        public void Sort()
+        {
+            foreach (var pair in this)
+            {
+                pair.Value.Sort(CompareApplicationType);
+            }
+        }
         
     }
 

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -50,7 +50,7 @@ namespace LuckParser.Models.ParseModels
             BoonData = boonData.GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
             BoonDataByDst = boonData.GroupBy(x => x.IsBuffRemove == ParseEnum.BuffRemove.None ? x.DstInstid : x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
             // damage events
-            var damageData = noStateActiBuffRem.Where(x => (x.IsBuff != 0 && x.Value == 0) || (x.IsBuff == 0)).ToList();
+            var damageData = noStateActiBuffRem.Where(x => (x.IsBuff != 0 && x.Value == 0) || (x.IsBuff == 0));
             DamageData = damageData.GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
             DamageTakenData = damageData.GroupBy(x => x.DstInstid).ToDictionary(x => x.Key, x => x.ToList());
 

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -23,22 +23,8 @@ namespace LuckParser.Models.ParseModels
         public CombatData(List<CombatItem> allCombatItems, FightData fightData)
         {
             AllCombatItems = allCombatItems;
-            var boonData = allCombatItems.Where(x => x.IsBuff > 0 && (x.IsBuff == 18 || x.BuffDmg == 0 || x.IsBuffRemove != ParseEnum.BuffRemove.None)).ToArray();
-            BoonData = boonData.GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
-            BoonDataByDst = boonData.GroupBy(x => x.IsBuffRemove == ParseEnum.BuffRemove.None ? x.DstInstid : x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
-
-            var damageData = allCombatItems.Where(x => x.IsStateChange == ParseEnum.StateChange.Normal && x.IsBuffRemove == ParseEnum.BuffRemove.None &&
-                                        ((x.IsBuff == 1 && x.BuffDmg >= 0 && x.Value == 0) ||
-                                        (x.IsBuff == 0 && x.Value >= 0))).ToArray();
-            DamageData = damageData.Where(x => x.DstInstid != 0 && x.IFF == ParseEnum.IFF.Foe).GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
-            DamageTakenData = damageData.GroupBy(x => x.DstInstid).ToDictionary(x => x.Key, x => x.ToList());
-
-            var castData = allCombatItems.Where(x => (x.IsStateChange == ParseEnum.StateChange.Normal && x.IsActivation != ParseEnum.Activation.None) || x.IsStateChange == ParseEnum.StateChange.WeaponSwap).ToArray();
-            CastData = castData.GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
-            CastDataById = castData.GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
-
-            StatesData = allCombatItems.GroupBy(x => x.IsStateChange).ToDictionary(x => x.Key, x => x.ToList());
-
+            var noStateActiBuffRem = allCombatItems.Where(x => x.IsStateChange == ParseEnum.StateChange.Normal && x.IsActivation == ParseEnum.Activation.None && x.IsBuffRemove == ParseEnum.BuffRemove.None);
+            // movement events
             MovementData = fightData.Logic.CanCombatReplay
                 ? allCombatItems.Where(x =>
                         x.IsStateChange == ParseEnum.StateChange.Position ||
@@ -47,6 +33,26 @@ namespace LuckParser.Models.ParseModels
                     .ToDictionary(x => x.Key, x => x.ToList())
                 : new Dictionary<ushort, List<CombatItem>>();
             fightData.Logic.CanCombatReplay = MovementData.Count > 1;
+            // state change events
+            StatesData = allCombatItems.GroupBy(x => x.IsStateChange).ToDictionary(x => x.Key, x => x.ToList());
+            // activation events
+            var castData = allCombatItems.Where(x => x.IsActivation != ParseEnum.Activation.None || x.IsStateChange == ParseEnum.StateChange.WeaponSwap);
+            CastData = castData.GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
+            CastDataById = castData.GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
+            // buff remove event
+            var buffRemove = allCombatItems.Where(x => x.IsBuffRemove != ParseEnum.BuffRemove.None && x.IsBuff != 0);
+            var buffApply = noStateActiBuffRem.Where(x => x.IsBuff != 0 && x.BuffDmg == 0);
+            var buffInitial = allCombatItems.Where(x => x.IsStateChange == ParseEnum.StateChange.BuffInitial);
+            var boonData = new List<CombatItem>(buffRemove);
+            boonData.AddRange(buffApply);
+            boonData.AddRange(buffInitial);
+            boonData.Sort((x, y) => x.Time < y.Time ? -1 : 1);
+            BoonData = boonData.GroupBy(x => x.SkillID).ToDictionary(x => x.Key, x => x.ToList());
+            BoonDataByDst = boonData.GroupBy(x => x.IsBuffRemove == ParseEnum.BuffRemove.None ? x.DstInstid : x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
+            // damage events
+            var damageData = noStateActiBuffRem.Where(x => (x.IsBuff != 0 && x.Value == 0) || (x.IsBuff == 0)).ToList();
+            DamageData = damageData.GroupBy(x => x.SrcInstid).ToDictionary(x => x.Key, x => x.ToList());
+            DamageTakenData = damageData.GroupBy(x => x.DstInstid).ToDictionary(x => x.Key, x => x.ToList());
 
             /*healing_data = allCombatItems.Where(x => x.getDstInstid() != 0 && x.isStateChange() == ParseEnum.StateChange.Normal && x.getIFF() == ParseEnum.IFF.Friend && x.isBuffremove() == ParseEnum.BuffRemove.None &&
                                          ((x.isBuff() == 1 && x.getBuffDmg() > 0 && x.getValue() == 0) ||

--- a/LuckParser/Models/ParseModels/CombatItem.cs
+++ b/LuckParser/Models/ParseModels/CombatItem.cs
@@ -26,12 +26,13 @@ namespace LuckParser.Models.ParseModels
         public ParseEnum.StateChange IsStateChange { get; }
         public byte IsFlanking { get; }
         public byte IsShields { get; }
+        public byte IsOffcycle { get; }
 
         // Constructor
         public CombatItem(long time, ulong srcAgent, ulong dstAgent, int value, int buffDmg, uint overstackValue,
                long skillId, ushort srcInstid, ushort dstInstid, ushort srcMasterInstid, ushort dstMasterInstid, ParseEnum.IFF iff, byte isBuff, ParseEnum.Result result,
                ParseEnum.Activation isActivation, ParseEnum.BuffRemove isBuffRemove, byte isNinety, byte isFifty, byte isMoving,
-               ParseEnum.StateChange isStateChange, byte isFlanking, byte isShields)
+               ParseEnum.StateChange isStateChange, byte isFlanking, byte isShields, byte isOffcycle)
         {
             Time = time;
             SrcAgent = srcAgent;
@@ -55,6 +56,7 @@ namespace LuckParser.Models.ParseModels
             IsStateChange = isStateChange;
             IsFlanking = isFlanking;
             IsShields = isShields;
+            IsOffcycle = isOffcycle;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/Mechanics/MechanicData.cs
+++ b/LuckParser/Models/ParseModels/Mechanics/MechanicData.cs
@@ -71,7 +71,6 @@ namespace LuckParser.Models.ParseModels
                 // ready enemy list
                 List<AbstractMasterPlayer> toAdd = new List<AbstractMasterPlayer>();
                 _enemyList.Add(toAdd);
-                toAdd.Add(log.Boss);
                 foreach(Mechanic m in Keys.Where(x=> x.IsEnemyMechanic))
                 {
                     foreach (AbstractMasterPlayer p in this[m].Where(x => phase.InInterval(x.Time)).Select(x => x.Player).Distinct())

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -201,7 +201,8 @@ namespace LuckParser.Models.ParseModels
                         loglist.Add(new BoonRemovalLog(time, c.DstInstid, c.Value, c.IsBuffRemove));
                     }
                 }
-            }   
+            }
+            boonMap.Sort();
             return boonMap;
         }
         // private setters

--- a/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractPlayer.cs
@@ -107,32 +107,30 @@ namespace LuckParser.Models.ParseModels
         // privates
         protected void AddDamageLog(long time, CombatItem c)
         {
-            if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
+            if (c.IsBuff != 0)//condi
             {
-                if (c.IsBuff == 1 && c.BuffDmg != 0)//condi
-                {
-                    DamageLogs.Add(new DamageLogCondition(time, c));
-                }
-                else if (c.IsBuff == 0 && c.Value != 0)//power
-                {
-                    DamageLogs.Add(new DamageLogPower(time, c));
-                }
-                else if (c.Result == ParseEnum.Result.Absorb || c.Result == ParseEnum.Result.Blind || c.Result == ParseEnum.Result.Interrupt)
-                {//Hits that where blinded, invulned, interrupts
-                    DamageLogs.Add(new DamageLogPower(time, c));
-                }
+                DamageLogs.Add(new DamageLogCondition(time, c));
             }
+            else if (c.IsBuff == 0)//power
+            {
+                DamageLogs.Add(new DamageLogPower(time, c));
+            }
+            else if (c.Result == ParseEnum.Result.Absorb || c.Result == ParseEnum.Result.Blind || c.Result == ParseEnum.Result.Interrupt)
+            {//Hits that where blinded, invulned, interrupts
+                DamageLogs.Add(new DamageLogPower(time, c));
+            }
+
 
         }
         protected void AddDamageTakenLog(long time, CombatItem c)
         {
-            if (c.IsBuff == 1 && c.BuffDmg != 0)
+            if (c.IsBuff != 0)
             {
                 //inco,ing condi dmg not working or just not present?
                 // damagetaken.Add(c.getBuffDmg());
                 _damageTakenlogs.Add(new DamageLogCondition(time, c));
             }
-            else if (c.IsBuff == 0 && c.Value >= 0)
+            else if (c.IsBuff == 0)
             {
                 _damageTakenlogs.Add(new DamageLogPower(time, c));
 

--- a/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
+++ b/LuckParser/Models/ParseModels/Simulator/BoonSimulator.cs
@@ -142,7 +142,7 @@ namespace LuckParser.Models.ParseModels
                     for (int i = 0; i < BoonStack.Count; i++)
                     {
                         BoonStackItem stackItem = BoonStack[i];
-                        if (boonDuration == stackItem.BoonDuration)
+                        if (Math.Abs(boonDuration-stackItem.BoonDuration) < 10)
                         {
                             OverstackSimulationResult.Add(new BoonSimulationOverstackItem(stackItem.Src, stackItem.BoonDuration, start));
                             CleanseSimulationResult.Add(new BoonSimulationCleanseItem(provokedBy, stackItem.BoonDuration, start));

--- a/LuckParser/Models/ParseModels/Simulator/EffectStackingLogic/OverrideLogic.cs
+++ b/LuckParser/Models/ParseModels/Simulator/EffectStackingLogic/OverrideLogic.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using LuckParser.Models.DataModels;
+using static LuckParser.Models.ParseModels.BoonSimulator;
 
 namespace LuckParser.Models.ParseModels
 {
@@ -12,7 +13,18 @@ namespace LuckParser.Models.ParseModels
 
         public override bool StackEffect(ParsedLog log, BoonSimulator.BoonStackItem stackItem, List<BoonSimulator.BoonStackItem> stacks, List<BoonSimulationOverstackItem> overstacks)
         {
-            return StackEffect(0, log, stackItem, stacks, overstacks);
+            for (int i = 0; i < stacks.Count; i++)
+            {
+                if (stacks[i].BoonDuration < stackItem.BoonDuration)
+                {
+                    BoonStackItem stack = stacks[i];
+                    overstacks.Add(new BoonSimulationOverstackItem(stack.Src, stack.BoonDuration, stack.Start));
+                    stacks[i] = stackItem;
+                    Sort(log, stacks);
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/Simulator/EffectStackingLogic/QueueLogic.cs
+++ b/LuckParser/Models/ParseModels/Simulator/EffectStackingLogic/QueueLogic.cs
@@ -1,4 +1,6 @@
-﻿using LuckParser.Models.DataModels;
+﻿using LuckParser.Controllers;
+using LuckParser.Models.DataModels;
+using System;
 using System.Collections.Generic;
 using static LuckParser.Models.ParseModels.BoonSimulator;
 
@@ -13,7 +15,22 @@ namespace LuckParser.Models.ParseModels
 
         public override bool StackEffect(ParsedLog log, BoonStackItem stackItem, List<BoonStackItem> stacks, List<BoonSimulationOverstackItem> overstacks)
         {
-            return StackEffect(1, log, stackItem, stacks, overstacks);
+            if (stacks.Count <= 1)
+            {
+                throw new InvalidOperationException("Queue logic based must have a >1 capacity");
+            }
+            BoonStackItem first = stacks[0];
+            stacks.RemoveAt(0);
+            BoonStackItem minItem = stacks.MinBy(x => x.BoonDuration);
+            if (minItem.BoonDuration >= stackItem.BoonDuration)
+            {
+                return false;
+            }
+            overstacks.Add(new BoonSimulationOverstackItem(minItem.Src, minItem.BoonDuration, minItem.Start));
+            stacks[stacks.IndexOf(minItem)] = stackItem;
+            stacks.Insert(0, first);
+            Sort(log, stacks);
+            return true;
         }
     }
 }

--- a/LuckParser/Models/ParseModels/Simulator/EffectStackingLogic/StackingLogic.cs
+++ b/LuckParser/Models/ParseModels/Simulator/EffectStackingLogic/StackingLogic.cs
@@ -8,22 +8,6 @@ namespace LuckParser.Models.ParseModels
     {
         public abstract bool StackEffect(ParsedLog log, BoonStackItem stackItem, List<BoonStackItem> stacks, List<BoonSimulationOverstackItem> overstacks);
 
-        protected bool StackEffect(int startIndex, ParsedLog log, BoonStackItem stackItem, List<BoonStackItem> stacks, List<BoonSimulationOverstackItem> overstacks)
-        {
-            for (int i = startIndex; i < stacks.Count; i++)
-            {
-                if (stacks[i].BoonDuration < stackItem.BoonDuration)
-                {
-                    BoonStackItem stack = stacks[i];
-                    overstacks.Add(new BoonSimulationOverstackItem(stack.Src, stack.BoonDuration, stack.Start));                   
-                    stacks[i] = stackItem;
-                    Sort(log, stacks);
-                    return true;
-                }
-            }
-            return false;
-        }
-
         public abstract void Sort(ParsedLog log, List<BoonStackItem> stacks);
     }
 }


### PR DESCRIPTION
- Some cleanup in combatdata
- Removed useless log.Boss calls
- Added off cycle to combat item
- Updated Aegis for 9 stacks
- Put an error margin on boon removes
- Added a sort to boon maps so that when the time of both items are equal, BoonRemovalLogs are considered "greater". This is to avoid situations where someone applies a buff at an exact time we have a buff remove. The application is treated first, then the removal
- Fixed a bug in Queue logic, the incoming buff is supposed to replace in the stack the minimum remaining time (disregarding the ticking buff) instead of replacing the first element it can replace