### PR TITLE
Some skill/id rework

### DIFF
--- a/LuckParser/Controllers/GW2APIController.cs
+++ b/LuckParser/Controllers/GW2APIController.cs
@@ -326,7 +326,7 @@ namespace LuckParser.Controllers
         [XmlArrayItem("GW2APISkillDetailed", typeof(GW2APISkillDetailed))]
         static SkillList _listOfSkills = new SkillList();
 
-        public GW2APISkill GetSkill(int id)
+        public GW2APISkill GetSkill(long id)
         {
             GW2APISkill skill = GetSkillList().Items.FirstOrDefault(x => x.id == id);
             //if (skill == null) {

--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -1797,7 +1797,7 @@ namespace LuckParser.Controllers
                                         if (_statistics.PresentBoons.Count > 0)
                                         {
                                             Dictionary<long, BoonsGraphModel> boonGraphData = p.GetBoonGraphs(_log);
-                                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.BoonName != "Number of Conditions"))
+                                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse())
                                             {
                                                 sw.Write("{");
                                                 {
@@ -3156,7 +3156,7 @@ namespace LuckParser.Controllers
                             }
                             //============================================
                             Dictionary<long, BoonsGraphModel> boonGraphData = _log.Boss.GetBoonGraphs(_log);
-                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse().Where(x => x.BoonName != "Number of Boons"))
+                            foreach (BoonsGraphModel bgm in boonGraphData.Values.Reverse())
                             {
                                 sw.Write("{");
                                 {

--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -2217,7 +2217,7 @@ namespace LuckParser.Controllers
                         {
                             name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                         }
-                        string skillname = _log.SkillData.GetOrDummy(dl.SkillId).Name.Replace("\'", "\\'");
+                        string skillname = _log.SkillData.Get(dl.SkillId).Name.Replace("\'", "\\'");
                         sw.Write("'" + name + "<br>" + skillname + " hit you for " + dl.Damage + "',");
                     }
                 }
@@ -2229,7 +2229,7 @@ namespace LuckParser.Controllers
                     {
                         name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                     }
-                    string skillname = _log.SkillData.GetOrDummy(damageToKill[d].SkillId).Name.Replace("\'", "\\'");
+                    string skillname = _log.SkillData.Get(damageToKill[d].SkillId).Name.Replace("\'", "\\'");
                     sw.Write("'" + name + "<br>" +
                            "hit you with <b>" + skillname + "</b> for " + damageToKill[d].Damage + "'");
 

--- a/LuckParser/Controllers/HTMLBuilder.cs
+++ b/LuckParser/Controllers/HTMLBuilder.cs
@@ -212,7 +212,7 @@ namespace LuckParser.Controllers
 
                     sw.Write("],");
                     sw.Write(" mode: 'markers',");
-                    if (!(mech.SkillId == -2 || mech.SkillId == -3))
+                    if (!(mech.SkillId == SkillItem.DeathId || mech.SkillId == SkillItem.DownId))
                     {
                         sw.Write("visible:'legendonly',");
                     }
@@ -2055,52 +2055,18 @@ namespace LuckParser.Controllers
                 //int autosCount = 0;
                 foreach (CastLog cl in casting)
                 {
-                    GW2APISkill apiskill = _log.SkillData.Get(cl.SkillId)?.ApiSkill;
+                    SkillItem skill = _log.SkillData.Get(cl.SkillId);
+                    GW2APISkill apiskill = skill?.ApiSkill;
 
-                    if (apiskill != null)
+                    // we must split the autos if we want to show interrupted skills
+                    if (apiskill != null && apiskill.slot == "Weapon_1" && !_settings.ShowAutos)
                     {
-                        // we must split the autos if we want to show interrupted skills
-                        if (apiskill.slot == "Weapon_1" && !_settings.ShowAutos)
-                        {
-                            continue;
-                        }
-                        string borderSize = simpleRotSize == 30 ? "3px" : "1px";
-                        string style = cl.EndActivation == ParseEnum.Activation.CancelCancel ? "style=\"outline: "+ borderSize + " solid red\"" : "";
-                        int imageSize = simpleRotSize - (style.Length > 0 ? (simpleRotSize == 30 ? 3 : 1) : 0);
-                        sw.Write("<span class=\"rot-skill\"><div class=\"rot-crop\"><img " + style + "src=\"" + apiskill.icon + "\" data-toggle=\"tooltip\" title= \"" + apiskill.name + " Time: " + cl.Time + "ms " + "Dur: " + cl.ActualDuration + "ms \" height=\"" + imageSize + "\" width=\"" + imageSize + "\"></div></span>");
+                        continue;
                     }
-                    else
-                    {
-                        if (cl.SkillId == SkillItem.WeaponSwapId)
-                        {//wepswap
-                            string skillName = "Weapon Swap";
-                            string skillLink = HTMLHelper.GetLink("Swap");
-                            sw.Write("<span class=\"rot-skill\"><div class=\"rot-crop\"><img src=\"" + skillLink + "\" data-toggle=\"tooltip\" title= \"" + skillName + " Time: " + cl.Time + "ms " + "Dur: " + cl.ActualDuration + "ms \" height=\"" + simpleRotSize + "\" width=\"" + simpleRotSize + "\"></div></span>");
-                            sw.Write("<br>");
-                        }
-                        else if (cl.SkillId == SkillItem.ResurrectId)
-                        {
-                            string skillName = "Resurrect";
-                            string skillLink = HTMLHelper.GetLink("Downs");
-                            sw.Write("<span class=\"rot-skill\"><div class=\"rot-crop\"><img src=\"" + skillLink + "\" data-toggle=\"tooltip\" title= \"" + skillName + " Time: " + cl.Time + "ms " + "Dur: " + cl.ActualDuration + "ms \" height=\"" + simpleRotSize + "\" width=\"" + simpleRotSize + "\"></div></span>");
-                        }
-                        else if (cl.SkillId == SkillItem.BandageId)
-                        {
-                            string skillName = "Bandage";
-                            string skillLink = HTMLHelper.GetLink("Bandage");
-                            sw.Write("<span class=\"rot-skill\"><div class=\"rot-crop\"><img src=\"" + skillLink + "\" data-toggle=\"tooltip\" title= \"" + skillName + " Time: " + cl.Time + "ms " + "Dur: " + cl.ActualDuration + "ms \" height=\"" + simpleRotSize + "\" width=\"" + simpleRotSize + "\"></div></span>");
-
-                        }
-                        else if (cl.SkillId == SkillItem.DodgeId)
-                        {
-                            string skillName = "Dodge";
-                            string skillLink = HTMLHelper.GetLink("Dodge");
-                            sw.Write("<span class=\"rot-skill\"><div class=\"rot-crop\"><img src=\"" + skillLink + "\" data-toggle=\"tooltip\" title= \"" + skillName + " Time: " + cl.Time + "ms " + "Dur: " + cl.ActualDuration + "ms \" height=\"" + simpleRotSize + "\" width=\"" + simpleRotSize + "\"></div></span>");
-
-                        }
-
-                    }
-
+                    string borderSize = simpleRotSize == 30 ? "3px" : "1px";
+                    string style = cl.EndActivation == ParseEnum.Activation.CancelCancel ? "style=\"outline: " + borderSize + " solid red\"" : "";
+                    int imageSize = simpleRotSize - (style.Length > 0 ? (simpleRotSize == 30 ? 3 : 1) : 0);
+                    sw.Write("<span class=\"rot-skill\"><div class=\"rot-crop\"><img " + style + "src=\"" + skill.Icon + "\" data-toggle=\"tooltip\" title= \"" + skill.Name + " Time: " + cl.Time + "ms " + "Dur: " + cl.ActualDuration + "ms \" height=\"" + imageSize + "\" width=\"" + imageSize + "\"></div></span>");
                 }
             }
 
