### PR TITLE
added skills from downed and transformed states to AA flag

### DIFF
--- a/LuckParser/Models/ParseModels/SkillItem.cs
+++ b/LuckParser/Models/ParseModels/SkillItem.cs
@@ -62,7 +62,7 @@ namespace LuckParser.Models.ParseModels
         // Fields
         public long ID { get; private set; }
         public int Range { get; private set; } = 0;
-        public bool AA => _apiSkill?.Slot == "Weapon_1";
+        public bool AA => _apiSkill?.Slot == "Weapon_1" || _apiSkill?.Slot == "Downed_1";
         public string Name { get; private set; }
         public string Icon { get; private set; }
         private GW2APISkill _apiSkill;


### PR DESCRIPTION
The downed state and also some transformations, such as holoforge, pets or shroud are marked as DOWNED_1 instead of WEAPON_1.

This pull requests aims to add them to the AA flag to have them hidden when the simple rotation flag "show auto attacks" is deactivated.