### PR TITLE
Combat replay

### DIFF
--- a/LuckParser/Controllers/StatisticsCalculator.cs
+++ b/LuckParser/Controllers/StatisticsCalculator.cs
@@ -64,7 +64,28 @@ namespace LuckParser.Controllers
                 {
                     target.InitCombatReplay(log, _settings.PollingRate, true, false);
                 }
-                log.FightData.Logic.ComputeTrashMobsData(log, _settings.PollingRate);
+                log.FightData.Logic.InitTrashMobCombatReplay(log, _settings.PollingRate);
+
+                // Ensuring all combat replays are initialized before extra data (and agent interaction) is computed
+                foreach (Player p in log.PlayerList)
+                {
+                    if (p.Group == 11)
+                    {
+                        continue;
+                    }
+                    p.ComputeAdditionalCombatReplayData(log);
+                }
+                foreach (Boss target in log.FightData.Logic.Targets)
+                {
+                    target.ComputeAdditionalCombatReplayData(log);
+                }
+
+                foreach (Mob mob in log.FightData.Logic.TrashMobs)
+                {
+                    mob.ComputeAdditionalCombatReplayData(log);
+                }
+
+
             }
             if (switches.CalculateDPS) CalculateDPS();
             if (switches.CalculateBoons) CalculateBoons();

--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Models\ParseModels\CombatReplay\Actors\PieActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\CircleActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\DoughnutActor.cs" />
+    <Compile Include="Models\ParseModels\CombatReplay\Actors\RotatedRectangleActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\RectangleActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\CombatReplay.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\CombatReplayMap.cs" />

--- a/LuckParser/LuckParser.csproj
+++ b/LuckParser/LuckParser.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Models\JsonModels\JsonBuffs.cs" />
     <Compile Include="Models\JsonModels\JsonSupport.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\Actor.cs" />
+    <Compile Include="Models\ParseModels\CombatReplay\Actors\LineActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\PieActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\CircleActor.cs" />
     <Compile Include="Models\ParseModels\CombatReplay\Actors\DoughnutActor.cs" />

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -198,7 +198,7 @@ namespace LuckParser.Models
         {
         }
 
-        public void ComputeTrashMobsData(ParsedLog log, int pollingRate)
+        public void InitTrashMobCombatReplay(ParsedLog log, int pollingRate)
         {
             List<ParseEnum.TrashIDS> ids = GetTrashMobsIDS();
             List<AgentItem> aList = log.AgentData.GetAgentByType(AgentItem.AgentType.NPC).Where(x => ids.Contains(ParseEnum.GetTrashIDS(x.ID))).ToList();

--- a/LuckParser/Models/BossLogic/Cairn.cs
+++ b/LuckParser/Models/BossLogic/Cairn.cs
@@ -63,9 +63,12 @@ namespace LuckParser.Models
                         int width = 1400; int height = 80;
                         Point3D facing = replay.Rotations.FirstOrDefault(x => x.Time >= start);
                         int initialDirection = (int)(Math.Atan2(facing.Y, facing.X) * 180 / Math.PI);
-                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(200, 0, 255, 0.1)"));
-                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start + preCastTime, start + preCastTime + initialHitDuration), "rgba(150, 0, 180, 0.5)"));
-                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, 360, new Tuple<int, int>(start + preCastTime + initialHitDuration, start + preCastTime + initialHitDuration + sweepDuration), "rgba(150, 0, 180, 0.5)"));
+                        if (facing != null)
+                        {
+                            replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(200, 0, 255, 0.1)"));
+                            replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start + preCastTime, start + preCastTime + initialHitDuration), "rgba(150, 0, 180, 0.5)"));
+                            replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, 360, new Tuple<int, int>(start + preCastTime + initialHitDuration, start + preCastTime + initialHitDuration + sweepDuration), "rgba(150, 0, 180, 0.5)"));
+                        }
                     }
                     break;
                 default:

--- a/LuckParser/Models/BossLogic/Cairn.cs
+++ b/LuckParser/Models/BossLogic/Cairn.cs
@@ -47,10 +47,26 @@ namespace LuckParser.Models
         
         public override void ComputeAdditionalBossData(Boss boss, ParsedLog log)
         {
-            // TODO: needs doughnuts (wave) and facing information (sword)
+            // TODO: needs doughnuts (wave)
+            CombatReplay replay = boss.CombatReplay;
+            List<CastLog> cls = boss.GetCastLogs(log, 0, log.FightData.FightDuration);
             switch (boss.ID)
             {
                 case (ushort)ParseEnum.BossIDS.Cairn:
+                    List<CastLog> swordSweep = cls.Where(x => x.SkillId == 37631).ToList();
+                    foreach (CastLog c in swordSweep)
+                    {
+                        int start = (int)c.Time;
+                        int preCastTime = 1400;
+                        int initialHitDuration = 850;
+                        int sweepDuration = 1100;
+                        int width = 1400; int height = 80;
+                        Point3D facing = replay.Rotations.FirstOrDefault(x => x.Time >= start);
+                        int initialDirection = (int)(Math.Atan2(facing.Y, facing.X) * 180 / Math.PI);
+                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(200, 0, 255, 0.1)"));
+                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start + preCastTime, start + preCastTime + initialHitDuration), "rgba(150, 0, 180, 0.5)"));
+                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, 360, new Tuple<int, int>(start + preCastTime + initialHitDuration, start + preCastTime + initialHitDuration + sweepDuration), "rgba(150, 0, 180, 0.5)"));
+                    }
                     break;
                 default:
                     throw new InvalidOperationException("Unknown ID in ComputeAdditionalData");

