### PR TITLE
Add icons for Thief raid stolen skills, unavailable in the API

### DIFF
--- a/LuckParser/Models/ParseModels/SkillItem.cs
+++ b/LuckParser/Models/ParseModels/SkillItem.cs
@@ -50,6 +50,7 @@ namespace LuckParser.Models.ParseModels
             {DodgeId, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
             {WeaponSwapId, "https://wiki.guildwars2.com/images/c/ce/Weapon_Swap_Button.png" },
             {49112, "https://wiki.guildwars2.com/images/e/e7/Throw_Magnetic_Bomb.png" },
+            {49063, "https://wiki.guildwars2.com/images/3/3d/Detonate_Plasma.png" },
         };
 
         private const string _defaultIcon = "https://render.guildwars2.com/file/1D55D34FB4EE20B1962E315245E40CA5E1042D0E/62248.png";

--- a/LuckParser/Models/ParseModels/SkillItem.cs
+++ b/LuckParser/Models/ParseModels/SkillItem.cs
@@ -46,11 +46,12 @@ namespace LuckParser.Models.ParseModels
         readonly static Dictionary<long, string> _overrideIcons = new Dictionary<long, string>()
         {
             {ResurrectId, "https://wiki.guildwars2.com/images/3/3d/Downed_ally.png"},
-            {BandageId, "https://wiki.guildwars2.com/images/0/0c/Bandage.png" },
-            {DodgeId, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
-            {WeaponSwapId, "https://wiki.guildwars2.com/images/c/ce/Weapon_Swap_Button.png" },
-            {49112, "https://wiki.guildwars2.com/images/e/e7/Throw_Magnetic_Bomb.png" },
-            {49063, "https://wiki.guildwars2.com/images/3/3d/Detonate_Plasma.png" },
+            {BandageId, "https://wiki.guildwars2.com/images/0/0c/Bandage.png"},
+            {DodgeId, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png"},
+            {WeaponSwapId, "https://wiki.guildwars2.com/images/c/ce/Weapon_Swap_Button.png"},
+            {49112, "https://wiki.guildwars2.com/images/e/e7/Throw_Magnetic_Bomb.png"},
+            {49063, "https://wiki.guildwars2.com/images/3/3d/Detonate_Plasma.png"},
+            {49123, "https://wiki.guildwars2.com/images/d/dd/Unstable_Artifact.png"},
         };
 
         private const string _defaultIcon = "https://render.guildwars2.com/file/1D55D34FB4EE20B1962E315245E40CA5E1042D0E/62248.png";


### PR DESCRIPTION
These are rather important (mainly detonate plasma). Soul Stone Venom is instant-cast and doesn't do damage directly, so it shouldn't appear in logs.