### PR TITLE
Separate static and dynamic combat replay script

### DIFF
--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using LuckParser.Models.DataModels;
+using Newtonsoft.Json;
 
 namespace LuckParser.Controllers
 {
@@ -749,69 +750,74 @@ namespace LuckParser.Controllers
         public static void WriteCombatReplayScript(StreamWriter sw, ParsedLog log, Tuple<int,int> canvasSize, CombatReplayMap map, int pollingRate)
         {
             sw.WriteLine("<script>");
+            sw.WriteLine(Properties.Resources.combatreplay_js);
+            sw.WriteLine("</script>");
+
+            Dictionary<string, object> options = new Dictionary<string, object>
             {
-                string replayScript = Properties.Resources.combatreplay_js;
-                replayScript = replayScript.Replace("'${inch}'", map.GetInch().ToString());
-                replayScript = replayScript.Replace("'${pollingRate}'", pollingRate.ToString());
-                replayScript = replayScript.Replace("'${mapLink}'", map.Link);
-                string actors = "";
-                CombatReplay replay;
-                int count = 0;
-                foreach (Player p in log.PlayerList)
+                { "inch", map.GetInch() },
+                { "pollingRate", pollingRate },
+                { "mapLink", map.Link }
+            };
+
+            string actors = "";
+            int count = 0;
+            foreach (Player p in log.PlayerList)
+            {
+                if (p.Group == 11)
                 {
-                    if (p.Group == 11)
-                    {
-                        continue;
-                    }
-                    if (p.CombatReplay.Positions.Count == 0)
-                    {
-                        continue;
-                    }
-                    if (count > 0)
-                    {
-                        actors += ",";
-                    }
-                    count++;
-                    actors += p.GetCombatReplayJSON(map);
-                    replay = p.CombatReplay;
-                    foreach (Actor a in replay.Actors)
-                    {
-                        actors += ",";
-                        actors += a.GetCombatReplayJSON(map);
-                    }
+                    continue;
                 }
-                foreach (Mob m in log.FightData.Logic.TrashMobs)
+                if (p.CombatReplay.Positions.Count == 0)
                 {
-                    if (m.CombatReplay.Positions.Count == 0)
-                    {
-                        continue;
-                    }
+                    continue;
+                }
+                if (count > 0)
+                {
                     actors += ",";
-                    actors += m.GetCombatReplayJSON(map);
-                    replay = m.CombatReplay;
-                    foreach (Actor a in replay.Actors)
-                    {
-                        actors += ",";
-                        actors += a.GetCombatReplayJSON(map);
-                    }
                 }
-                foreach (Boss target in log.FightData.Logic.Targets)
+                count++;
+                actors += p.GetCombatReplayJSON(map);
+                foreach (Actor a in p.CombatReplay.Actors)
                 {
-                    if (target.CombatReplay.Positions.Count == 0)
-                    {
-                        continue;
-                    }
                     actors += ",";
-                    actors += target.GetCombatReplayJSON(map);
-                    replay = target.CombatReplay;
-                    foreach (Actor a in replay.Actors)
-                    {
-                        actors += ",";
-                        actors += a.GetCombatReplayJSON(map);
-                    }
+                    actors += a.GetCombatReplayJSON(map);
                 }
-                replayScript = replayScript.Replace("'${actors}'", actors);
-                sw.Write(replayScript);
+            }
+            foreach (Mob m in log.FightData.Logic.TrashMobs)
+            {
+                if (m.CombatReplay.Positions.Count == 0)
+                {
+                    continue;
+                }
+                actors += ",";
+                actors += m.GetCombatReplayJSON(map);
+                foreach (Actor a in m.CombatReplay.Actors)
+                {
+                    actors += ",";
+                    actors += a.GetCombatReplayJSON(map);
+                }
+            }
+            foreach (Boss target in log.FightData.Logic.Targets)
+            {
+                if (target.CombatReplay.Positions.Count == 0)
+                {
+                    continue;
+                }
+                actors += ",";
+                actors += target.GetCombatReplayJSON(map);
+                foreach (Actor a in target.CombatReplay.Actors)
+                {
+                    actors += ",";
+                    actors += a.GetCombatReplayJSON(map);
+                }
+            }
+
+            sw.WriteLine("<script>");
+            {
+                sw.WriteLine("var options = " + JsonConvert.SerializeObject(options) + ";");
+                sw.WriteLine("var actors = [" + actors + "];");
+                sw.WriteLine("initCombatReplay(actors, options);");
             }
             sw.WriteLine("</script>");
         }

--- a/LuckParser/Resources/combatreplay.js
+++ b/LuckParser/Resources/combatreplay.js
@@ -3,8 +3,13 @@ const deadIcon = new Image();
 deadIcon.src = "https://wiki.guildwars2.com/images/4/4a/Ally_death_%28interface%29.png";
 const downIcon = new Image();
 downIcon.src = "https://wiki.guildwars2.com/images/c/c6/Downed_enemy.png";
+const bgImage = new Image();
+bgImage.onload = function () {
+    animateCanvas();
+    bgLoaded = true;
+};
 let time = 0;
-let inch = '${inch}';
+let inch = 10;
 let speed = 1;
 const times = [];
 const bossData = new Map();
@@ -14,19 +19,38 @@ const mechanicActorData = new Set();
 const rangeControl = new Map();
 let selectedGroup = -1;
 let selectedPlayer = null;
-const timeSlider = document.getElementById('timeRange');
-const timeSliderDisplay = document.getElementById('timeRangeDisplay');
-const canvas = document.getElementById('replayCanvas');
-const ctx = canvas.getContext('2d');
-const bgImage = new Image();
 let bgLoaded = false;
 let animation = null;
 let prevTime = 0;
-let pollingRate = '${pollingRate}';
+let pollingRate = 150;
+let timeSlider = null;
+let timeSliderDisplay = null;
+let canvas = null;
+let ctx = null;
 
-// canvas
-ctx.imageSmoothingEnabled = true;
-ctx.imageSmoothingQuality = 'high';
+
+function initCombatReplay(actors, options) {
+	time = 0;
+	if (options) {
+		if (options.inch) inch = options.inch;
+		if (options.pollingRate) pollingRate = options.pollingRate;
+		if (options.mapLink) bgImage.src = options.mapLink;
+	}
+	speed = 1;
+	timeSlider = document.getElementById('timeRange');
+	timeSliderDisplay = document.getElementById('timeRangeDisplay');
+	canvas = document.getElementById('replayCanvas');
+	ctx = canvas.getContext('2d');
+	bgLoaded = false;
+	animation = null;
+	prevTime = 0;
+
+	// canvas
+	ctx.imageSmoothingEnabled = true;
+	ctx.imageSmoothingQuality = 'high';
+
+	createAllActors(actors);
+}
 
 // Animation methods
 function animateCanvas(noRequest) {
@@ -65,10 +89,6 @@ function animateCanvas(noRequest) {
         animation = requestAnimationFrame(animateCanvas);
     }
 }
-bgImage.onload = function () {
-    animateCanvas();
-    bgLoaded = true;
-};
 
 function startAnimate() {
     if (animation === null && times.length > 0) {
@@ -578,9 +598,7 @@ class LineMechanicDrawable extends MechanicDrawable {
     }
 }
 
-let actors = ['${actors}'];
-
-function createAllActors() {
+function createAllActors(actors) {
     for (let i = 0; i < actors.length; i++) {
         const actor = actors[i];
         switch (actor.Type) {
@@ -619,5 +637,3 @@ function createAllActors() {
         }
     }
 }
-createAllActors();
-bgImage.src = "'${mapLink}'";


### PR DESCRIPTION
- Moved all code in the combatreplay.js into functions
- changed all dynamic placeholders in combatreplay.js to function arguments
- Split the generated script to 2 script blocks, one static part and a generated part, that simply calls a static init function with replay data as arguments

With these changes it is a trivial step to make the combatreplay.js a cacheable external resource, like the other javascripts too