--- a/LuckParser/Models/BossLogic/Deimos.cs
+++ b/LuckParser/Models/BossLogic/Deimos.cs
@@ -322,8 +322,9 @@ namespace LuckParser.Models
                 else
                 {
                     int tpEnd = (int)(c.Time - log.FightData.FightStart);
-                    replay.Actors.Add(new CircleActor(true, 0, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
-                    replay.Actors.Add(new CircleActor(true, tpEnd, 180, new Tuple<int, int>(tpStart, tpEnd), "rgba(0, 150, 0, 0.3)"));
+                    Tuple<int, int> lifespan = new Tuple<int, int>(tpStart, tpEnd);
+                    replay.Actors.Add(new CircleActor(true, 0, 180, lifespan, "rgba(0, 150, 0, 0.3)"));
+                    replay.Actors.Add(new CircleActor(true, tpEnd, 180, lifespan, "rgba(0, 150, 0, 0.3)"));
                 }
             }
         }

--- a/LuckParser/Models/BossLogic/Dhuum.cs
+++ b/LuckParser/Models/BossLogic/Dhuum.cs
@@ -264,6 +264,44 @@ namespace LuckParser.Models
                     replay.Actors.Add(new CircleActor(true, bombDhuumStart + 13000, 100, new Tuple<int, int>(bombDhuumStart, bombDhuumEnd), "rgba(80, 180, 0, 0.5)"));
                 }
             }
+            // shackles connection
+            List<CombatItem> shackles = GetFilteredList(log, 47335, p.InstID).Concat(GetFilteredList(log, 48591, p.InstID)).ToList();
+            int shacklesStart = 0;
+            Player shacklesTarget = null;
+            foreach (CombatItem c in shackles)
+            {
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
+                {
+                    shacklesStart = (int)(c.Time - log.FightData.FightStart);
+                    shacklesTarget = log.PlayerList.FirstOrDefault(x => x.Agent == c.SrcAgent);
+                }
+                else
+                {
+                    int shacklesEnd = (int)(c.Time - log.FightData.FightStart);
+                    Tuple<int, int> duration = new Tuple<int, int>(shacklesStart, shacklesEnd);
+                    replay.Actors.Add(new LineActor(0, 10, shacklesTarget, duration, "rgba(0, 255, 255, 0.5)"));
+                }
+            }
+            // shackles damage (identical to the connection for now, not yet properly distinguishable from the pure connection, further investigation needed due to inconsistent behavior (triggering too early, not triggering the damaging skill though)
+            // shackles start with buff 47335 applied from one player to the other, this is switched over to buff 48591 after mostly 2 seconds, sometimes later. This is switched to 48042 usually 4 seconds after initial application and the damaging skill 47164 starts to deal damage from that point on.
+            // Before that point, 47164 is only logged when evaded/blocked, but doesn't deal damage. Further investigation needed.
+            List<CombatItem> shacklesDmg = GetFilteredList(log, 48042, p.InstID);
+            int shacklesDmgStart = 0;
+            Player shacklesDmgTarget = null;
+            foreach (CombatItem c in shacklesDmg)
+            {
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
+                {
+                    shacklesDmgStart = (int)(c.Time - log.FightData.FightStart);
+                    shacklesDmgTarget = log.PlayerList.FirstOrDefault(x => x.Agent == c.SrcAgent);
+                }
+                else
+                {
+                    int shacklesDmgEnd = (int)(c.Time - log.FightData.FightStart);
+                    Tuple<int, int> duration = new Tuple<int, int>(shacklesDmgStart, shacklesDmgEnd);
+                    replay.Actors.Add(new LineActor(0, 10, shacklesDmgTarget, duration, "rgba(0, 255, 255, 0.5)"));
+                }
+            }
         }
 
         public override int IsCM(ParsedLog log)

--- a/LuckParser/Models/BossLogic/Dhuum.cs
+++ b/LuckParser/Models/BossLogic/Dhuum.cs
@@ -279,7 +279,10 @@ namespace LuckParser.Models
                 {
                     int shacklesEnd = (int)(c.Time - log.FightData.FightStart);
                     Tuple<int, int> duration = new Tuple<int, int>(shacklesStart, shacklesEnd);
-                    replay.Actors.Add(new LineActor(0, 10, shacklesTarget, duration, "rgba(0, 255, 255, 0.5)"));
+                    if (shacklesTarget != null)
+                    {
+                        replay.Actors.Add(new LineActor(0, 10, shacklesTarget, duration, "rgba(0, 255, 255, 0.5)"));
+                    }
                 }
             }
             // shackles damage (identical to the connection for now, not yet properly distinguishable from the pure connection, further investigation needed due to inconsistent behavior (triggering too early, not triggering the damaging skill though)

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -310,7 +310,10 @@ namespace LuckParser.Models
                 {
                     int fixationStatueEnd = (int)(c.Time - log.FightData.FightStart);
                     Tuple<int, int> duration = new Tuple<int, int>(fixationStatueStart, fixationStatueEnd);
-                    replay.Actors.Add(new LineActor(0, 10, statue, duration, "rgba(255, 0, 255, 0.5)"));
+                    if (statue != null)
+                    {
+                        replay.Actors.Add(new LineActor(0, 10, statue, duration, "rgba(255, 0, 255, 0.5)"));
+                    }
                 }
             }
         }

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -160,7 +160,7 @@ namespace LuckParser.Models
                     break;
                 case (ushort)GreenPhantasm:
                     int lifetime = 8000;
