### PR TITLE
Buff extension

### DIFF
--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -254,7 +254,7 @@ namespace LuckParser.Models.ParseModels
                 CastLog item = cls.First();
                 if (extension == 2000 && log.PlayerListBySpec.TryGetValue("Tempest", out List<Player> tempests))
                 {
-                    List<CombatItem> magAuraApplications = log.GetBoonData(5684).Where(x => x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
+                    List<CombatItem> magAuraApplications = log.GetBoonData(5684).Where(x => x.IsBuffRemove == ParseEnum.BuffRemove.None && x.IsOffcycle == 0).ToList();
                     foreach (Player tempest in tempests)
                     {
                         if (magAuraApplications.FirstOrDefault(x => x.SrcInstid == tempest.InstID && Math.Abs(x.Time - time) < 50) != null)

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -252,10 +252,8 @@ namespace LuckParser.Models.ParseModels
             if (cls.Count == 1)
             {
                 CastLog item = cls.First();
-                if (extension == 2000)
+                if (extension == 2000 && log.PlayerListBySpec.TryGetValue("Tempest", out List<Player> tempests))
                 {
-                    // find every tempest 
-                    List<Player> tempests = log.PlayerList.Where(x => x.Prof == "Tempest" && x.InstID != item.SrcInstId).ToList();
                     List<CombatItem> magAuraApplications = log.GetBoonData(5684).Where(x => x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
                     foreach (Player tempest in tempests)
                     {

--- a/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
+++ b/LuckParser/Models/ParseModels/Players/AbstractMasterPlayer.cs
@@ -257,7 +257,7 @@ namespace LuckParser.Models.ParseModels
                     List<CombatItem> magAuraApplications = log.GetBoonData(5684).Where(x => x.IsBuffRemove == ParseEnum.BuffRemove.None).ToList();
                     foreach (Player tempest in tempests)
                     {
-                        if (magAuraApplications.FirstOrDefault(x => x.DstInstid == tempest.InstID && Math.Abs(x.Time - time) < 50) != null)
+                        if (magAuraApplications.FirstOrDefault(x => x.SrcInstid == tempest.InstID && Math.Abs(x.Time - time) < 50) != null)
                         {
                             return 0;
                         }


### PR DESCRIPTION
- Added Imbued Melodies management (check if a tempest other than the SQ caster has given out magnetic aura around the moment of extension, if yes return unknown)
- Added Soulbeast  trait management (only if self is Soulbeast and no tempest/herald are present in the squad)