@@ -2251,7 +2217,7 @@ namespace LuckParser.Controllers
                         {
                             name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                         }
-                        string skillname = _log.SkillData.GetName(dl.SkillId).Replace("\'", "\\'");
+                        string skillname = _log.SkillData.GetOrDummy(dl.SkillId).Name.Replace("\'", "\\'");
                         sw.Write("'" + name + "<br>" + skillname + " hit you for " + dl.Damage + "',");
                     }
                 }
@@ -2263,7 +2229,7 @@ namespace LuckParser.Controllers
                     {
                         name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                     }
-                    string skillname = _log.SkillData.GetName(damageToKill[d].SkillId).Replace("\'", "\\'");
+                    string skillname = _log.SkillData.GetOrDummy(damageToKill[d].SkillId).Name.Replace("\'", "\\'");
                     sw.Write("'" + name + "<br>" +
                            "hit you with <b>" + skillname + "</b> for " + damageToKill[d].Damage + "'");
 
@@ -2331,7 +2297,7 @@ namespace LuckParser.Controllers
                             }
                         }
                     }
-                    HTMLHelper.WriteDamageDistTableSkill(sw, skill, _log.SkillData, listToUse, finalTotalDamage, casts, timeswasted / 1000.0, -timessaved / 1000.0);
+                    HTMLHelper.WriteDamageDistTableSkill(sw, skill, listToUse, finalTotalDamage, casts, timeswasted / 1000.0, -timessaved / 1000.0);
                 }
             }
             foreach (int id in casting.Where(x => !usedIDs.Contains(x.SkillId)).Select(x => (int)x.SkillId).Distinct())
@@ -2357,7 +2323,7 @@ namespace LuckParser.Controllers
                             }
                         }
                     }
-                    HTMLHelper.WriteDamageDistTableSkill(sw, skill, _log.SkillData, new List<DamageLog>(), finalTotalDamage, casts, timeswasted / 1000.0, -timessaved / 1000.0);
+                    HTMLHelper.WriteDamageDistTableSkill(sw, skill, new List<DamageLog>(), finalTotalDamage, casts, timeswasted / 1000.0, -timessaved / 1000.0);
                 }
             }
 
@@ -2643,40 +2609,21 @@ namespace LuckParser.Controllers
                             }
                             int avgdamage = (int)(totaldamage / (double)hits);
 
-                            if (skill.ApiSkill != null)
+                            sw.Write("<tr>");
                             {
-                                sw.Write("<tr>");
-                                {
-                                    sw.Write("<td align=\"left\"><img src=\"" + skill.ApiSkill.icon + "\" alt=\"" + skill.Name + "\" title=\"" + skill.ID + "\" height=\"18\" width=\"18\">" + skill.Name + "</td>");
-                                    sw.Write("<td>" + totaldamage + "</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)totaldamage / finalTotalDamage,2) + "%</td>");
-                                    sw.Write("<td>" + hits + "</td>");
-                                    sw.Write("<td>" + mindamage + "</td>");
-                                    sw.Write("<td>" + avgdamage + "</td>");
-                                    sw.Write("<td>" + maxdamage + "</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)crit / hits,2) + "%</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)flank / hits,2) + "%</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)glance / hits,2) + "%</td>");
-                                }
-                                sw.Write("</tr>");
+                                sw.Write("<td align=\"left\"><img src=\"" + skill.Icon + "\" alt=\"" + skill.Name + "\" title=\"" + skill.ID + "\" height=\"18\" width=\"18\">" + skill.Name + "</td>");
+                                sw.Write("<td>" + totaldamage + "</td>");
+                                sw.Write("<td>" + Math.Round(100 * (double)totaldamage / finalTotalDamage, 2) + "%</td>");
+                                sw.Write("<td>" + hits + "</td>");
+                                sw.Write("<td>" + mindamage + "</td>");
+                                sw.Write("<td>" + avgdamage + "</td>");
+                                sw.Write("<td>" + maxdamage + "</td>");
+                                sw.Write("<td>" + Math.Round(100 * (double)crit / hits, 2) + "%</td>");
+                                sw.Write("<td>" + Math.Round(100 * (double)flank / hits, 2) + "%</td>");
+                                sw.Write("<td>" + Math.Round(100 * (double)glance / hits, 2) + "%</td>");
                             }