-                    replay.Actors.Add(new CircleActor(false, start + lifetime, 0, new Tuple<int, int>(start, start + lifetime), "rgba(0,255,0,0.5)"));
+                    replay.Actors.Add(new CircleActor(true, 0, 210, new Tuple<int, int>(start, start + lifetime), "rgba(0,255,0,0.2)"));
                     replay.Actors.Add(new CircleActor(true, start + lifetime, 210, new Tuple<int, int>(start, start + lifetime), "rgba(0,255,0,0.3)"));
                     break;
                 case (ushort)RetrieverProjection:
@@ -294,6 +294,27 @@ namespace LuckParser.Models
                     replay.Actors.Add(new CircleActor(true, xeraFuryEnd, 550, new Tuple<int, int>(xeraFuryStart, xeraFuryEnd), "rgba(200, 150, 0, 0.4)"));
                 }
 
+            }
+            //fixated Statue
+            List<CombatItem> fixatedStatue = GetFilteredList(log, 34912, p.InstID).Concat(GetFilteredList(log, 34925, p.InstID)).ToList();
+            int fixationStatueStart = 0;
+            Mob statue = null;
+            foreach (CombatItem c in fixatedStatue)
+            {
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
+                {
+                    fixationStatueStart = (int)(c.Time - log.FightData.FightStart);
+                    statue = TrashMobs.FirstOrDefault(x => x.Agent == c.SrcAgent);
+                    
+                    //statue = Targets.FirstOrDefault(x => x.ID == (ushort)ParseEnum.TrashIDS.Rigom && c.Time >= x.FirstAware && c.Time <= x.LastAware);
+                }
+                else
+                {
+                    int fixationStatueEnd = (int)(c.Time - log.FightData.FightStart);
+                    Tuple<int, int> duration = new Tuple<int, int>(fixationStatueStart, fixationStatueEnd);
+                    //replay.Actors.Add(new CircleActor(true, 0, 200, duration, "rgba(255, 80, 255, 0.3)"));
+                    replay.Actors.Add(new LineActor(0, 10, statue, duration, "rgba(255, 0, 255, 0.5)"));
+                }
             }
         }
     }

--- a/LuckParser/Models/BossLogic/KeepConstruct.cs
+++ b/LuckParser/Models/BossLogic/KeepConstruct.cs
@@ -305,14 +305,11 @@ namespace LuckParser.Models
                 {
                     fixationStatueStart = (int)(c.Time - log.FightData.FightStart);
                     statue = TrashMobs.FirstOrDefault(x => x.Agent == c.SrcAgent);
-                    
-                    //statue = Targets.FirstOrDefault(x => x.ID == (ushort)ParseEnum.TrashIDS.Rigom && c.Time >= x.FirstAware && c.Time <= x.LastAware);
                 }
                 else
                 {
                     int fixationStatueEnd = (int)(c.Time - log.FightData.FightStart);
                     Tuple<int, int> duration = new Tuple<int, int>(fixationStatueStart, fixationStatueEnd);
-                    //replay.Actors.Add(new CircleActor(true, 0, 200, duration, "rgba(255, 80, 255, 0.3)"));
                     replay.Actors.Add(new LineActor(0, 10, statue, duration, "rgba(255, 0, 255, 0.5)"));
                 }
             }

--- a/LuckParser/Models/BossLogic/Matthias.cs
+++ b/LuckParser/Models/BossLogic/Matthias.cs
@@ -201,8 +201,11 @@ namespace LuckParser.Models
                         int width = 4000; int height = 130;
                         Point3D facing = replay.Rotations.LastOrDefault(x => x.Time <= start+1000);
                         int direction = (int)(Math.Atan2(facing.Y, facing.X) * 180 / Math.PI);
-                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, direction, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(255, 0, 0, 0.1)"));
-                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, direction, width / 2, new Tuple<int, int>(start + preCastTime, start + preCastTime + duration), "rgba(255, 0, 0, 0.7)"));
+                        if (facing != null)
+                        {
+                            replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, direction, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(255, 0, 0, 0.1)"));
+                            replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, direction, width / 2, new Tuple<int, int>(start + preCastTime, start + preCastTime + duration), "rgba(255, 0, 0, 0.7)"));
+                        }
                     }
                         break;
                 default:

--- a/LuckParser/Models/BossLogic/Matthias.cs
+++ b/LuckParser/Models/BossLogic/Matthias.cs
@@ -192,7 +192,19 @@ namespace LuckParser.Models
                         replay.Actors.Add(new CircleActor(false, 0, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
                         replay.Actors.Add(new CircleActor(true, end, 300, new Tuple<int, int>(start, end), "rgba(255, 0, 0, 0.5)"));
                     }
-                    break;
+                    List<CastLog> hadouken = cls.Where(x => x.SkillId == 34371 || x.SkillId == 34380).ToList();
+                    foreach (CastLog c in hadouken)
+                    {
+                        int start = (int)c.Time;
+                        int preCastTime = 1000;
+                        int duration = 750;
+                        int width = 4000; int height = 130;
+                        Point3D facing = replay.Rotations.LastOrDefault(x => x.Time <= start+1000);
+                        int direction = (int)(Math.Atan2(facing.Y, facing.X) * 180 / Math.PI);
+                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, direction, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(255, 0, 0, 0.1)"));
+                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, direction, width / 2, new Tuple<int, int>(start + preCastTime, start + preCastTime + duration), "rgba(255, 0, 0, 0.7)"));
+                    }
+                        break;
                 default:
                     throw new InvalidOperationException("Unknown ID in ComputeAdditionalData");
             }

