### PR TITLE
Combat replay

### DIFF
--- a/LuckParser/Builders/HTMLBuilder.cs
+++ b/LuckParser/Builders/HTMLBuilder.cs
@@ -1850,7 +1850,6 @@ namespace LuckParser.Builders
             logData.success = _log.FightData.Success;
             logData.fightName = FilterStringChars(_log.FightData.Name);
             logData.fightIcon = _log.FightData.Logic.IconUrl;
-            logData.combatReplay = (_settings.ParseCombatReplay && _log.FightData.Logic.CanCombatReplay);
             logData.lightTheme = _settings.LightTheme;
             logData.singleGroup = _log.PlayerList.Where(x => x.Account != ":Conjured Sword").Select(x => x.Group).Distinct().Count() == 1;
             logData.noMechanics = _log.FightData.Logic.MechanicList.Count == 3;

--- a/LuckParser/Builders/Helpers/CombatReplayHelper.cs
+++ b/LuckParser/Builders/Helpers/CombatReplayHelper.cs
@@ -107,7 +107,7 @@ namespace LuckParser.Builders
                 }
             }
             string script = "var initialOnLoad = window.onload;";
-            script += "window.onload = function () { if (initialOnLoad) {initialOnLoad();} animator = new Animator(" + JsonConvert.SerializeObject(options)+", [" + actors + "]);};";
+            script += "window.onload = function () { if (initialOnLoad) {initialOnLoad();} animator = new Animator(" + JsonConvert.SerializeObject(options) + "); animator.initActors([" + actors + "]);};";
 #if !DEBUG
             script = Uglify.Js(script, GeneralHelper.JSMinifySettings).Code;
 #endif

--- a/LuckParser/Models/HtmlModels/LogDataDto.cs
+++ b/LuckParser/Models/HtmlModels/LogDataDto.cs
@@ -19,7 +19,6 @@ namespace LuckParser.Models.HtmlModels
         public bool success;
         public string fightName;
         public string fightIcon;
-        public bool combatReplay;
         public bool lightTheme;
         public bool noMechanics;
         public bool singleGroup;