-                            else
-                            {
-                                sw.Write("<tr>");
-                                {
-                                    sw.Write("<td align=\"left\">" + skill.Name + "</td>");
-                                    sw.Write("<td>" + totaldamage + "</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)totaldamage / finalTotalDamage,2) + "%</td>");
-                                    sw.Write("<td>" + hits + "</td>");
-                                    sw.Write("<td>" + mindamage + "</td>");
-                                    sw.Write("<td>" + avgdamage + "</td>");
-                                    sw.Write("<td>" + maxdamage + "</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)crit / hits,2) + "%</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)flank / hits,2) + "%</td>");
-                                    sw.Write("<td>" + Math.Round(100 * (double)glance / hits,2) + "%</td>");
-                                }
-                                sw.Write("</tr>");
-                            }
+                            sw.Write("</tr>");
+
                         }
                     }
                 }

--- a/LuckParser/Controllers/HTMLBuilderNew.cs
+++ b/LuckParser/Controllers/HTMLBuilderNew.cs
@@ -692,7 +692,7 @@ namespace LuckParser.Controllers
                         {
                             name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                         }
-                        string skillname = _log.SkillData.GetName(dl.SkillId).Replace("\'", "\\'");
+                        string skillname = _log.SkillData.GetOrDummy(dl.SkillId).Name.Replace("\'", "\\'");
                         sw.Write("'" + name + "<br>" + skillname + " hit you for " + dl.Damage + "',");
                     }
                 }
@@ -704,7 +704,7 @@ namespace LuckParser.Controllers
                     {
                         name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                     }
-                    string skillname = _log.SkillData.GetName(damageToKill[d].SkillId).Replace("\'", "\\'");
+                    string skillname = _log.SkillData.GetOrDummy(damageToKill[d].SkillId).Name.Replace("\'", "\\'");
                     sw.Write("'" + name + "<br>" +
                            "hit you with <b>" + skillname + "</b> for " + damageToKill[d].Damage + "'");
 
@@ -1154,7 +1154,7 @@ namespace LuckParser.Controllers
                     description = mech.Description,
                     color = mech.PlotlyColor,
                     symbol = mech.PlotlySymbol,
-                    visible = (mech.SkillId == -2 || mech.SkillId == -3),
+                    visible = (mech.SkillId == SkillItem.DeathId|| mech.SkillId == SkillItem.DownId),
                     data = BuildMechanicData(mechanicLogs),
                     playerMech = playerMechs.Contains(mech),
                     enemyMech = enemyMechs.Contains(mech)
@@ -1785,11 +1785,7 @@ namespace LuckParser.Controllers
             foreach (SkillItem skill in skills)
             {
                 GW2APISkill apiSkill = skill.ApiSkill;
-                SkillDto dto = new SkillDto(skill.ID, skill.Name, apiSkill?.icon, apiSkill?.slot == "Weapon_1");
-                if (skill.ID == SkillItem.WeaponSwapId) dto.icon = "https://wiki.guildwars2.com/images/c/ce/Weapon_Swap_Button.png";
-                else if (skill.ID == SkillItem.ResurrectId) dto.icon = "https://wiki.guildwars2.com/images/3/3d/Downed_ally.png";
-                else if (skill.ID == SkillItem.BandageId) dto.icon = "https://wiki.guildwars2.com/images/0/0c/Bandage.png";
-                else if (skill.ID == SkillItem.DodgeId) dto.icon = "https://wiki.guildwars2.com/images/b/b2/Dodge.png";
+                SkillDto dto = new SkillDto(skill.ID, skill.Name, skill.Icon, apiSkill?.slot == "Weapon_1");
                 dtos.Add(dto);
             }
             return dtos;

--- a/LuckParser/Controllers/HTMLBuilderNew.cs
+++ b/LuckParser/Controllers/HTMLBuilderNew.cs
@@ -523,7 +523,7 @@ namespace LuckParser.Controllers
             SkillData skillList = _log.SkillData;
             foreach (CastLog cl in casting)
             {
-                if (!usedSkills.ContainsKey(cl.SkillId)) usedSkills.Add(cl.SkillId, skillList.GetOrDummy(cl.SkillId));
+                if (!usedSkills.ContainsKey(cl.SkillId)) usedSkills.Add(cl.SkillId, skillList.Get(cl.SkillId));
                 double[] rotEntry = new double[5];
                 list.Add(rotEntry);
                 rotEntry[0] = (cl.Time - phase.Start) / 1000.0;
@@ -692,7 +692,7 @@ namespace LuckParser.Controllers
                         {
                             name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                         }
-                        string skillname = _log.SkillData.GetOrDummy(dl.SkillId).Name.Replace("\'", "\\'");
+                        string skillname = _log.SkillData.Get(dl.SkillId).Name.Replace("\'", "\\'");
                         sw.Write("'" + name + "<br>" + skillname + " hit you for " + dl.Damage + "',");
                     }
                 }
@@ -704,7 +704,7 @@ namespace LuckParser.Controllers
                     {
                         name = ag.Name.Replace("\0", "").Replace("\'", "\\'");
                     }
-                    string skillname = _log.SkillData.GetOrDummy(damageToKill[d].SkillId).Name.Replace("\'", "\\'");
+                    string skillname = _log.SkillData.Get(damageToKill[d].SkillId).Name.Replace("\'", "\\'");
                     sw.Write("'" + name + "<br>" +
                            "hit you with <b>" + skillname + "</b> for " + damageToKill[d].Damage + "'");
 
@@ -769,7 +769,7 @@ namespace LuckParser.Controllers
                 }
                 else
                 {
-                    if (!usedSkills.ContainsKey(entry.Key)) usedSkills.Add(entry.Key, skillList.GetOrDummy(entry.Key));
+                    if (!usedSkills.ContainsKey(entry.Key)) usedSkills.Add(entry.Key, skillList.Get(entry.Key));
                 }
 
                 if (!isCondi && castLogsBySkill.TryGetValue(entry.Key, out List<CastLog> clList))