--- a/LuckParser/Models/BossLogic/Sabetha.cs
+++ b/LuckParser/Models/BossLogic/Sabetha.cs
@@ -158,8 +158,11 @@ namespace LuckParser.Models
                         int width = 1300; int height = 60;
                         Point3D facing = replay.Rotations.LastOrDefault(x => x.Time <= start);
                         int initialDirection = (int)(Math.Atan2(facing.Y, facing.X) * 180 / Math.PI);
-                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(255, 100, 0, 0.2)"));
-                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, 360, new Tuple<int, int>(start + preCastTime, start + preCastTime + duration), "rgba(255, 50, 0, 0.5)"));
+                        if (facing != null)
+                        {
+                            replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(255, 100, 0, 0.2)"));
+                            replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, 360, new Tuple<int, int>(start + preCastTime, start + preCastTime + duration), "rgba(255, 50, 0, 0.5)"));
+                        }
                     }
                     break;
                 case (ushort)Kernan:

--- a/LuckParser/Models/BossLogic/Sabetha.cs
+++ b/LuckParser/Models/BossLogic/Sabetha.cs
@@ -144,9 +144,24 @@ namespace LuckParser.Models
 
         public override void ComputeAdditionalBossData(Boss boss, ParsedLog log)
         {
+            CombatReplay replay = boss.CombatReplay;
+            List<CastLog> cls = boss.GetCastLogs(log, 0, log.FightData.FightDuration);
             switch (boss.ID)
             {
                 case (ushort)ParseEnum.BossIDS.Sabetha:
+                    List<CastLog> flameWall = cls.Where(x => x.SkillId == 31332).ToList();
+                    foreach (CastLog c in flameWall)
+                    {
+                        int start = (int)c.Time;
+                        int preCastTime = 2800;
+                        int duration = 10000;
+                        int width = 1300; int height = 60;
+                        Point3D facing = replay.Rotations.LastOrDefault(x => x.Time <= start);
+                        int initialDirection = (int)(Math.Atan2(facing.Y, facing.X) * 180 / Math.PI);
+                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, new Tuple<int, int>(start, start + preCastTime), "rgba(255, 100, 0, 0.2)"));
+                        replay.Actors.Add(new RotatedRectangleActor(true, 0, width, height, initialDirection, width / 2, 360, new Tuple<int, int>(start + preCastTime, start + preCastTime + duration), "rgba(255, 50, 0, 0.5)"));
+                    }
+                    break;
                 case (ushort)Kernan:
                 case (ushort)Knuckles:
                 case (ushort)Karde:

--- a/LuckParser/Models/BossLogic/Samarog.cs
+++ b/LuckParser/Models/BossLogic/Samarog.cs
@@ -19,7 +19,7 @@ namespace LuckParser.Models
             new Mechanic(37797, "Trampling Rush", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Samarog, "symbol:'triangle-right',color:'rgb(255,0,0)'", "Trmpl","Trampling Rush (hit by stampede towards home)", "Trampling Rush",0),
             new Mechanic(38305, "Bludgeon", Mechanic.MechType.SkillOnPlayer, ParseEnum.BossIDS.Samarog, "symbol:'triangle-down',color:'rgb(0,0,255)'", "Slm","Bludgeon (vertical Slam)", "Slam",0),
             new Mechanic(37868, "Fixate: Samarog", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Samarog, "symbol:'star',color:'rgb(255,0,255)'", "S.Fix","Fixated by Samarog", "Fixate: Samarog",0),
-            new Mechanic(38223, "Fixate: Guldhem", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Samarog, "symbol:'star-open',color:'rgb(255,200,0)'", "G.Fix","Fixated by Guldhem", "Fixate: Guldhem",0),
+            new Mechanic(38223, "Fixate: Guldhem", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Samarog, "symbol:'star-open',color:'rgb(255,100,0)'", "G.Fix","Fixated by Guldhem", "Fixate: Guldhem",0),
             new Mechanic(37693, "Fixate: Rigom", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Samarog, "symbol:'star-open',color:'rgb(255,0,0)'", "R.Fix","Fixated by Rigom", "Fixate: Rigom",0),
             new Mechanic(37966, "Big Hug", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Samarog, "symbol:'circle',color:'rgb(0,128,0)'", "BgGrn","Big Green (friends mechanic)", "Big Green",0), 
             new Mechanic(38247, "Small Hug", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.Samarog, "symbol:'circle-open',color:'rgb(0,128,0)'", "SmGrn","Small Green (friends mechanic)", "Small Green",0),