--- a/LuckParser/Resources/JS/combatReplayStats.js
+++ b/LuckParser/Resources/JS/combatReplayStats.js
@@ -296,12 +296,12 @@ var compileCombatReplay = function () {
 
     Vue.component("combat-replay-damage-data-component", {
         template: `${tmplCombatReplayDamageData}`,
-        props: ["time"],
+        props: ["time", "selectedplayer", "selectedplayerid"],
         computed: {
             playerindex: function () {
-                if (animator.selectedPlayer) {
+                if (this.selectedplayer) {
                     for (var i = 0; i < logData.players.length; i++) {
-                        if (logData.players[i].combatReplayID == animator.selectedPlayerID) {
+                        if (logData.players[i].combatReplayID == this.selectedplayerid) {
                             return i;
                         }
                     }
@@ -313,7 +313,7 @@ var compileCombatReplay = function () {
 
     Vue.component("combat-replay-status-data-component", {
         template: `${tmplCombatReplayStatusData}`,
-        props: ["time"],
+        props: ["time", "selectedplayer", "selectedplayerid"],
         data: function() {
             return {
                 details: false
@@ -325,9 +325,9 @@ var compileCombatReplay = function () {
         },
         computed: {
             playerindex: function () {
-                if (animator.selectedPlayer) {
+                if (this.selectedplayer) {
                     for (var i = 0; i < logData.players.length; i++) {
-                        if (logData.players[i].combatReplayID == animator.selectedPlayerID) {
+                        if (logData.players[i].combatReplayID == this.selectedplayerid) {
                             return i;
                         }
                     }

--- a/LuckParser/Resources/JS/combatReplayStats.js
+++ b/LuckParser/Resources/JS/combatReplayStats.js
@@ -296,12 +296,12 @@ var compileCombatReplay = function () {
 
     Vue.component("combat-replay-damage-data-component", {
         template: `${tmplCombatReplayDamageData}`,
-        props: ["animator"],
+        props: ["time"],
         computed: {
             playerindex: function () {
-                if (this.animator.selectedPlayer) {
+                if (animator.selectedPlayer) {
                     for (var i = 0; i < logData.players.length; i++) {
-                        if (logData.players[i].combatReplayID == this.animator.selectedPlayerID) {
+                        if (logData.players[i].combatReplayID == animator.selectedPlayerID) {
                             return i;
                         }
                     }
@@ -313,17 +313,21 @@ var compileCombatReplay = function () {
 
     Vue.component("combat-replay-status-data-component", {
         template: `${tmplCombatReplayStatusData}`,
-        props: ["animator"],
+        props: ["time"],
         data: function() {
             return {
                 details: false
             };
         },
+        updated() {
+            animator.controlledByHTML = this.details;
+            animator.draw();
+        },
         computed: {
             playerindex: function () {
-                if (this.animator.selectedPlayer) {
+                if (animator.selectedPlayer) {
                     for (var i = 0; i < logData.players.length; i++) {
-                        if (logData.players[i].combatReplayID == this.animator.selectedPlayerID) {
+                        if (logData.players[i].combatReplayID == animator.selectedPlayerID) {
                             return i;
                         }
                     }

--- a/LuckParser/Resources/combatReplayLinkTemplates/tmplCombatReplayDamageData.html
+++ b/LuckParser/Resources/combatReplayLinkTemplates/tmplCombatReplayDamageData.html
@@ -1,4 +1,4 @@
-<div v-if="animator !== null" class="d-flex flex-column justify-content-center">
-    <combat-replay-damage-stats-component :time="animator.time" :playerindex="playerindex">
+<div class="d-flex flex-column justify-content-center">
+    <combat-replay-damage-stats-component :time="time" :playerindex="playerindex">
     </combat-replay-damage-stats-component>
 </div>

--- a/LuckParser/Resources/combatReplayLinkTemplates/tmplCombatReplayStatusData.html
+++ b/LuckParser/Resources/combatReplayLinkTemplates/tmplCombatReplayStatusData.html
@@ -1,4 +1,4 @@
-<div v-if="animator !== null" class="d-flex flex-column justify-content-center" style="min-width: 200px;">
+<div class="d-flex flex-column justify-content-center" style="min-width: 200px;">
     <ul class="nav nav-pills d-flex flex-row justify-content-center mb-1">
         <li class="nav-item">
             <a class="nav-link" :class="{active: details}" @click="details = !details">Details Window</a>
@@ -10,7 +10,7 @@
             <div class=" d-flex flex-column flex-wrap group-details">
                 <div v-for="player in group" class="player-data  ml-1 mr-1" :class="{active: playerindex === player.id}"
                      :key="id + '-group-' +  player.id">
-                    <combat-replay-player-stats-component :time="animator.time" :playerindex=" player.id"></combat-replay-player-stats-component>
+                    <combat-replay-player-stats-component :time="time" :playerindex="player.id"></combat-replay-player-stats-component>
                 </div>
             </div>
         </div>

--- a/LuckParser/Resources/combatReplayTemplates/tmplCombatReplay.html
+++ b/LuckParser/Resources/combatReplayTemplates/tmplCombatReplay.html
@@ -1,7 +1,7 @@
 <div class="d-flex mt-2 align-items-center">
     <div class="d-flex flex-column align-items-center mr-2" style="margin-left: auto;">
         <keep-alive>
-            <combat-replay-damage-data-component v-if="mode === 1" :animator="animator"></combat-replay-damage-data-component>
+            <combat-replay-damage-data-component v-if="mode === 1 && animator !== null" :time="animator.time"></combat-replay-damage-data-component>
         </keep-alive>
         <div class="d-flex flex-row flex-wrap justify-content-center align-items-start btn-group btn-group-toggle mb-2"
              data-toggle="buttons">
@@ -74,7 +74,7 @@
     </div>
     <div class="d-flex flex-column align-items-center ml-2" style="margin-right: auto;">
         <keep-alive>
-            <combat-replay-status-data-component v-if="mode === 1" :animator="animator"></combat-replay-status-data-component>
+            <combat-replay-status-data-component v-if="mode === 1 && animator !== null" :time="animator.time"></combat-replay-status-data-component>
         </keep-alive>
     </div>
 </div>

--- a/LuckParser/Resources/combatReplayTemplates/tmplCombatReplay.html
+++ b/LuckParser/Resources/combatReplayTemplates/tmplCombatReplay.html
@@ -1,7 +1,7 @@
 <div class="d-flex mt-2 align-items-center">
     <div class="d-flex flex-column align-items-center mr-2" style="margin-left: auto;">
         <keep-alive>
-            <combat-replay-damage-data-component v-if="mode === 1 && animator !== null" :time="animator.time"></combat-replay-damage-data-component>
+            <combat-replay-damage-data-component v-if="mode === 1 && animationStatus !== null" :time="animationStatus.time" :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID"></combat-replay-damage-data-component>
         </keep-alive>
         <div class="d-flex flex-row flex-wrap justify-content-center align-items-start btn-group btn-group-toggle mb-2"
              data-toggle="buttons">
@@ -74,7 +74,7 @@
     </div>
     <div class="d-flex flex-column align-items-center ml-2" style="margin-right: auto;">
         <keep-alive>
-            <combat-replay-status-data-component v-if="mode === 1 && animator !== null" :time="animator.time"></combat-replay-status-data-component>
+            <combat-replay-status-data-component v-if="mode === 1 && animationStatus !== null" :time="animationStatus.time" :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID"></combat-replay-status-data-component>
         </keep-alive>
     </div>
 </div>

--- a/LuckParser/Resources/combatreplay.js
+++ b/LuckParser/Resources/combatreplay.js
@@ -121,14 +121,13 @@ class Animator {
 
     updateTime(value) {
         this.time = parseInt(value);
-        this.updateTextInput();
         if (this.animation === null) {
             animateCanvas(-1);
         }
     }
 
-    updateTextInput(val) {
-        this.timeSliderDisplay.value = (val / 1000.0).toFixed(3);
+    updateTextInput() {
+        this.timeSliderDisplay.value = (this.time / 1000.0).toFixed(3);
     }
 
     updateInputTime(value) {
@@ -349,6 +348,21 @@ class Animator {
 }
 
 function animateCanvas(noRequest) {
+    let lastTime = animator.times[animator.times.length - 1];
+    if (noRequest > -1 && animator.animation !== null && bgLoaded) {
+        let curTime = new Date().getTime();
+        let timeOffset = curTime - animator.prevTime;
+        animator.prevTime = curTime;
+        animator.time = Math.round(Math.min(animator.time + animator.speed * timeOffset, lastTime));
+    }
+    if (animator.time === lastTime) {
+        animator.stopAnimate();
+    }
+    animator.timeSlider.value = animator.time.toString();
+    if (noRequest > -2) {
+        animator.updateTextInput();
+    }
+
     var ctx = animator.ctx;
     var canvas = animator.canvas;
     var p1 = ctx.transformedPoint(0, 0);
@@ -390,19 +404,7 @@ function animateCanvas(noRequest) {
             animator.attachedActorData.get(animator.selectedPlayerID).draw();
         }
     }
-    let lastTime = animator.times[animator.times.length - 1];
-    if (animator.time === lastTime) {
-        animator.stopAnimate();
-    }
-    animator.timeSlider.value = animator.time.toString();
-    if (noRequest !== -2) {
-        animator.updateTextInput(animator.time);
-    }
     if (noRequest > -1 && animator.animation !== null && bgLoaded) {
-        let curTime = new Date().getTime();
-        let timeOffset = curTime - animator.prevTime;
-        animator.prevTime = curTime;
-        animator.time = Math.round(Math.min(animator.time + animator.speed * timeOffset, lastTime));
         animator.animation = requestAnimationFrame(animateCanvas);
     }
 }

--- a/LuckParser/Resources/combatreplay.js
+++ b/LuckParser/Resources/combatreplay.js
@@ -17,7 +17,7 @@ const resolutionMultiplier = 2;
 var animator = null;
 
 class Animator {
-    constructor(options, actors) {
+    constructor(options) {
         // time
         this.prevTime = 0;
         this.time = 0;
@@ -41,13 +41,14 @@ class Animator {
         this.timeSlider = document.getElementById('timeRange');
         this.timeSliderDisplay = document.getElementById('timeRangeDisplay');
         this.canvas = document.getElementById('replayCanvas');
-        this.canvas.style.width = this.canvas.width +"px";
-        this.canvas.style.height = this.canvas.height +"px";
+        this.canvas.style.width = this.canvas.width + "px";
+        this.canvas.style.height = this.canvas.height + "px";
         this.canvas.width *= resolutionMultiplier;
         this.canvas.height *= resolutionMultiplier;
         this.ctx = this.canvas.getContext('2d');
         this.ctx.imageSmoothingEnabled = true;
         this.ctx.imageSmoothingQuality = "high";
+        this.controlledByHTML = false;
         // manipulation
         this.lastX = this.canvas.width / 2;
         this.lastY = this.canvas.height / 2;
@@ -60,15 +61,14 @@ class Animator {
             if (options.mapLink) bgImage.src = options.mapLink;
         }
         //
-        this.rangeControl.set(this.inch * 180, false);
-        this.rangeControl.set(this.inch * 240, false);
-        this.rangeControl.set(this.inch * 300, false);
-        this.rangeControl.set(this.inch * 600, false);
-        this.rangeControl.set(this.inch * 900, false);
-        this.rangeControl.set(this.inch * 1200, false);
+        this.rangeControl.set(180, false);
+        this.rangeControl.set(240, false);
+        this.rangeControl.set(300, false);
+        this.rangeControl.set(600, false);
+        this.rangeControl.set(900, false);
+        this.rangeControl.set(1200, false);
         this.trackTransforms();
         this.ctx.scale(resolutionMultiplier, resolutionMultiplier);
-        this.initActors(actors);
         this.initMouseEvents();
         this.initTouchEvents();
         if (typeof mainComponent !== "undefined" && mainComponent !== null) {
@@ -77,6 +77,11 @@ class Animator {
     }
 
     initActors(actors) {
+        this.playerData.clear();
+        this.targetData.clear();
+        this.trashMobData.clear();
+        this.attachedActorData.clear();
+        this.mechanicActorData = [];
         for (let i = 0; i < actors.length; i++) {
             const actor = actors[i];
             switch (actor.Type) {
@@ -95,19 +100,19 @@ class Animator {
                     this.trashMobData.set(actor.ID, new EnemyIconDrawable(actor.Start, actor.End, actor.Img, 25, actor.Positions));
                     break;
                 case "Circle":
-                    this.mechanicActorData.push(new CircleMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Radius, actor.ConnectedTo, actor.MinRadius, this.inch));
+                    this.mechanicActorData.push(new CircleMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Radius, actor.ConnectedTo, actor.MinRadius));
                     break;
                 case "Rectangle":
-                    this.mechanicActorData.push(new RectangleMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Width, actor.Height, actor.ConnectedTo, this.inch));
+                    this.mechanicActorData.push(new RectangleMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Width, actor.Height, actor.ConnectedTo));
                     break;
                 case "RotatedRectangle":
-                    this.mechanicActorData.push(new RotatedRectangleMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Width, actor.Height, actor.Rotation, actor.RadialTranslation, actor.SpinAngle, actor.ConnectedTo, this.inch));
+                    this.mechanicActorData.push(new RotatedRectangleMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Width, actor.Height, actor.Rotation, actor.RadialTranslation, actor.SpinAngle, actor.ConnectedTo));
                     break;
                 case "Doughnut":
-                    this.mechanicActorData.push(new DoughnutMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.InnerRadius, actor.OuterRadius, actor.ConnectedTo, this.inch));
+                    this.mechanicActorData.push(new DoughnutMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.InnerRadius, actor.OuterRadius, actor.ConnectedTo));
                     break;
                 case "Pie":
-                    this.mechanicActorData.push(new PieMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Direction, actor.OpeningAngle, actor.Radius, actor.ConnectedTo, this.inch));
+                    this.mechanicActorData.push(new PieMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.Direction, actor.OpeningAngle, actor.Radius, actor.ConnectedTo));
                     break;
                 case "Line":
                     this.mechanicActorData.push(new LineMechanicDrawable(actor.Start, actor.End, actor.Fill, actor.Growing, actor.Color, actor.ConnectedFrom, actor.ConnectedTo));
@@ -192,7 +197,7 @@ class Animator {
         });
         if (this.animation === null) {
             animateCanvas(-1);
-        }           
+        }
     }
 
     initMouseEvents() {
@@ -206,7 +211,7 @@ class Animator {
             _this.dragStart = null;
             _this.dragged = false;
             ctx.setTransform(1, 0, 0, 1, 0, 0);
-            ctx.scale(resolutionMultiplier, resolutionMultiplier);         
+            ctx.scale(resolutionMultiplier, resolutionMultiplier);
             if (_this.animation === null) {
                 animateCanvas(-1);
             }
@@ -264,7 +269,7 @@ class Animator {
     }
 
     toggleRange(radius) {
-        this.rangeControl.set(this.inch * radius, !this.rangeControl.get(this.inch * radius));
+        this.rangeControl.set(radius, !this.rangeControl.get(radius));
         if (this.animation === null) {
             animateCanvas(-1);
         }
@@ -345,6 +350,51 @@ class Animator {
             return pt.matrixTransform(xform.inverse());
         };
     }
+    // animation
+    draw() {
+        var _this = this;
+        var ctx = this.ctx;
+        var canvas = this.canvas;
+        var p1 = ctx.transformedPoint(0, 0);
+        var p2 = ctx.transformedPoint(canvas.width, canvas.height);
+        ctx.clearRect(p1.x, p1.y, p2.x - p1.x, p2.y - p1.y);
+
+        ctx.save();
+        ctx.setTransform(1, 0, 0, 1, 0, 0);
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.restore();
+        //
+        ctx.drawImage(bgImage, 0, 0, canvas.width / resolutionMultiplier, canvas.height / resolutionMultiplier);
+        for (let i = 0; i < this.mechanicActorData.length; i++) {
+            this.mechanicActorData[i].draw();
+        }
+        this.playerData.forEach(function (value, key, map) {
+            if (!value.selected) {
+                value.draw();
+                if (_this.attachedActorData.has(key)) {
+                    _this.attachedActorData.get(key).draw();
+                }
+            }
+        });
+        this.trashMobData.forEach(function (value, key, map) {
+            value.draw();
+            if (_this.attachedActorData.has(key)) {
+                _this.attachedActorData.get(key).draw();
+            }
+        });
+        this.targetData.forEach(function (value, key, map) {
+            value.draw();
+            if (_this.attachedActorData.has(key)) {
+                _this.attachedActorData.get(key).draw();
+            }
+        });
+        if (this.selectedPlayer !== null) {
+            this.selectedPlayer.draw();
+            if (this.attachedActorData.has(this.selectedPlayerID)) {
+                this.attachedActorData.get(this.selectedPlayerID).draw();
+            }
+        }
+    }
 }
 
 function animateCanvas(noRequest) {
@@ -362,47 +412,8 @@ function animateCanvas(noRequest) {
     if (noRequest > -2) {
         animator.updateTextInput();
     }
-
-    var ctx = animator.ctx;
-    var canvas = animator.canvas;
-    var p1 = ctx.transformedPoint(0, 0);
-    var p2 = ctx.transformedPoint(canvas.width, canvas.height);
-    ctx.clearRect(p1.x, p1.y, p2.x - p1.x, p2.y - p1.y);
-
-    ctx.save();
-    ctx.setTransform(1, 0, 0, 1, 0, 0);
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.restore();
-    //
-    ctx.drawImage(bgImage, 0, 0, canvas.width / resolutionMultiplier, canvas.height / resolutionMultiplier);
-    for (let i = 0; i < animator.mechanicActorData.length; i++) {
-        animator.mechanicActorData[i].draw();
-    }
-    animator.playerData.forEach(function (value, key, map) {
-        if (!value.selected) {
-            value.draw();
-            if (animator.attachedActorData.has(key)) {
-                animator.attachedActorData.get(key).draw();
-            }
-        }
-    });
-    animator.trashMobData.forEach(function (value, key, map) {
-        value.draw();
-        if (animator.attachedActorData.has(key)) {
-            animator.attachedActorData.get(key).draw();
-        }
-    });
-    animator.targetData.forEach(function (value, key, map) {
-        value.draw();
-        if (animator.attachedActorData.has(key)) {
-            animator.attachedActorData.get(key).draw();
-        }
-    });
-    if (animator.selectedPlayer !== null) {
-        animator.selectedPlayer.draw();
-        if (animator.attachedActorData.has(animator.selectedPlayerID)) {
-            animator.attachedActorData.get(animator.selectedPlayerID).draw();
-        }
+    if (!animator.controlledByHTML || noRequest < 0) {
+        animator.draw();
     }
     if (noRequest > -1 && animator.animation !== null && bgLoaded) {
         animator.animation = requestAnimationFrame(animateCanvas);
@@ -475,8 +486,8 @@ class IconDrawable {
             pt.x = positionX;
             pt.y = positionY;
         }
-        pt.x = Math.round(10*pt.x * animator.scale) / (10*animator.scale);
-        pt.y = Math.round(10*pt.y * animator.scale) / (10*animator.scale);
+        pt.x = Math.round(10 * pt.x * animator.scale) / (10 * animator.scale);
+        pt.y = Math.round(10 * pt.y * animator.scale) / (10 * animator.scale);
         return pt;
     }
 
@@ -496,11 +507,11 @@ class IconDrawable {
         const lastTime = animator.times[animator.times.length - 1];
         const startIndex = Math.ceil((animator.times.length - 1) * Math.max(this.start, 0) / lastTime);
         const currentIndex = Math.floor((animator.times.length - 1) * animator.time / lastTime);
-        return this.getInterpolatedPosition(startIndex, Math.max(currentIndex, startIndex), animator.time);
+        return this.getInterpolatedPosition(startIndex, Math.max(currentIndex, startIndex));
     }
 
     draw() {
-        const pos = this.getPosition(animator.time, animator.times);
+        const pos = this.getPosition();
         if (pos === null) {
             return;
         }
@@ -532,7 +543,7 @@ class PlayerIconDrawable extends IconDrawable {
         const halfSize = fullSize / 2;
         if (!this.selected && this.group === animator.selectedGroup) {
             ctx.beginPath();
-            ctx.lineWidth = (2/animator.scale).toString();
+            ctx.lineWidth = (2 / animator.scale).toString();
             ctx.strokeStyle = 'blue';
             ctx.rect(pos.x - halfSize, pos.y - halfSize, fullSize, fullSize);
             ctx.stroke();
@@ -547,7 +558,7 @@ class PlayerIconDrawable extends IconDrawable {
                 ctx.beginPath();
                 ctx.lineWidth = (2 / animator.scale).toString();
                 ctx.strokeStyle = 'green';
-                ctx.arc(pos.x, pos.y, radius, 0, 2 * Math.PI);
+                ctx.arc(pos.x, pos.y, animator.inch * radius, 0, 2 * Math.PI);
                 ctx.stroke();
             });
         }
@@ -639,13 +650,13 @@ class FacingMechanicDrawable extends MechanicDrawable {
         this.facingData = facingData;
     }
 
-    getRotation(time) {
+    getRotation() {
         if (this.facingData.length === 0) {
             return null;
         }
         var rot = this.facingData[0][0];
         for (let i = 1; i < this.facingData.length; i++) {
-            if (time < this.facingData[i][1] - 150) {
+            if (animator.time < this.facingData[i][1] - 150) {
                 break;
             } else {
                 rot = this.facingData[i][0];
@@ -656,7 +667,7 @@ class FacingMechanicDrawable extends MechanicDrawable {
 
     draw() {
         const pos = this.getPosition();
-        const rot = this.getRotation(animator.time);
+        const rot = this.getRotation();
         if (pos === null || rot === null) {
             return;
         }
@@ -665,7 +676,7 @@ class FacingMechanicDrawable extends MechanicDrawable {
         ctx.save();
         ctx.translate(pos.x, pos.y);
         ctx.rotate(angle);
-        const facingFullSize = 5*this.master.pixelSize / (3*animator.scale);
+        const facingFullSize = 5 * this.master.pixelSize / (3 * animator.scale);
         const facingHalfSize = facingFullSize / 2;
         ctx.drawImage(facingIcon, -facingHalfSize, -facingHalfSize, facingFullSize, facingFullSize);
         ctx.restore();
@@ -689,10 +700,10 @@ class FormMechanicDrawable extends MechanicDrawable {
 }
 
 class CircleMechanicDrawable extends FormMechanicDrawable {
-    constructor(start, end, fill, growing, color, radius, connectedTo, minRadius, inch) {
+    constructor(start, end, fill, growing, color, radius, connectedTo, minRadius) {
         super(start, end, fill, growing, color, connectedTo);
-        this.radius = inch * radius;
-        this.minRadius = inch * minRadius;
+        this.radius = animator.inch * radius;
+        this.minRadius = animator.inch * minRadius;
     }
 
     draw() {
@@ -715,10 +726,10 @@ class CircleMechanicDrawable extends FormMechanicDrawable {
 }
 
 class DoughnutMechanicDrawable extends FormMechanicDrawable {
-    constructor(start, end, fill, growing, color, innerRadius, outerRadius, connectedTo, inch) {
+    constructor(start, end, fill, growing, color, innerRadius, outerRadius, connectedTo) {
         super(start, end, fill, growing, color, connectedTo);
-        this.outerRadius = inch * outerRadius;
-        this.innerRadius = inch * innerRadius;
+        this.outerRadius = animator.inch * outerRadius;
+        this.innerRadius = animator.inch * innerRadius;
     }
 
     draw() {
@@ -744,10 +755,10 @@ class DoughnutMechanicDrawable extends FormMechanicDrawable {
 }
 
 class RectangleMechanicDrawable extends FormMechanicDrawable {
-    constructor(start, end, fill, growing, color, width, height, connectedTo, inch) {
+    constructor(start, end, fill, growing, color, width, height, connectedTo) {
         super(start, end, fill, growing, color, connectedTo);
-        this.height = height * inch;
-        this.width = width * inch;
+        this.height = height * animator.inch;
+        this.width = width * animator.inch;
     }
 
     draw() {
@@ -771,10 +782,10 @@ class RectangleMechanicDrawable extends FormMechanicDrawable {
 }
 
 class RotatedRectangleMechanicDrawable extends RectangleMechanicDrawable {
-    constructor(start, end, fill, growing, color, width, height, rotation, translation, spinangle, connectedTo, inch) {
-        super(start, end, fill, growing, color, width, height, connectedTo, inch);
+    constructor(start, end, fill, growing, color, width, height, rotation, translation, spinangle, connectedTo) {
+        super(start, end, fill, growing, color, width, height, connectedTo);
         this.rotation = -rotation * Math.PI / 180; // positive mathematical direction, reversed since JS has downwards increasing y axis
-        this.translation = translation * inch;
+        this.translation = translation * animator.inch;
         this.spinangle = -spinangle * Math.PI / 180; // positive mathematical direction, reversed since JS has downwards increasing y axis
     }
 
@@ -816,11 +827,11 @@ class RotatedRectangleMechanicDrawable extends RectangleMechanicDrawable {
 }
 
 class PieMechanicDrawable extends FormMechanicDrawable {
-    constructor(start, end, fill, growing, color, direction, openingAngle, radius, connectedTo, inch) {
+    constructor(start, end, fill, growing, color, direction, openingAngle, radius, connectedTo) {
         super(start, end, fill, growing, color, connectedTo);
         this.direction = -direction * Math.PI / 180; // positive mathematical direction, reversed since JS has downwards increasing y axis
         this.openingAngle = 0.5 * openingAngle * Math.PI / 180;
-        this.radius = inch * radius;
+        this.radius = animator.inch * radius;
         this.dx = Math.cos(this.direction - this.openingAngle) * this.radius;
         this.dy = Math.sin(this.direction - this.openingAngle) * this.radius;
     }
@@ -879,7 +890,6 @@ class LineMechanicDrawable extends FormMechanicDrawable {
     draw() {
         const pos = this.getPosition();
         const target = this.getTargetPosition();
-
         if (pos === null || target === null) {
             return;
         }

--- a/LuckParser/Resources/ei.js
+++ b/LuckParser/Resources/ei.js
@@ -54,7 +54,7 @@ window.onload = function () {
     compileGraphs();
     compilePlayerTab();
     compileTargetTab();
-    if (logData.combatReplay) {
+    if (typeof compileCombatReplay !== "undefined") {
         compileCombatReplay();
     }
     mainComponent = new Vue({
@@ -63,17 +63,16 @@ window.onload = function () {
             logdata: simpleLogData,
             layout: layout,
             datatypes: DataTypes,
-            combatreplay: logData.combatReplay,
             light: logData.lightTheme,
             mode: 0,
             animate: false,
             animationStatus: null
         },
         methods: {
-            switchCombatReplayButtons: function(from, to) {          
+            switchCombatReplayButtons: function (from, to) {
                 var combatReplay = $('#combat-replay');
                 if (combatReplay) {
-                    var buttons = combatReplay.find('.'+from);
+                    var buttons = combatReplay.find('.' + from);
                     buttons.addClass(to).removeClass(from);
                 }
             },
@@ -87,8 +86,8 @@ window.onload = function () {
                 document.body.classList.remove("theme-"+style);
                 document.body.classList.add("theme-"+newStyle);
                 var theme = document.getElementById('theme');
-                theme.href = themes[newStyle];              
-                this.switchCombatReplayButtons(this.light ? 'btn-dark' : 'btn-light', this.light ? 'btn-light' : 'btn-dark');
+                theme.href = themes[newStyle];
+                this.switchCombatReplayButtons(this.light ? 'btn-dark' : 'btn-light', this.light ? 'btn-light' : 'btn-dark');     
             },
             changeMode: function(iMode) {
                 if (this.mode === iMode) {

--- a/LuckParser/Resources/ei.js
+++ b/LuckParser/Resources/ei.js
@@ -67,7 +67,7 @@ window.onload = function () {
             light: logData.lightTheme,
             mode: 0,
             animate: false,
-            animator: null
+            animationStatus: null
         },
         methods: {
             switchCombatReplayButtons: function(from, to) {          
@@ -105,6 +105,9 @@ window.onload = function () {
             },
         },
         computed: {
+            animator: function () {
+                return this.animationStatus ? animator : null;
+            },
             activePhase: function () {
                 var phases = this.logdata.phases;
                 for (var i = 0; i < phases.length; i++) {

--- a/LuckParser/Resources/template.html
+++ b/LuckParser/Resources/template.html
@@ -53,7 +53,7 @@
                         </li>
                     </ul>
                 </div>
-                <div v-if="combatreplay">
+                <div v-if="animationStatus">
                     <ul class="nav nav-pills flex-column justify-content-center d-flex align-items-center">
                         <li class="nav-item mb-1">
                             <a class="nav-link" @click="changeMode(0)" :class="{active: !mode}">Statistics</a>

--- a/LuckParser/Resources/template.html
+++ b/LuckParser/Resources/template.html
@@ -72,7 +72,7 @@
                 </div>
                 <div class="d-flex flex-row justify-content-center mb-3 mt-3" id="actors">
                     <div v-show="dataType !== datatypes.targetTab" :class="{'d-flex':dataType !== datatypes.targetTab}"
-                        id="targets" class="flex-row justify-content-center align-items-center flex-wrap mr-5">
+                         id="targets" class="flex-row justify-content-center align-items-center flex-wrap mr-5">
                         <target-component :targets="logdata.targets" :phaseindex="activePhase"></target-component>
                     </div>
                     <div id="players" class="ml-5">
@@ -83,41 +83,40 @@
                 </general-layout-component>
                 <keep-alive>
                     <damage-stats-component v-if="dataType === datatypes.damageTable" :key="'damage'" :phaseindex="activePhase"
-                        :playerindex="activePlayer" :activetargets="activePhaseTargets"></damage-stats-component>
+                                            :playerindex="activePlayer" :activetargets="activePhaseTargets"></damage-stats-component>
                     <gameplay-stats-component v-if="dataType === datatypes.gameplayTable" :key="'gameplay'" :phaseindex="activePhase"
-                        :playerindex="activePlayer" :activetargets="activePhaseTargets"></gameplay-stats-component>
+                                              :playerindex="activePlayer" :activetargets="activePhaseTargets"></gameplay-stats-component>
                     <dmgmodifier-stats-component v-if="dataType === datatypes.dmgModifiersTable" :key="'modifier'"
-                        :phaseindex="activePhase" :playerindex="activePlayer" :activetargets="activePhaseTargets"></dmgmodifier-stats-component>
+                                                 :phaseindex="activePhase" :playerindex="activePlayer" :activetargets="activePhaseTargets"></dmgmodifier-stats-component>
                     <support-stats-component v-if="dataType === datatypes.supTable" :key="'support'" :phaseindex="activePhase"
-                        :playerindex="activePlayer"></support-stats-component>
+                                             :playerindex="activePlayer"></support-stats-component>
                     <defense-stats-component v-if="dataType === datatypes.defTable" :key="'defense'" :phaseindex="activePhase"
-                        :playerindex="activePlayer"></defense-stats-component>
+                                             :playerindex="activePlayer"></defense-stats-component>
                     <graph-stats-component v-if="dataType === datatypes.dpsGraph" :key="'graph'" :activetargets="activePhaseTargets"
-                        :phaseindex="activePhase" :playerindex="activePlayer" :light="light"></graph-stats-component>
+                                           :phaseindex="activePhase" :playerindex="activePlayer" :light="light"></graph-stats-component>
                     <buff-stats-component v-if="dataType <= datatypes.defensiveBuffTable && dataType>= datatypes.boonTable"
-                        :key="'buffs'" :datatypes="datatypes" :datatype="dataType" :phaseindex="activePhase"
-                        :playerindex="activePlayer"></buff-stats-component>
+                                          :key="'buffs'" :datatypes="datatypes" :datatype="dataType" :phaseindex="activePhase"
+                                          :playerindex="activePlayer"></buff-stats-component>
                     <personal-buff-table-component v-if="dataType === datatypes.personalBuffTable" :key="'persbuffs'"
-                        :phaseindex="activePhase" :persbuffs="logdata.persBuffs" :playerindex="activePlayer"></personal-buff-table-component>
+                                                   :phaseindex="activePhase" :persbuffs="logdata.persBuffs" :playerindex="activePlayer"></personal-buff-table-component>
                     <mechanics-stats-component v-if="dataType === datatypes.mechanicTable" :key="'mechanics'"
-                        :phaseindex="activePhase" :playerindex="activePlayer"></mechanics-stats-component>
+                                               :phaseindex="activePhase" :playerindex="activePlayer"></mechanics-stats-component>
                     <target-stats-component v-if="dataType === datatypes.targetTab" :key="'targets'" :playerindex="activePlayer"
-                        :simplephase="logdata.phases[activePhase]" :phaseindex="activePhase" :light="light"></target-stats-component>
+                                            :simplephase="logdata.phases[activePhase]" :phaseindex="activePhase" :light="light"></target-stats-component>
                     <player-stats-component v-if="dataType === datatypes.playerTab" :key="'players'" :activeplayer="activePlayer"
-                        :phaseindex="activePhase" :activetargets="activePhaseTargets" :light="light"></player-stats-component>
+                                            :phaseindex="activePhase" :activetargets="activePhaseTargets" :light="light"></player-stats-component>
                 </keep-alive>
             </div>
         </div>
         <div id="combat-replay" v-show="mode === 1" class="ei-container-big">
             <!--${CombatReplayBody}-->
         </div>
-    </div>
-
-    <div class="footer">
-        <div>Time Start: ${encounterStart} | Time End: ${encounterEnd}</div>
-        <div>ARC: ${evtcVersion} | Fight ID: ${fightID} | EI Version: ${eiVersion}</div>
-        <div class="mb-2">File recorded by: ${recordedBy}</div>
-        <!--${UploadLinks}-->
+        <div class="footer" :class="{'ei-header': !mode, 'ei-header-big': mode}">
+            <div>Time Start: ${encounterStart} | Time End: ${encounterEnd}</div>
+            <div>ARC: ${evtcVersion} | Fight ID: ${fightID} | EI Version: ${eiVersion}</div>
+            <div class="mb-2">File recorded by: ${recordedBy}</div>
+            <!--${UploadLinks}-->
+        </div>
     </div>
 </body>
 


### PR DESCRIPTION
- Some layout fixes as is tradition
- Some refactoring in the combat replay js code
- Added controlled by html flag to combat replay, this one is set to true by the details window when enabled. The animation will continue as usual but the drawing will be done by the details window component when it has been updated. Before the pipeline was hardcoded as request -> update time -> draw -> update html components, with this we can have request -> update time -> update components -> draw. I did this because if we want the buff highlight and skill range on hover functionality we need to make sure that part is done before the drawing else we'll have a single frame delay