@@ -801,7 +801,7 @@ namespace LuckParser.Controllers
             {
                 if (damageLogsBySkill.ContainsKey(entry.Key)) continue;
 
-                if (!usedSkills.ContainsKey(entry.Key)) usedSkills.Add(entry.Key, skillList.GetOrDummy(entry.Key));
+                if (!usedSkills.ContainsKey(entry.Key)) usedSkills.Add(entry.Key, skillList.Get(entry.Key));
 
                 int casts = entry.Value.Count;
                 int timeswasted = 0, timessaved = 0;

--- a/LuckParser/Controllers/HTMLHelper.cs
+++ b/LuckParser/Controllers/HTMLHelper.cs
@@ -14,16 +14,16 @@ namespace LuckParser.Controllers
 
         public static void WriteCastingItem(StreamWriter sw, CastLog cl, SkillData skillList, PhaseData phase)
         {
-            GW2APISkill skill = skillList.Get(cl.SkillId)?.ApiSkill;
-            string skillName = skill == null ? skillList.GetName(cl.SkillId) : skill.name;
+            SkillItem skill = skillList.Get(cl.SkillId);
+            GW2APISkill skillApi = skill?.ApiSkill;
+            string skillName = skill.Name;
             float dur;
-            if (skillName == "Dodge")
+            if (cl.SkillId == SkillItem.DodgeId)
             {
                 dur = 0.5f;
             }
             else if (cl.SkillId == SkillItem.WeaponSwapId)
             {
-                skillName = "Weapon Swap";
                 dur = 0.1f;
             }
             else
@@ -49,10 +49,9 @@ namespace LuckParser.Controllers
                        "orientation:'h'," +
                        "mode: 'markers'," +
                        "type: 'bar',");
-                if (skill != null)
+                if (skillApi != null)
                 {
-                    sw.Write(skill.slot == "Weapon_1" ? "width:'0.5'," : "width:'1',");
-
+                    sw.Write(skillApi.slot == "Weapon_1" ? "width:'0.5'," : "width:'1',");
                 }
                 else
                 { 
@@ -101,59 +100,24 @@ namespace LuckParser.Controllers
 
         public static void WriteCastingItemIcon(StreamWriter sw, CastLog cl, SkillData skillList, PhaseData phase, bool last)
         {
-            string skillIcon = "";
-            GW2APISkill skill = skillList.Get(cl.SkillId)?.ApiSkill;
-            if (skill != null && cl.SkillId != -2)
+            SkillItem skill = skillList.Get(cl.SkillId);
+            GW2APISkill skillApi = skill?.ApiSkill;
+            float offset = (cl.Time - phase.Start) / 1000f;
+            if ((skillApi != null && skillApi.slot != "Weapon_1") || skillApi == null)
             {
-                float offset = (cl.Time - phase.Start) / 1000f;
-                if (skill.slot != "Weapon_1")
-                {
-                    skillIcon = skill.icon;
-                    sw.Write("{" +
-                                 "source: '" + skillIcon + "'," +
-                                 "xref: 'x'," +
-                                 "yref: 'y'," +
-                                 "x: " + Math.Max(offset, 0.0f) + "," +
-                                 "y: 0," +
-                                 "sizex: 1.1," +
-                                 "sizey: 1.1," +
-                                 "xanchor: 'left'," +
-                                 "yanchor: 'bottom'" +
-                            "}");
-                }
-            }
-            else
-            {
-                string skillName = cl.SkillId == SkillItem.WeaponSwapId ? "Weapon Swap" : skillList.GetName(cl.SkillId);
-                if (skillName == "Dodge")
-                {
-                    skillIcon = GetLink("Dodge");
-                }
-                else if (skillName == "Resurrect")
-                {
-                    skillIcon = GetLink("Resurrect");
-                }
-                else if (skillName == "Bandage")
-                {
-                    skillIcon = GetLink("Bandage");
-                }
-                else if (cl.SkillId == SkillItem.WeaponSwapId)
-                {
-                    skillIcon = GetLink("Swap");
-                }
-
                 sw.Write("{" +
-                              "source: '" + skillIcon + "'," +
-                              "xref: 'x'," +
-                              "yref: 'y'," +
-                              "x: " + (cl.Time - phase.Start) / 1000f + "," +
-                              "y: 0," +
-                              "sizex: 1.1," +
-                              "sizey: 1.1," +
-                              "xanchor: 'left'," +
-                              "yanchor: 'bottom'" +
-                          "}");
+                             "source: '" + skill.Icon + "'," +
+                             "xref: 'x'," +
+                             "yref: 'y'," +
+                             "x: " + Math.Max(offset, 0.0f) + "," +
+                             "y: 0," +
+                             "sizex: 1.1," +
+                             "sizey: 1.1," +
+                             "xanchor: 'left'," +
+                             "yanchor: 'bottom'" +
+                        "}");
             }
+
             if (!last)
             {
                 sw.Write(",");
@@ -300,7 +264,7 @@ namespace LuckParser.Controllers
             }
         }
 
-        public static void WriteDamageDistTableSkill(StreamWriter sw, SkillItem skill, SkillData skillData, List<DamageLog> damageLogs, int finalTotalDamage, int casts = -1, double timeswasted = -1, double timessaved = 1)
+        public static void WriteDamageDistTableSkill(StreamWriter sw, SkillItem skill, List<DamageLog> damageLogs, int finalTotalDamage, int casts = -1, double timeswasted = -1, double timessaved = 1)
         {
             int totaldamage = 0;
             int mindamage = 0;
@@ -328,12 +292,11 @@ namespace LuckParser.Controllers
             if (casts > 0) {
                 hpcast = Math.Round(hits / (double)casts, 2);
             }
-            string skillName = (skill.ID.ToString() == skill.Name) ? skillData.GetName(skill.ID) : skill.Name;
-            if (totaldamage != 0 && skill.ApiSkill != null)
+            if (totaldamage != 0)
             {
                 sw.Write("<tr>");
                 {
-                    sw.Write("<td align=\"left\"><img src=\"" + skill.ApiSkill.icon + "\" alt=\"" + skill.Name + "\" title=\"" + skill.ID + "\" height=\"18\" width=\"18\">" + skillName + "</td>");
+                    sw.Write("<td align=\"left\"><img src=\"" + skill.Icon + "\" alt=\"" + skill.Name + "\" title=\"" + skill.ID + "\" height=\"18\" width=\"18\">" + skill.Name + "</td>");
                     sw.Write("<td>" + Math.Round(100 * (double)totaldamage / finalTotalDamage,2) + "%</td>");
                     sw.Write("<td>" + totaldamage + "</td>");
                     sw.Write("<td>" + mindamage + "</td>");
@@ -351,53 +314,11 @@ namespace LuckParser.Controllers
                 }
                 sw.Write("</tr>");
             }
-            else if (totaldamage != 0)
-            {
-                sw.Write("<tr>");
-                {
-                    sw.Write("<td align=\"left\">" + skillName + "</td>");
-                    sw.Write("<td>" + Math.Round(100 * (double)totaldamage / finalTotalDamage,2) + "%</td>");
-                    sw.Write("<td>" + totaldamage + "</td>");
-                    sw.Write("<td>" + mindamage + "</td>");
-                    sw.Write("<td>" + avgdamage + "</td>");
-                    sw.Write("<td>" + maxdamage + "</td>");
-                    sw.Write("<td>" + (casts != -1 ? casts.ToString() : "") + "</td>");
-                    sw.Write("<td>" + hits + "</td>");
-                    sw.Write("<td>" + (hpcast > 0 ? hpcast.ToString() : "") + "</td>");
-                    sw.Write("<td data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + crit + " out of " + hits + " hits\">" + Math.Round(100 * (double)crit / hits,2) + "%</td>");
-                    sw.Write("<td data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + flank + " out of " + hits + " hits\">" + Math.Round(100 * (double)flank / hits,2) + "%</td>");
-                    sw.Write("<td data-toggle=\"tooltip\" data-html=\"true\" data-placement=\"top\" title=\"" + glance + " out of " + hits + " hits\">" + Math.Round(100 * (double)glance / hits,2) + "%</td>");
-                    sw.Write("<td>" + wasted + "</td>");
-                    sw.Write("<td>" + saved + "</td>");
-                }
-                sw.Write("</tr>");
-            }
-            else if (skill.ApiSkill != null)
-            {
-                sw.Write("<tr>");
-                {
-                    sw.Write("<td align=\"left\"><img src=\"" + skill.ApiSkill.icon + "\" alt=\"" + skill.Name + "\" title=\"" + skill.ID + "\" height=\"18\" width=\"18\">" + skillName + "</td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td>" + (casts != -1 ? casts.ToString() : "") + "</td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td></td>");
-                    sw.Write("<td>" + wasted + "</td>");
-                    sw.Write("<td>" + saved + "</td>");
-                }
-                sw.Write("</tr>");
-            }
             else
             {
                 sw.Write("<tr>");
                 {
-                    sw.Write("<td align=\"left\">" + skillName + "</td>");
+                    sw.Write("<td align=\"left\"><img src=\"" + skill.Icon + "\" alt=\"" + skill.Name + "\" title=\"" + skill.ID + "\" height=\"18\" width=\"18\">" + skill.Name + "</td>");
                     sw.Write("<td></td>");
                     sw.Write("<td></td>");
                     sw.Write("<td></td>");

--- a/LuckParser/Controllers/JSONBuilder.cs
+++ b/LuckParser/Controllers/JSONBuilder.cs
@@ -206,8 +206,8 @@ namespace LuckParser.Controllers
                     LastAware = (int)(target.LastAware - _log.FightData.FightStart),
                     Minions = BuildMinions(target),
                     TotalDamageDist = BuildDamageDist(target, null),
-                    AvgBoonsStates = BuildBuffStates(target.GetBoonGraphs(_log)[-2]),
-                    AvgConditionsStates = BuildBuffStates(target.GetBoonGraphs(_log)[-3])
+                    AvgBoonsStates = BuildBuffStates(target.GetBoonGraphs(_log)[Boon.NumberOfBoonsID]),
+                    AvgConditionsStates = BuildBuffStates(target.GetBoonGraphs(_log)[Boon.NumberOfConditionsID])
                 };
                 int finalBossHealth = target.HealthOverTime.Count > 0
                     ? target.HealthOverTime.Last().Y
@@ -258,8 +258,8 @@ namespace LuckParser.Controllers
                     TotalDamageTaken = BuildDamageTaken(player),
                     DeathRecap = BuilDeathRecap(player),
                     Consumables = BuildConsumables(player),
-                    AvgBoonsStates = BuildBuffStates(player.GetBoonGraphs(_log)[-2]),
-                    AvgConditionsStates = BuildBuffStates(player.GetBoonGraphs(_log)[-3]),
+                    AvgBoonsStates = BuildBuffStates(player.GetBoonGraphs(_log)[Boon.NumberOfBoonsID]),
+                    AvgConditionsStates = BuildBuffStates(player.GetBoonGraphs(_log)[Boon.NumberOfConditionsID]),
                 });
                 if (_devMode)
                 {

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -213,30 +213,17 @@ namespace LuckParser.Controllers
             using (var reader = CreateReader(stream))
             {
                 // 4 bytes: player count
-                int skillCount = reader.ReadInt32();
+                uint skillCount = reader.ReadUInt32();
                 //TempData["Debug"] += "Skill Count:" + skill_count.ToString();
                 // 68 bytes: each skill
                 for(int i = 0; i < skillCount; i++)
                 {
                     // 4 bytes: skill ID
                     int skillId = reader.ReadInt32();
-
                     // 64 bytes: name
                     var name = ParseHelper.GetString(stream, 64);
-                    if(skillId != 0 && int.TryParse(name, out int n) && n == skillId)
-                    {
-                        //was it a known buff?
-                        if (Boon.BoonsByIds.TryGetValue(skillId, out Boon boon))
-                        {
-                            name = boon.Name;
-                        }
-                    }
                     //Save
-
-                    var skill = new SkillItem(skillId, name);
-
-                    skill.SetGW2APISkill(apiController);
-                    _skillData.Add(skill);
+                    var skill = new SkillItem(skillId, name, apiController);
                 }
             }
         }

--- a/LuckParser/Controllers/Parser.cs
+++ b/LuckParser/Controllers/Parser.cs
@@ -224,6 +224,7 @@ namespace LuckParser.Controllers
                     var name = ParseHelper.GetString(stream, 64);
                     //Save
                     var skill = new SkillItem(skillId, name, apiController);
+                    _skillData.Add(skill);
                 }
             }
         }