@@ -187,12 +187,48 @@ namespace LuckParser.Models
             {
                 if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
                 {
-                    fixatedSamStart = (int)(c.Time - log.FightData.FightStart);
+                    fixatedSamStart = Math.Max((int)(c.Time - log.FightData.FightStart), 0);
                 }
                 else
                 {
                     int fixatedSamEnd = (int)(c.Time - log.FightData.FightStart);
                     replay.Actors.Add(new CircleActor(true, 0, 80, new Tuple<int, int>(fixatedSamStart, fixatedSamEnd), "rgba(255, 80, 255, 0.3)"));
+                }
+            }
+            //fixated Ghuldem
+            List<CombatItem> fixatedGuldhem = GetFilteredList(log, 38223, p.InstID);
+            int fixationGuldhemStart = 0;
+            Boss guldhem = null;
+            foreach (CombatItem c in fixatedGuldhem)
+            {
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
+                {
+                    fixationGuldhemStart = (int)(c.Time - log.FightData.FightStart);
+                    guldhem = Targets.FirstOrDefault(x => x.ID == (ushort)ParseEnum.TrashIDS.Guldhem && c.Time >= x.FirstAware && c.Time <= x.LastAware);
+                }
+                else
+                {
+                    int fixationGuldhemEnd = (int)(c.Time - log.FightData.FightStart);
+                    Tuple<int, int> duration = new Tuple<int, int>(fixationGuldhemStart, fixationGuldhemEnd);
+                    replay.Actors.Add(new LineActor(0, 10, guldhem, duration, "rgba(255, 100, 0, 0.3)"));
+                }
+            }
+            //fixated Rigom
+            List<CombatItem> fixatedRigom = GetFilteredList(log, 37693, p.InstID);
+            int fixationRigomStart = 0;
+            Boss rigom = null;
+            foreach (CombatItem c in fixatedRigom)
+            {
+                if (c.IsBuffRemove == ParseEnum.BuffRemove.None)
+                {
+                    fixationRigomStart = (int)(c.Time - log.FightData.FightStart);
+                    rigom = Targets.FirstOrDefault(x => x.ID == (ushort)ParseEnum.TrashIDS.Rigom && c.Time >= x.FirstAware && c.Time <= x.LastAware);
+                }
+                else
+                {
+                    int fixationRigomEnd = (int)(c.Time - log.FightData.FightStart);
+                    Tuple<int, int> duration = new Tuple<int, int>(fixationRigomStart, fixationRigomEnd);
+                    replay.Actors.Add(new LineActor(0, 10, rigom, duration, "rgba(255, 0, 0, 0.3)"));
                 }
             }
         }

--- a/LuckParser/Models/BossLogic/Samarog.cs
+++ b/LuckParser/Models/BossLogic/Samarog.cs
@@ -210,7 +210,10 @@ namespace LuckParser.Models
                 {
                     int fixationGuldhemEnd = (int)(c.Time - log.FightData.FightStart);
                     Tuple<int, int> duration = new Tuple<int, int>(fixationGuldhemStart, fixationGuldhemEnd);
-                    replay.Actors.Add(new LineActor(0, 10, guldhem, duration, "rgba(255, 100, 0, 0.3)"));
+                    if (guldhem != null)
+                    {
+                        replay.Actors.Add(new LineActor(0, 10, guldhem, duration, "rgba(255, 100, 0, 0.3)"));
+                    }
                 }
             }
             //fixated Rigom
@@ -228,7 +231,10 @@ namespace LuckParser.Models
                 {
                     int fixationRigomEnd = (int)(c.Time - log.FightData.FightStart);
                     Tuple<int, int> duration = new Tuple<int, int>(fixationRigomStart, fixationRigomEnd);
-                    replay.Actors.Add(new LineActor(0, 10, rigom, duration, "rgba(255, 0, 0, 0.3)"));
+                    if (rigom != null)
+                    {
+                        replay.Actors.Add(new LineActor(0, 10, rigom, duration, "rgba(255, 0, 0, 0.3)"));
+                    }
                 }
             }
         }

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/LineActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/LineActor.cs
@@ -8,43 +8,23 @@ namespace LuckParser.Models.ParseModels
         public Object Target { get; }
         public int Width { get; }
 