--- a/LuckParser/Models/BossLogic/BossLogic.cs
+++ b/LuckParser/Models/BossLogic/BossLogic.cs
@@ -14,8 +14,8 @@ namespace LuckParser.Models
 
         private CombatReplayMap _map;
         public readonly List<Mechanic> MechanicList = new List<Mechanic> {
-            new Mechanic(-2, "Dead", Mechanic.MechType.PlayerStatus, ParseEnum.BossIDS.Unknown, "symbol:'x',color:'rgb(0,0,0)'", "Dead",0),
-            new Mechanic(-3, "Downed", Mechanic.MechType.PlayerStatus, ParseEnum.BossIDS.Unknown, "symbol:'cross',color:'rgb(255,0,0)'", "Downed",0),
+            new Mechanic(SkillItem.DeathId, "Dead", Mechanic.MechType.PlayerStatus, ParseEnum.BossIDS.Unknown, "symbol:'x',color:'rgb(0,0,0)'", "Dead",0),
+            new Mechanic(SkillItem.DownId, "Downed", Mechanic.MechType.PlayerStatus, ParseEnum.BossIDS.Unknown, "symbol:'cross',color:'rgb(255,0,0)'", "Downed",0),
             new Mechanic(SkillItem.ResurrectId, "Resurrect", Mechanic.MechType.PlayerStatus, ParseEnum.BossIDS.Unknown, "symbol:'cross-open',color:'rgb(0,255,255)'", "Res",0)}; //Resurrects (start), Resurrect
         public ParseMode Mode { get; protected set; } = ParseMode.Unknown;
         public bool CanCombatReplay { get; set; } = false;
@@ -250,10 +250,10 @@ namespace LuckParser.Models
                             List<CombatItem> cList = new List<CombatItem>();
                             switch (mech.SkillId)
                             {
-                                case -2:
+                                case SkillItem.DeathId:
                                     cList = combatData.GetStates(p.InstID, ParseEnum.StateChange.ChangeDead, start, end);
                                     break;
-                                case -3:
+                                case SkillItem.DownId:
                                     cList = combatData.GetStates(p.InstID, ParseEnum.StateChange.ChangeDown, start, end);
                                     break;
                                 case SkillItem.ResurrectId:

--- a/LuckParser/Models/ParseModels/Boons/Boon.cs
+++ b/LuckParser/Models/ParseModels/Boons/Boon.cs
@@ -13,6 +13,9 @@ namespace LuckParser.Models.ParseModels
         public enum BoonType { Duration, Intensity };
         private enum Logic { Queue, HealingPower, Override, ForceOverride };
 
+        public const long NumberOfConditionsID = -3;
+        public const long NumberOfBoonsID = -2;
+
         public static BoonSource ProfToEnum(string prof)
         {
             switch (prof)
@@ -67,7 +70,7 @@ namespace LuckParser.Models.ParseModels
         public readonly string Link;
         private readonly Logic _logic;
 
-        private Boon(string name, int id, BoonSource source, BoonType type, int capacity, BoonNature nature, Logic logic, string link)
+        private Boon(string name, long id, BoonSource source, BoonType type, int capacity, BoonNature nature, Logic logic, string link)
         {
             Name = name;
             ID = id;
@@ -82,6 +85,9 @@ namespace LuckParser.Models.ParseModels
 
         private static List<Boon> _allBoons = new List<Boon>
             {
+                // Custom Boons
+                new Boon("Number of Conditions", NumberOfConditionsID, BoonSource.Mixed, BoonType.Intensity, 0, BoonNature.GraphOnlyBuff, Logic.Override, "https://wiki.guildwars2.com/images/3/38/Condition_Duration.png"),
+                new Boon("Number of Boons", NumberOfBoonsID, BoonSource.Mixed, BoonType.Intensity, 0, BoonNature.GraphOnlyBuff, Logic.Override, "https://wiki.guildwars2.com/images/4/44/Boon_Duration.png"),
                 //Base boons
                 new Boon("Might", 740, BoonSource.Mixed, BoonType.Intensity, 25, BoonNature.Boon, Logic.Override, "https://wiki.guildwars2.com/images/7/7c/Might.png"),
                 new Boon("Fury", 725, BoonSource.Mixed, BoonType.Duration, 9, BoonNature.Boon, Logic.Queue, "https://wiki.guildwars2.com/images/4/46/Fury.png"),//or 3m and 30s

--- a/LuckParser/Models/ParseModels/CombatData.cs
+++ b/LuckParser/Models/ParseModels/CombatData.cs
@@ -72,7 +72,7 @@ namespace LuckParser.Models.ParseModels
             return new List<CombatItem>();
         }
 
-        public int GetSkillCount(int srcInstid, int skillId, long start, long end)
+        public int GetSkillCount(int srcInstid, long skillId, long start, long end)
         {
             if (CastDataById.TryGetValue(skillId, out List<CombatItem> data))
             {
@@ -81,7 +81,7 @@ namespace LuckParser.Models.ParseModels
             return 0;
         }
 
-        public int GetBuffCount(int srcInstid, int skillId, long start, long end)
+        public int GetBuffCount(int srcInstid, long skillId, long start, long end)
         {
             if (BoonData.TryGetValue(skillId, out List<CombatItem> data))
             {

--- a/LuckParser/Models/ParseModels/GW2API/GW2APISkill.cs
+++ b/LuckParser/Models/ParseModels/GW2API/GW2APISkill.cs
@@ -2,7 +2,7 @@
 {
     public class GW2APISkill
     {
-        public int id { get; set; }
+        public long id { get; set; }
         public string name { get; set; }
         public string description { get; set; }
         public string icon { get; set; }

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -537,8 +537,8 @@ namespace LuckParser.Models.ParseModels
                     
                 }
             }
-            _boonPoints[-2] = boonPresenceGraph;
-            _boonPoints[-3] = condiPresenceGraph;
+            _boonPoints[Boon.NumberOfBoonsID] = boonPresenceGraph;
+            _boonPoints[Boon.NumberOfConditionsID] = condiPresenceGraph;
         }
         private void SetMinions(ParsedLog log)
         {

--- a/LuckParser/Models/ParseModels/SkillData.cs
+++ b/LuckParser/Models/ParseModels/SkillData.cs
@@ -14,34 +14,7 @@ namespace LuckParser.Models.ParseModels
         }
         // Fields
         private readonly Dictionary<long, SkillItem> _skills = new Dictionary<long, SkillItem>();
-        readonly static Dictionary<long, string> _apiMissingID = new Dictionary<long, string>()
-        {
-            {SkillItem.ResurrectId, "Resurrect"},
-            {SkillItem.BandageId, "Bandage" },
-            {SkillItem.DodgeId, "Dodge" },
-            // Gorseval
-            {31834,"Ghastly Rampage" },
-            {31759,"Protective Shadow" },
-            {31466,"Ghastly Rampage (Begin)" },
-            // Sabetha
-            {31372, "Shadow Step" },
-            // Slothasor
-            {34547, "Tantrum Start" },
-            {34515, "Sleeping" },
-            {34340, "Fear Me!" },
-            // Matthias
-            { 34468, "Shield (Human)"},
-            { 34427, "Abomination Transformation"},
-            { 34510, "Shield (Abomination)"},
-            // Generic
-            {-5, "Phase out" },
-            // Deimos
-            {-6, "Roleplay" },
-            // Dhuum
-            {47396, "Major Soul Split" },
-            // Keep Construct
-            {35048, "Magic Blast Charge" }
-        };
+        
         
         // Public Methods
 
@@ -60,31 +33,12 @@ namespace LuckParser.Models.ParseModels
             {
                 return value;
             }
-            return new SkillItem((int)ID, GetName(ID));
+            return new SkillItem(ID, "UNKNOWN");
         }
 
         public void Add(SkillItem skillItem)
         {
             _skills.Add(skillItem.ID, skillItem);
         }
-
-        public String GetName(long ID)
-        {
-            // Custom
-            if (_apiMissingID.ContainsKey(ID))
-            {
-                return _apiMissingID[ID];
-            }
-
-            // Normal
-            SkillItem skillItem = Get(ID);
-            if (skillItem != null)
-            {
-                return skillItem.Name;
-            }
-
-            // Unknown
-            return "uid: " + ID.ToString();
-        }    
     }
 }

--- a/LuckParser/Models/ParseModels/SkillData.cs
+++ b/LuckParser/Models/ParseModels/SkillData.cs
@@ -24,16 +24,9 @@ namespace LuckParser.Models.ParseModels
             {
                 return value;
             }
-            return null;
-        }
-
-        public SkillItem GetOrDummy(long ID)
-        {
-            if (_skills.TryGetValue(ID, out SkillItem value))
-            {
-                return value;
-            }
-            return new SkillItem(ID, "UNKNOWN");
+            SkillItem item = new SkillItem(ID, "UNKNOWN");
+            Add(item);
+            return item;
         }
 
         public void Add(SkillItem skillItem)

--- a/LuckParser/Models/ParseModels/SkillItem.cs
+++ b/LuckParser/Models/ParseModels/SkillItem.cs
@@ -1,59 +1,106 @@
 ﻿using LuckParser.Controllers;
 using System;
+using System.Collections.Generic;
 
 namespace LuckParser.Models.ParseModels
 {
     public class SkillItem
     {
-        public const int ResurrectId = 1066;
-        public const int BandageId = 1175;
-        public const int DodgeId = 65001;
-        public const int WeaponSwapId = -2;
+        public const long DodgeId = 65001;
+        public const long ResurrectId = 1066;
+        public const long BandageId = 1175;
+        public const long WeaponSwapId = -2;
+        public const long DeathId = -4;
+        public const long DownId = -3;
+
+        readonly static Dictionary<long, string> _missingNames = new Dictionary<long, string>()
+        {
+            {ResurrectId, "Resurrect"},
+            {BandageId, "Bandage" },
+            {DodgeId, "Dodge" },
+            {WeaponSwapId, "Weapon Swap" },
+            // Gorseval
+            {31834,"Ghastly Rampage" },
+            {31759,"Protective Shadow" },
+            {31466,"Ghastly Rampage (Begin)" },
+            // Sabetha
+            {31372, "Shadow Step" },
+            // Slothasor
+            {34547, "Tantrum Start" },
+            {34515, "Sleeping" },
+            {34340, "Fear Me!" },
+            // Matthias
+            { 34468, "Shield (Human)"},
+            { 34427, "Abomination Transformation"},
+            { 34510, "Shield (Abomination)"},
+            // Generic
+            {-5, "Phase out" },
+            // Deimos
+            {-6, "Roleplay" },
+            // Dhuum
+            {47396, "Major Soul Split" },
+            // Keep Construct
+            {35048, "Magic Blast Charge" }
+        };
+
+        readonly static Dictionary<long, string> _missingIcons = new Dictionary<long, string>()
+        {
+            {ResurrectId, "https://wiki.guildwars2.com/images/3/3d/Downed_ally.png"},
+            {BandageId, "https://wiki.guildwars2.com/images/0/0c/Bandage.png" },
+            {DodgeId, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
+            {WeaponSwapId, "https://wiki.guildwars2.com/images/c/ce/Weapon_Swap_Button.png" },
+            {49112, "https://wiki.guildwars2.com/images/e/e7/Throw_Magnetic_Bomb.png" },
+        };
+
+        private const string _defaultIcon = "https://render.guildwars2.com/file/1D55D34FB4EE20B1962E315245E40CA5E1042D0E/62248.png";
 
         // Fields
-        public readonly int ID;
-        private String _name;
-        public String Name
+        public readonly long ID;
+        private readonly string _name;
+        public string Name
         {
             get
             {
-                return ID == ResurrectId ? "Resurrect" : _name;
+                if (_missingNames.TryGetValue(ID, out string name))
+                {
+                    return name;
+                }
+                return  _name;
+            }
+        }
+        public string Icon
+        {
+            get
+            {
+                if (_missingIcons.TryGetValue(ID, out string icon))
+                {
+                    return icon;
+                }
+                return ApiSkill != null ? ApiSkill.icon : _defaultIcon;
             }
         }
         public GW2APISkill ApiSkill { get; private set; }
         public int CC { get; private set; }
 
         // Constructor
-        public SkillItem(int ID, String name)
+        public SkillItem(long ID, String name)
         {
-            name = name.Replace("\0", "");
             this.ID = ID;
-            _name = name;
+            _name = name.Replace("\0", "");
+        }
+
+        public SkillItem(long ID, String name, GW2APIController apiController)
+        {
+            this.ID = ID;
+            _name = name.Replace("\0", "");
+            ApiSkill = apiController.GetSkill(ID);
+            if (ApiSkill != null)
+            {
+                _name = ApiSkill.name;
+            }
         }
 
         // Public Methods
-        public String[] ToStringArray()
-        {
-            String[] array = new String[2];
-            array[0] = ID.ToString();
-            array[1] = _name;
-            return array;
-        }
-        //setter
-        public void SetGW2APISkill(GW2APIController apiController)
-        {
-            if (ApiSkill == null)
-            {
-                GW2APISkill skillAPI = apiController.GetSkill(ID);
-
-                if (skillAPI != null) {
-                    ApiSkill = skillAPI;
-                    _name = skillAPI.name;
-                }
-                
-            }
-            
-        }
 
         public void SetCCAPI()//this is 100% off the GW2 API is not a reliable source of finding skill CC
         {

--- a/LuckParser/Models/ParseModels/SkillItem.cs
+++ b/LuckParser/Models/ParseModels/SkillItem.cs
@@ -13,7 +13,7 @@ namespace LuckParser.Models.ParseModels
         public const long DeathId = -4;
         public const long DownId = -3;
 
-        readonly static Dictionary<long, string> _missingNames = new Dictionary<long, string>()
+        readonly static Dictionary<long, string> _overrideNames = new Dictionary<long, string>()
         {
             {ResurrectId, "Resurrect"},
             {BandageId, "Bandage" },
@@ -43,7 +43,7 @@ namespace LuckParser.Models.ParseModels
             {35048, "Magic Blast Charge" }
         };
 
-        readonly static Dictionary<long, string> _missingIcons = new Dictionary<long, string>()
+        readonly static Dictionary<long, string> _overrideIcons = new Dictionary<long, string>()
         {
             {ResurrectId, "https://wiki.guildwars2.com/images/3/3d/Downed_ally.png"},
             {BandageId, "https://wiki.guildwars2.com/images/0/0c/Bandage.png" },
@@ -56,29 +56,8 @@ namespace LuckParser.Models.ParseModels
 
         // Fields
         public readonly long ID;
-        private readonly string _name;
-        public string Name
-        {
-            get
-            {
-                if (_missingNames.TryGetValue(ID, out string name))
-                {
-                    return name;
-                }
-                return  _name;
-            }
-        }
-        public string Icon
-        {
-            get
-            {
-                if (_missingIcons.TryGetValue(ID, out string icon))
-                {
-                    return icon;
-                }
-                return ApiSkill != null ? ApiSkill.icon : _defaultIcon;
-            }
-        }
+        public string Name { get; private set; }
+        public string Icon { get; private set; }
         public GW2APISkill ApiSkill { get; private set; }
         public int CC { get; private set; }
 
@@ -86,17 +65,34 @@ namespace LuckParser.Models.ParseModels
         public SkillItem(long ID, String name)
         {
             this.ID = ID;
-            _name = name.Replace("\0", "");
+            Name = name.Replace("\0", "");
+            CompleteItem();
         }
 
         public SkillItem(long ID, String name, GW2APIController apiController)
         {
             this.ID = ID;
-            _name = name.Replace("\0", "");
+            Name = name.Replace("\0", "");
             ApiSkill = apiController.GetSkill(ID);
             if (ApiSkill != null)
             {
-                _name = ApiSkill.name;
+                Name = ApiSkill.name;
+            }
+            CompleteItem();
+        }
+
+        private void CompleteItem()
+        {
+            if (_overrideNames.TryGetValue(ID,out string name))
+            {
+                Name = name;
+            }
+            if (_overrideIcons.TryGetValue(ID, out string icon))
+            {
+                Icon = icon;
+            } else
+            {
+                Icon = ApiSkill != null ? ApiSkill.icon : _defaultIcon;
             }
         }
 


### PR DESCRIPTION
- Reworked skillData so that it only takes the role of managing skill items
- Added Icon attribute to SkillItem. At construction level, a SkillItem will override its name and/or icon if necessary. Added a default icon. SkillItem.Name and SkillItem.Icon will always give appropriate values.
- Removed every apiSkill check for the icon/names from the code. ApiSkills are only used for weapon slot checks and weapon estimation
- Added IDs for death/downs mechanics
- Added IDs for Number of Conditions/Boons
- Added custom boons for Number of Conditions and Number of Boons