-        // using startpoint and endpoint
-        public LineActor(int growing, int width, Point3D endPoint, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
+        public LineActor(int growing, int width, Object targetAgent, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
         {
-            Target = endPoint;
+            Target = targetAgent;
             Width = width;
         }
 
-        public LineActor(int growing, int width, Point3D endPoint, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
+        public LineActor(int growing, int width, Object targetAgent, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
         {
-            Target = endPoint;
+            Target = targetAgent;
             Width = width;
         }
 
-        public LineActor(int growing, int width, Point3D endPoint, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
+        public LineActor(int growing, int width, Object targetAgent, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
         {
-            Target = endPoint;
+            Target = targetAgent;
             Width = width;
         }
-
-        public LineActor(int growing, int width, int targetID, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
-        {
-            Target = targetID;
-            Width = width;
-        }
-
-        public LineActor(int growing, int width, int targetID, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
-        {
-            Target = targetID;
-            Width = width;
-        }
-
-        public LineActor(int growing, int width, int targetID, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
-        {
-            Target = targetID;
-            Width = width;
-        }
-        //
 
         private class LineSerializable : Serializable
         {
@@ -74,9 +54,24 @@ namespace LuckParser.Models.ParseModels
                         mapPos.Item2
                 };
             }
-            else
+            else if (Target is int)
             {
                 aux.Target = (int)Target;
+            }
+            else if (Target is AbstractMasterPlayer)
+            {
+                if (((AbstractMasterPlayer)Target).CombatReplay != null)
+                {
+                    aux.Target = Target.GetType().GetMethod("GetCombatReplayID").Invoke(Target, null);
+                }
+                else
+                {
+                    aux.Target = master.GetCombatReplayID(); // Line Actor with zero length: same origin and destination
+                }
+            }
+            else
+            {
+                throw new InvalidOperationException("Target object is neihter a 3DPoint, nor AbstractMasterPlayer (or one of its children) nor an agent ID");
             }
             if (Position != null)
             {

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/LineActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/LineActor.cs
@@ -1,0 +1,136 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace LuckParser.Models.ParseModels
+{
+    public class LineActor : Actor
+    {
+        public Object Target { get; }
+        public int Width { get; }
+
+        // using startpoint and endpoint
+        public LineActor(int growing, int width, Point3D endPoint, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
+        {
+            Target = endPoint;
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, Point3D endPoint, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
+        {
+            Target = endPoint;
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, Point3D endPoint, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
+        {
+            Target = endPoint;
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, int targetID, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
+        {
+            Target = targetID;
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, int targetID, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
+        {
+            Target = targetID;
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, int targetID, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
+        {
+            Target = targetID;
+            Width = width;
+        }
+
+        // using startpoint, direction as arcs rotation argument and length
+        public LineActor(int growing, int width, Point3D startPoint, Point3D rotation, int length, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
+        {
+            Target = new Point3D(startPoint.X + rotation.X * length, startPoint.Y + rotation.Y * length, startPoint.Z, startPoint.Time);
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, Point3D rotation, int length, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
+        {
+            Target = new Point3D(position.X + rotation.X * length, position.Y + rotation.Y * length, position.Z, position.Time);
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, Point3D startPoint, Point3D rotation, int length, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
+        {
+            Target = new Point3D(startPoint.X + rotation.X * length, startPoint.Y + rotation.Y * length, startPoint.Z, startPoint.Time);
+            Width = width;
+        }
+
+        // using startpoint, direction as angle value (in degrees) and length
+        public LineActor(int growing, int width, Point3D startPoint, int direction, int length, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
+        {
+            Target = new Point3D(startPoint.X + (int)Math.Cos(direction / 180 * Math.PI) * length, startPoint.Y + (int)Math.Sin(direction / 180 * Math.PI) * length, startPoint.Z, startPoint.Time);
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, int direction, int length, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
+        {
+            Target = new Point3D(position.X + (int)Math.Cos(direction / 180 * Math.PI) * length, position.Y + (int)Math.Sin(direction / 180 * Math.PI) * length, position.Z, position.Time);
+            Width = width;
+        }
+
+        public LineActor(int growing, int width, Point3D startPoint, int direction, int length, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
+        {
+            Target = new Point3D(startPoint.X + (int)Math.Cos(direction / 180 * Math.PI) * length, startPoint.Y + (int)Math.Sin(direction / 180 * Math.PI) * length, startPoint.Z, startPoint.Time);
+            Width = width;
+        }
+
+        //
+        private class LineSerializable : Serializable
+        {
+            public Object Target { get; set; }
+            public int Width { get; set; }
+        }
+
+        public override string GetCombatReplayJSON(CombatReplayMap map, AbstractMasterPlayer master)
+        {
+            LineSerializable aux = new LineSerializable
+            {
+                Type = "Line",
+                Width = Width,
+                Fill = Filled,
+                Color = Color,
+                Growing = Growing,
+                Start = Lifespan.Item1,
+                End = Lifespan.Item2
+            };
+            if (Target is Point3D)
+            {
+                Point3D TargetPoint = (Point3D)Target;
+                Tuple<int, int> mapPos = map.GetMapCoord(TargetPoint.X, TargetPoint.Y);
+                aux.Target = new int[2]
+                {
+                        mapPos.Item1,
+                        mapPos.Item2
+                };
+            }
+            else
+            {
+                aux.Target = (int)Target;
+            }
+            if (Position != null)
+            {
+                Tuple<int, int> mapPos = map.GetMapCoord(Position.X, Position.Y);
+                aux.ConnectedTo = new int[2]
+                {
+                        mapPos.Item1,
+                        mapPos.Item2
+                };
+                return JsonConvert.SerializeObject(aux);
+            }
+            else
+            {
+                aux.ConnectedTo = master.GetCombatReplayID();
+                return JsonConvert.SerializeObject(aux);
+            }
+        }
+    }
+}

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/LineActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/LineActor.cs
@@ -44,46 +44,8 @@ namespace LuckParser.Models.ParseModels
             Target = targetID;
             Width = width;
         }
-
-        // using startpoint, direction as arcs rotation argument and length
-        public LineActor(int growing, int width, Point3D startPoint, Point3D rotation, int length, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
-        {
-            Target = new Point3D(startPoint.X + rotation.X * length, startPoint.Y + rotation.Y * length, startPoint.Z, startPoint.Time);
-            Width = width;
-        }
-
-        public LineActor(int growing, int width, Point3D rotation, int length, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
-        {
-            Target = new Point3D(position.X + rotation.X * length, position.Y + rotation.Y * length, position.Z, position.Time);
-            Width = width;
-        }
-
-        public LineActor(int growing, int width, Point3D startPoint, Point3D rotation, int length, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
-        {
-            Target = new Point3D(startPoint.X + rotation.X * length, startPoint.Y + rotation.Y * length, startPoint.Z, startPoint.Time);
-            Width = width;
-        }
-
-        // using startpoint, direction as angle value (in degrees) and length
-        public LineActor(int growing, int width, Point3D startPoint, int direction, int length, Tuple<int, int> lifespan, string color) : base(false, growing, lifespan, color)
-        {
-            Target = new Point3D(startPoint.X + (int)Math.Cos(direction / 180 * Math.PI) * length, startPoint.Y + (int)Math.Sin(direction / 180 * Math.PI) * length, startPoint.Z, startPoint.Time);
-            Width = width;
-        }
-
-        public LineActor(int growing, int width, int direction, int length, Tuple<int, int> lifespan, string color, Point3D position) : base(false, growing, lifespan, color, position)
-        {
-            Target = new Point3D(position.X + (int)Math.Cos(direction / 180 * Math.PI) * length, position.Y + (int)Math.Sin(direction / 180 * Math.PI) * length, position.Z, position.Time);
-            Width = width;
-        }
-
-        public LineActor(int growing, int width, Point3D startPoint, int direction, int length, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(false, growing, lifespan, color, prev, next, time)
-        {
-            Target = new Point3D(startPoint.X + (int)Math.Cos(direction / 180 * Math.PI) * length, startPoint.Y + (int)Math.Sin(direction / 180 * Math.PI) * length, startPoint.Z, startPoint.Time);
-            Width = width;
-        }
-
         //
+
         private class LineSerializable : Serializable
         {
             public Object Target { get; set; }

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/RectangleActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/RectangleActor.cs
@@ -28,7 +28,7 @@ namespace LuckParser.Models.ParseModels
         //
 
 
-        private class RectangleSerializable : Serializable
+        protected class RectangleSerializable : Serializable
         {
             public int Height { get; set; }
             public int Width { get; set; }

--- a/LuckParser/Models/ParseModels/CombatReplay/Actors/RotatedRectangleActor.cs
+++ b/LuckParser/Models/ParseModels/CombatReplay/Actors/RotatedRectangleActor.cs
@@ -1,0 +1,94 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace LuckParser.Models.ParseModels
+{
+    public class RotatedRectangleActor : RectangleActor
+    {
+        public int Rotation { get; } // initial rotation angle
+        public int RadialTranslation { get; } // translation of the triangle center in the direction of the current rotation
+        public int SpinAngle { get; } // rotation the rectangle is supposed to go through over the course of its lifespan, 0 for no rotation
+
+        // Rectangles with fixed rotation and no translation
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, Tuple<int, int> lifespan, string color)
+            : this(fill, growing, width, height, rotation, 0, 0, lifespan, color) { }
+
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, Tuple<int, int> lifespan, string color, Point3D position)
+            : this(fill, growing, width, height, rotation, 0, 0, lifespan, color, position) { }
+
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time)
+            : this(fill, growing, width, height, rotation, 0, 0, lifespan, color, prev, next, time) { }
+
+        // Rectangles with a fixed rotation and translation
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, int translation, Tuple<int, int> lifespan, string color) 
+            : this(fill, growing, width, height, rotation, translation, 0, lifespan, color) { }
+
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, int translation, Tuple<int, int> lifespan, string color, Point3D position) 
+            : this(fill, growing, width, height, rotation, translation, 0, lifespan, color, position) { }
+
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, int translation, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) 
+            : this(fill, growing, width, height, rotation, translation, 0, lifespan, color, prev, next, time) { }
+
+        // Rectangles rotating over time
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, int translation, int spinAngle, Tuple<int, int> lifespan, string color) : base(fill, growing, width, height, lifespan, color)
+        {
+            Rotation = rotation;
+            RadialTranslation = translation;
+            SpinAngle = spinAngle;
+        }
+
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, int translation, int spinAngle, Tuple<int, int> lifespan, string color, Point3D position) : base(fill, growing, width, height, lifespan, color, position)
+        {
+            Rotation = rotation;
+            RadialTranslation = translation;
+            SpinAngle = spinAngle;
+        }
+
+        public RotatedRectangleActor(bool fill, int growing, int width, int height, int rotation, int translation, int spinAngle, Tuple<int, int> lifespan, string color, Point3D prev, Point3D next, int time) : base(fill, growing, width, height, lifespan, color, prev, next, time)
+        {
+            Rotation = rotation;
+            RadialTranslation = translation;
+            SpinAngle = spinAngle;
+        }
+
+        private class RotatedRectangleSerializable : RectangleSerializable
+        {
+            public int Rotation { get; set; }
+            public int RadialTranslation { get; set; }
+            public int SpinAngle { get; set; }
+        }
+
+        public override string GetCombatReplayJSON(CombatReplayMap map, AbstractMasterPlayer master)
+        {
+            RotatedRectangleSerializable aux = new RotatedRectangleSerializable
+            {
+                Type = "RotatedRectangle",
+                Width = Width,
+                Height = Height,
+                Rotation = Rotation,
+                RadialTranslation = RadialTranslation,
+                SpinAngle = SpinAngle,
+                Fill = Filled,
+                Color = Color,
+                Growing = Growing,
+                Start = Lifespan.Item1,
+                End = Lifespan.Item2
+            };
+            if (Position != null)
+            {
+                Tuple<int, int> mapPos = map.GetMapCoord(Position.X, Position.Y);
+                aux.ConnectedTo = new int[2]
+                {
+                        mapPos.Item1,
+                        mapPos.Item2
+                };
+                return JsonConvert.SerializeObject(aux);
+            }
+            else
+            {
+                aux.ConnectedTo = master.GetCombatReplayID();
+                return JsonConvert.SerializeObject(aux);
+            }
+        }
+    }
+}

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -150,6 +150,14 @@ namespace LuckParser.Models.ParseModels
                         CombatReplay.Trim(AgentItem.FirstAware - log.FightData.FightStart, AgentItem.LastAware - log.FightData.FightStart);
                     }
                 }
+                //SetAdditionalCombatReplayData(log);
+            }
+        }
+
+        public void ComputeAdditionalCombatReplayData(ParsedLog log)
+        {
+            if (CombatReplay != null && CombatReplay.Actors.Count == 0)
+            {
                 SetAdditionalCombatReplayData(log);
             }
         }

--- a/LuckParser/Resources/combatreplay.js
+++ b/LuckParser/Resources/combatreplay.js
@@ -487,6 +487,50 @@ class PieMechanicDrawable extends MechanicDrawable {
     }
 }
 
+class LineMechanicDrawable extends MechanicDrawable {
+    constructor(start, end, fill, growing, color, width, target, connectedTo) {
+        super(start, end, fill, growing, color, connectedTo);
+        this.target = target;
+        this.width = width*inch;
+        this.endmaster = null
+    }
+
+    getTargetPosition(currentTime) {
+        if (this.target === null) {
+            return null;
+        }
+        if (this.start !== -1 && (this.start >= currentTime || this.end <= currentTime)) {
+            return null;
+        }
+        if (this.target instanceof Array) {
+            return {
+                x: this.target[0],
+                y: this.target[1]
+            };
+        } else {
+            if (this.endmaster === null) {
+                let endMasterID = this.target;
+                this.endmaster = playerData.has(endMasterID) ? playerData.get(endMasterID) : trashMobData.has(endMasterID) ? trashMobData.get(endMasterID) : bossData.get(endMasterID);
+            }
+            return this.endmaster.getPosition(currentTime);
+        }
+    }
+
+    draw(ctx, currentTime) {
+        const pos = this.getPosition(currentTime);
+        if (pos === null || endpos === null) {
+            return;
+        }
+        const percent = this.getPercent(currentTime);
+        ctx.beginPath();
+        ctx.moveTo(pos.x, pos.y);
+        ctx.lineTo(pos.x + percent * (target.x - pos.x), percent * (target.y - pos.y));
+        ctx.lineWidth = width;
+        ctx.strokeStyle = this.color;
+        ctx.stroke();
+    }
+}
+
 let actors = ['${actors}'];
 
 function createAllActors() {
@@ -518,6 +562,9 @@ function createAllActors() {
                 break;
             case "Pie":
                 mechanicActorData.add(new PieMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Direction, actor.OpeningAngle, actor.Radius, actor.ConnectedTo));
+                break;
+            case "Line":
+                mechanicActorData.add(new LineMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Width, actor.Target, actor.ConnectedTo));
                 break;
         }
     }

--- a/LuckParser/Resources/combatreplay.js
+++ b/LuckParser/Resources/combatreplay.js
@@ -518,14 +518,16 @@ class LineMechanicDrawable extends MechanicDrawable {
 
     draw(ctx, currentTime) {
         const pos = this.getPosition(currentTime);
-        if (pos === null || endpos === null) {
+        const target = this.getTargetPosition(currentTime);
+
+        if (pos === null || target === null) {
             return;
         }
         const percent = this.getPercent(currentTime);
         ctx.beginPath();
         ctx.moveTo(pos.x, pos.y);
-        ctx.lineTo(pos.x + percent * (target.x - pos.x), percent * (target.y - pos.y));
-        ctx.lineWidth = width;
+        ctx.lineTo(pos.x + percent * (target.x - pos.x), pos.y + percent * (target.y - pos.y));
+        ctx.lineWidth = this.width;
         ctx.strokeStyle = this.color;
         ctx.stroke();
     }


### PR DESCRIPTION
- Added LineActor class that creates a simple line between two points, usage:
  - specify `width` in ingame units
  - specify `target` either as `Point3D` coordinates or as `int` agentID or as `AbstractMasterPlayer` (or one of its children) target agent
- Added RotatedRectangleActor class that creates a rectangle non-parallel to the coordinate system axes, with optional rotation over time, usage:
  - specify `width` and `height` as for a normal RectangleActor
  - specify `rotation` in degrees in mathematically positive direction
  - (optionally) specify `translation` (in ingame units) of the rectangle's center point in the direction of `rotation`, this argument is mandatory if you also specify `spinAngle`
  - (optionally) specify `spinAngle` in degrees, this is the amount of degrees the rectangle is supposed to be turning over its whole lifespan, negative values and values > 360 are also accepted
- Added Sabetha Firestorm (Flamewall) to CombatReplay
- Added Cairn Orbital Sweep (Sword/Arm Spin) to CombatReplay
- Added Matthias Oppressive Gaze (Hadouken) to CombatReplay
- Added Guldhem/Rigom fixations to CombatReplay
- Added named Phantasms fixations on Keep Construct to CombatReplay
- Added Dhuum Soul Shackle to CombatReplay
- Slightly altered CombatReplay initialization order to ensure all agents are available when additional data is generated and interaction between agents is checked for the combat replay
- minor polishing/cleanup