### PR TITLE
Damage modifiers 2

### DIFF
--- a/LuckParser/Models/HtmlModels/DamageModData.cs
+++ b/LuckParser/Models/HtmlModels/DamageModData.cs
@@ -33,7 +33,7 @@ namespace LuckParser.Models.HtmlModels
                         0,
                         dMod.GetDamageLogs(player, log, null, phases[phaseIndex]).Count,
                         0,
-                        dMod.Multiplier ? dMod.GetTotalDamage(player, log, null, phases[phaseIndex]) : 0
+                        dMod.Multiplier ? dMod.GetTotalDamage(player, log, null, phaseIndex) : 0
                     });
                 }
             }
@@ -63,7 +63,7 @@ namespace LuckParser.Models.HtmlModels
                             0,
                             dMod.GetDamageLogs(player, log, target, phases[phaseIndex]).Count,
                             0,
-                            dMod.Multiplier ? dMod.GetTotalDamage(player, log, target, phases[phaseIndex]) : 0
+                            dMod.Multiplier ? dMod.GetTotalDamage(player, log, target, phaseIndex) : 0
                         });
                     }
                 }

--- a/LuckParser/Models/HtmlModels/DamageModData.cs
+++ b/LuckParser/Models/HtmlModels/DamageModData.cs
@@ -13,6 +13,7 @@ namespace LuckParser.Models.HtmlModels
         public DamageModData(Player player, ParsedLog log, List<DamageModifier> listToUse, int phaseIndex)
         {
             Dictionary<string, List<Statistics.DamageModifierData>> dModData = player.GetDamageModifierData(log, null);
+            List<PhaseData> phases = log.FightData.GetPhases(log);
             foreach (DamageModifier dMod in listToUse)
             {
                 if (dModData.TryGetValue(dMod.Name, out var list))
@@ -30,9 +31,9 @@ namespace LuckParser.Models.HtmlModels
                     Data.Add(new object[]
                     {
                         0,
+                        dMod.GetDamageLogs(player, log, null, phases[phaseIndex]).Count,
                         0,
-                        0,
-                        0
+                        dMod.Multiplier ? dMod.GetTotalDamage(player, log, null, phases[phaseIndex]) : 0
                     });
                 }
             }
@@ -60,9 +61,9 @@ namespace LuckParser.Models.HtmlModels
                         pTarget.Add(new object[]
                         {
                             0,
+                            dMod.GetDamageLogs(player, log, target, phases[phaseIndex]).Count,
                             0,
-                            0,
-                            0
+                            dMod.Multiplier ? dMod.GetTotalDamage(player, log, target, phases[phaseIndex]) : 0
                         });
                     }
                 }

--- a/LuckParser/Models/JsonModels/JsonBuffDamageModifierData.cs
+++ b/LuckParser/Models/JsonModels/JsonBuffDamageModifierData.cs
@@ -24,7 +24,7 @@ namespace LuckParser.Models.JsonModels
             /// <summary>
             /// Gained damage
             /// </summary>
-            public int DamageGain;
+            public double DamageGain;
             /// <summary>
             /// Total damage done
             /// </summary>

--- a/LuckParser/Models/JsonModels/JsonStatistics.cs
+++ b/LuckParser/Models/JsonModels/JsonStatistics.cs
@@ -118,6 +118,30 @@ namespace LuckParser.Models.JsonModels
             /// Total power damage
             /// </summary>
             public int PowerDamage;
+            /// <summary>
+            /// Total actor only dps
+            /// </summary>
+            public int ActorDps;
+            /// <summary>
+            /// Total actor only damage
+            /// </summary>
+            public int ActorDamage;
+            /// <summary>
+            /// Total actor only condi dps
+            /// </summary>
+            public int ActorCondiDps;
+            /// <summary>
+            /// Total actor only condi damage
+            /// </summary>
+            public int ActorCondiDamage;
+            /// <summary>
+            /// Total actor only power dps
+            /// </summary>
+            public int ActorPowerDps;
+            /// <summary>
+            /// Total actor only power damage
+            /// </summary>
+            public int ActorPowerDamage;
 
             public JsonDPS(Statistics.FinalDPS stats)
             {
@@ -127,6 +151,13 @@ namespace LuckParser.Models.JsonModels
                 CondiDamage = stats.CondiDamage;
                 PowerDps = stats.PowerDps;
                 PowerDamage = stats.PowerDamage;
+
+                ActorDps = stats.ActorDps;
+                ActorDamage = stats.ActorDamage;
+                ActorCondiDps = stats.ActorCondiDps;
+                ActorCondiDamage = stats.ActorCondiDamage;
+                ActorPowerDps = stats.ActorPowerDps;
+                ActorPowerDamage = stats.ActorPowerDamage;
             }
 
         }

--- a/LuckParser/Models/ParseModels/Actors/AbstractMasterActor.cs
+++ b/LuckParser/Models/ParseModels/Actors/AbstractMasterActor.cs
@@ -240,7 +240,7 @@ namespace LuckParser.Models.ParseModels
             }
             if (!targetDict.TryGetValue(target??GeneralHelper.NullActor, out List<DamageLog> dls))
             {
-                dls = GetDamageLogs(target, log, phase);
+                dls = GetDamageLogs(target, log, phase).Where(x => x.SrcInstId == InstID).ToList();
                 targetDict[target ?? GeneralHelper.NullActor] = dls;
             }
             return dls;

--- a/LuckParser/Models/ParseModels/Actors/AbstractMasterActor.cs
+++ b/LuckParser/Models/ParseModels/Actors/AbstractMasterActor.cs
@@ -186,6 +186,32 @@ namespace LuckParser.Models.ParseModels
             }
             final.PowerDps = (int)Math.Round(dps);
             final.PowerDamage = damage;
+            // Actor DPS
+            damage = GetJustPlayerDamageLogs(target, log, phase).Sum(x => x.Damage);
+
+            if (phaseDuration > 0)
+            {
+                dps = damage / phaseDuration;
+            }
+            final.ActorDps = (int)Math.Round(dps);
+            final.ActorDamage = damage;
+            //Actor Condi DPS
+            damage = GetJustPlayerDamageLogs(target, log, phase).Sum(x => x.IsCondi ? x.Damage : 0);
+
+            if (phaseDuration > 0)
+            {
+                dps = damage / phaseDuration;
+            }
+            final.ActorCondiDps = (int)Math.Round(dps);
+            final.ActorCondiDamage = damage;
+            //Actor Power DPS
+            damage = final.ActorDamage - final.ActorCondiDamage;
+            if (phaseDuration > 0)
+            {
+                dps = damage / phaseDuration;
+            }
+            final.ActorPowerDps = (int)Math.Round(dps);
+            final.ActorPowerDamage = damage;
             return final;
         }
 

--- a/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifier.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifier.cs
@@ -75,7 +75,7 @@ namespace LuckParser.Models.ParseModels
                         int totalDamage = GetTotalDamage(p, log, target, phases[i]);
                         List<DamageLog> typeHits = GetDamageLogs(p, log, target, phases[i]);
                         List<double> damages = typeHits.Select(x => ComputeGain(BuffsChecker.GetStack(bgms, x.Time), x)).Where(x => x != -1.0).ToList();
-                        extraDataList.Add(new DamageModifierData(damages.Count, typeHits.Count, (int)Math.Round(damages.Sum()), totalDamage));
+                        extraDataList.Add(new DamageModifierData(damages.Count, typeHits.Count, damages.Sum(), totalDamage));
                     }
                     dict[Name] = extraDataList;
                 }
@@ -86,7 +86,7 @@ namespace LuckParser.Models.ParseModels
                 int totalDamage = GetTotalDamage(p, log, null, phases[i]);
                 List<DamageLog> typeHits = GetDamageLogs(p, log, null, phases[i]);
                 List<double> damages = typeHits.Select(x => ComputeGain(BuffsChecker.GetStack(bgms, x.Time), x)).Where(x => x != -1.0).ToList();
-                data[Name].Add(new DamageModifierData(damages.Count, typeHits.Count, (int)Math.Round(damages.Sum()), totalDamage));
+                data[Name].Add(new DamageModifierData(damages.Count, typeHits.Count, damages.Sum(), totalDamage));
             }
         }
     }

--- a/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifier.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifier.cs
@@ -72,7 +72,7 @@ namespace LuckParser.Models.ParseModels
                     List<DamageModifierData> extraDataList = new List<DamageModifierData>();
                     for (int i = 0; i < phases.Count; i++)
                     {
-                        int totalDamage = GetTotalDamage(p, log, target, phases[i]);
+                        int totalDamage = GetTotalDamage(p, log, target, i);
                         List<DamageLog> typeHits = GetDamageLogs(p, log, target, phases[i]);
                         List<double> damages = typeHits.Select(x => ComputeGain(BuffsChecker.GetStack(bgms, x.Time), x)).Where(x => x != -1.0).ToList();
                         extraDataList.Add(new DamageModifierData(damages.Count, typeHits.Count, damages.Sum(), totalDamage));
@@ -83,7 +83,7 @@ namespace LuckParser.Models.ParseModels
             data[Name] = new List<DamageModifierData>();
             for (int i = 0; i < phases.Count; i++)
             {
-                int totalDamage = GetTotalDamage(p, log, null, phases[i]);
+                int totalDamage = GetTotalDamage(p, log, null, i);
                 List<DamageLog> typeHits = GetDamageLogs(p, log, null, phases[i]);
                 List<double> damages = typeHits.Select(x => ComputeGain(BuffsChecker.GetStack(bgms, x.Time), x)).Where(x => x != -1.0).ToList();
                 data[Name].Add(new DamageModifierData(damages.Count, typeHits.Count, damages.Sum(), totalDamage));

--- a/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifierTarget.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifierTarget.cs
@@ -55,7 +55,7 @@ namespace LuckParser.Models.ParseModels
                     List<DamageModifierData> extraDataList = new List<DamageModifierData>();
                     for (int i = 0; i < phases.Count; i++)
                     {
-                        int totalDamage = GetTotalDamage(p, log, target, phases[i]);
+                        int totalDamage = GetTotalDamage(p, log, target, i);
                         List<DamageLog> typedHits = GetDamageLogs(p, log, target, phases[i]);
                         List<double> damages = typedHits.Select(x => ComputeGain(BuffsChecker.GetStack(bgms, x.Time), x)).Where(x => x != -1.0).ToList();
                         extraDataList.Add(new DamageModifierData(damages.Count, typedHits.Count, damages.Sum(), totalDamage));

--- a/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifierTarget.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/BuffDamageModifierTarget.cs
@@ -58,7 +58,7 @@ namespace LuckParser.Models.ParseModels
                         int totalDamage = GetTotalDamage(p, log, target, phases[i]);
                         List<DamageLog> typedHits = GetDamageLogs(p, log, target, phases[i]);
                         List<double> damages = typedHits.Select(x => ComputeGain(BuffsChecker.GetStack(bgms, x.Time), x)).Where(x => x != -1.0).ToList();
-                        extraDataList.Add(new DamageModifierData(damages.Count, typedHits.Count, (int)Math.Round(damages.Sum()), totalDamage));
+                        extraDataList.Add(new DamageModifierData(damages.Count, typedHits.Count, damages.Sum(), totalDamage));
                     }
                     dict[Name] = extraDataList;
                 }

--- a/LuckParser/Models/ParseModels/DamageModifiers/BuffsTrackers/BuffsTrackerSingle.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/BuffsTrackers/BuffsTrackerSingle.cs
@@ -17,7 +17,11 @@ namespace LuckParser.Models.ParseModels
 
         public override int GetStack(Dictionary<long, BoonsGraphModel> bgms, long time)
         {
-            return bgms[_id].GetStackCount(time);
+            if (bgms.TryGetValue(_id, out var bgm))
+            {
+                return bgm.GetStackCount(time);
+            }
+            return 0;
         }
 
         public override bool Has(Dictionary<long, BoonsGraphModel> bgms)

--- a/LuckParser/Models/ParseModels/DamageModifiers/DamageLogDamageModifier.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/DamageLogDamageModifier.cs
@@ -41,7 +41,7 @@ namespace LuckParser.Models.ParseModels
                     List<DamageModifierData> extraDataList = new List<DamageModifierData>();
                     for (int i = 0; i < phases.Count; i++)
                     {
-                        int totalDamage = GetTotalDamage(p, log, target, phases[i]);
+                        int totalDamage = GetTotalDamage(p, log, target, i);
                         List<DamageLog> typeHits = GetDamageLogs(p, log, target, phases[i]);
                         List<DamageLog> effect = typeHits.Where(x => DLChecker(x)).ToList();
                         extraDataList.Add(new DamageModifierData(effect.Count, typeHits.Count, gain * effect.Sum(x => x.Damage), totalDamage));
@@ -52,7 +52,7 @@ namespace LuckParser.Models.ParseModels
             data[Name] = new List<DamageModifierData>();
             for (int i = 0; i < phases.Count; i++)
             {
-                int totalDamage = GetTotalDamage(p, log, null, phases[i]);
+                int totalDamage = GetTotalDamage(p, log, null, i);
                 List<DamageLog> typeHits = GetDamageLogs(p, log, null, phases[i]);
                 List<DamageLog> effect = typeHits.Where(x => DLChecker(x)).ToList();
                 data[Name].Add(new DamageModifierData(effect.Count, typeHits.Count, gain * effect.Sum(x => x.Damage), totalDamage));

--- a/LuckParser/Models/ParseModels/DamageModifiers/DamageLogDamageModifier.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/DamageLogDamageModifier.cs
@@ -44,8 +44,7 @@ namespace LuckParser.Models.ParseModels
                         int totalDamage = GetTotalDamage(p, log, target, phases[i]);
                         List<DamageLog> typeHits = GetDamageLogs(p, log, target, phases[i]);
                         List<DamageLog> effect = typeHits.Where(x => DLChecker(x)).ToList();
-                        int damage = (int)Math.Round(gain * effect.Sum(x => x.Damage));
-                        extraDataList.Add(new DamageModifierData(effect.Count, typeHits.Count, damage, totalDamage));
+                        extraDataList.Add(new DamageModifierData(effect.Count, typeHits.Count, gain * effect.Sum(x => x.Damage), totalDamage));
                     }
                     dict[Name] = extraDataList;
                 }
@@ -56,8 +55,7 @@ namespace LuckParser.Models.ParseModels
                 int totalDamage = GetTotalDamage(p, log, null, phases[i]);
                 List<DamageLog> typeHits = GetDamageLogs(p, log, null, phases[i]);
                 List<DamageLog> effect = typeHits.Where(x => DLChecker(x)).ToList();
-                int damage = (int)Math.Round(gain * effect.Sum(x => x.Damage));
-                data[Name].Add(new DamageModifierData(effect.Count, typeHits.Count, damage, totalDamage));
+                data[Name].Add(new DamageModifierData(effect.Count, typeHits.Count, gain * effect.Sum(x => x.Damage), totalDamage));
             }
         }
     }

--- a/LuckParser/Models/ParseModels/DamageModifiers/DamageModifier.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/DamageModifier.cs
@@ -51,8 +51,7 @@ namespace LuckParser.Models.ParseModels
             DLChecker = dlChecker;
         }
 
-
-        protected int GetTotalDamage(Player p, ParsedLog log, Target t, PhaseData phase)
+        public int GetTotalDamage(Player p, ParsedLog log, Target t, PhaseData phase)
         {
             List<DamageLog> dls = new List<DamageLog>();
             switch (_compareType)
@@ -70,7 +69,7 @@ namespace LuckParser.Models.ParseModels
             return dls.Sum(x => x.Damage);
         }
 
-        protected List<DamageLog> GetDamageLogs(Player p, ParsedLog log, Target t, PhaseData phase)
+        public List<DamageLog> GetDamageLogs(Player p, ParsedLog log, Target t, PhaseData phase)
         {
             switch (_srcType)
             {
@@ -80,7 +79,7 @@ namespace LuckParser.Models.ParseModels
                     return (_dmgSrc == DamageSource.All ? p.GetDamageLogs(t, log, phase) : p.GetJustPlayerDamageLogs(t, log, phase)).Where(x => x.IsCondi).ToList();
                 case DamageType.Power:
                 default:
-                    return (_dmgSrc == DamageSource.All ? p.GetDamageLogs(t, log, phase) : p.GetJustPlayerDamageLogs(t, log, phase)).Where(x => !x.IsCondi).ToList();
+                    return (_dmgSrc == DamageSource.All ? p.GetDamageLogs(t, log, phase) : p.GetJustPlayerDamageLogs(t, log, phase)).Where(x => !x.IsIndirectDamage).ToList();
             }
         }
 

--- a/LuckParser/Models/ParseModels/DamageModifiers/DamageModifier.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/DamageModifier.cs
@@ -157,13 +157,13 @@ namespace LuckParser.Models.ParseModels
             new DamageLogDamageModifier("Scholar Rune", DamageSource.NoPets, 5.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff,"https://wiki.guildwars2.com/images/2/2b/Superior_Rune_of_the_Scholar.png", x => x.IsNinety, ByPresence ),
             new DamageLogDamageModifier("Eagle Rune", DamageSource.NoPets, 10.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff,"https://wiki.guildwars2.com/images/9/9b/Superior_Rune_of_the_Eagle.png", x => x.IsFifty, ByPresence ),
             new DamageLogDamageModifier("Thief Rune", DamageSource.NoPets, 10.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff,"https://wiki.guildwars2.com/images/9/96/Superior_Rune_of_the_Thief.png", x => x.IsFlanking , ByPresence),
+            new DamageLogDamageModifier("Moving Bonus", DamageSource.NoPets, 5.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff,"https://wiki.guildwars2.com/images/1/1c/Bowl_of_Seaweed_Salad.png", x => x.IsMoving, ByPresence),
             new BuffDamageModifier(Boon.GetBoonByName("Might"), "Strength Rune",  DamageSource.NoPets, 5.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff, ByPresence, "https://wiki.guildwars2.com/images/2/2b/Superior_Rune_of_Strength.png"),
             new BuffDamageModifier(Boon.GetBoonByName("Fire Shield"), "Fire Rune",  DamageSource.NoPets, 10.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff, ByPresence, "https://wiki.guildwars2.com/images/4/4a/Superior_Rune_of_the_Fire.png"),
             new BuffDamageModifierTarget(Boon.GetBoonByName("Burning"), "Flame Legion Rune",  DamageSource.NoPets, 7.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff, ByPresence, "https://wiki.guildwars2.com/images/4/4a/Superior_Rune_of_the_Flame_Legion.png"),
             new BuffDamageModifierTarget(Boon.GetBoonByName("Number of Boons"), "Spellbreaker Rune",  DamageSource.NoPets, 7.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff, ByAbsence, "https://wiki.guildwars2.com/images/1/1a/Superior_Rune_of_the_Spellbreaker.png"),
             new BuffDamageModifierTarget(Boon.GetBoonByName("Chilled"), "Ice Rune",  DamageSource.NoPets, 7.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff, ByPresence, "https://wiki.guildwars2.com/images/7/78/Superior_Rune_of_the_Ice.png"),
             new BuffDamageModifier(Boon.GetBoonByName("Fury"), "Rage Rune",  DamageSource.NoPets, 5.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff, ByPresence, "https://wiki.guildwars2.com/images/9/9e/Superior_Rune_of_Rage.png"),
-            new BuffDamageModifier(Boon.GetBoonByName("Bowl of Seaweed Salad"), DamageSource.NoPets, 5.0, DamageType.Power, DamageType.Power, ModifierSource.ItemBuff, ByPresence, x => x.IsMoving),
             /// commons
             new BuffDamageModifierTarget(Boon.GetBoonByName("Vulnerability"), DamageSource.All, 1.0, DamageType.All, DamageType.All, ModifierSource.CommonBuff, ByStack),
             new BuffDamageModifier(Boon.GetBoonByName("Frost Spirit"), DamageSource.NoPets, 5.0, DamageType.Power, DamageType.All, ModifierSource.CommonBuff, ByPresence),
@@ -189,7 +189,7 @@ namespace LuckParser.Models.ParseModels
             new DamageLogDamageModifier("Swift Termination", DamageSource.NoPets, 20.0, DamageType.Power, DamageType.All, ModifierSource.Revenant,"https://wiki.guildwars2.com/images/b/bb/Swift_Termination.png", x => x.IsFifty, ByPresence),
             /// Warrior
             new BuffDamageModifier(Boon.GetBoonByName("Peak Performance"), DamageSource.NoPets, 20.0, DamageType.Power, DamageType.All, ModifierSource.Warrior, ByPresence),
-            new BuffDamageModifier(Boon.GetBoonByName("Always Angry"), DamageSource.NoPets, 7.0, DamageType.All, DamageType.All, ModifierSource.Berserker, ByStack),
+            new BuffDamageModifier(Boon.GetBoonByName("Always Angry"), DamageSource.NoPets, 7.0, DamageType.All, DamageType.All, ModifierSource.Berserker, ByPresence),
             new BuffDamageModifierTarget(Boon.GetBoonByName("Weakness"), "Cull the Weak", DamageSource.NoPets, 7.0, DamageType.Power, DamageType.All, ModifierSource.Warrior, ByPresence, "https://wiki.guildwars2.com/images/7/72/Cull_the_Weak.png"),
             new BuffDamageModifier(Boon.GetBoonByName("Number of Boons"), "Empowered", DamageSource.NoPets, 1.0, DamageType.Power, DamageType.All, ModifierSource.Warrior, ByStack, "https://wiki.guildwars2.com/images/c/c2/Empowered.png"),
             new BuffDamageModifierTarget(Boon.GetBoonByName("Number of Boons"), "Destruction of the Empowered", DamageSource.NoPets, 3.0, DamageType.Power, DamageType.All, ModifierSource.Warrior, ByStack, "https://wiki.guildwars2.com/images/5/5c/Destruction_of_the_Empowered.png"),

--- a/LuckParser/Models/ParseModels/DamageModifiers/DamageModifier.cs
+++ b/LuckParser/Models/ParseModels/DamageModifiers/DamageModifier.cs
@@ -51,22 +51,19 @@ namespace LuckParser.Models.ParseModels
             DLChecker = dlChecker;
         }
 
-        public int GetTotalDamage(Player p, ParsedLog log, Target t, PhaseData phase)
+        public int GetTotalDamage(Player p, ParsedLog log, Target t, int phaseIndex)
         {
-            List<DamageLog> dls = new List<DamageLog>();
+            FinalDPS damageData = p.GetDPSTarget(log, phaseIndex, t);
             switch (_compareType)
             {
                 case DamageType.All:
-                    dls = _dmgSrc == DamageSource.All ? p.GetDamageLogs(t, log, phase) : p.GetJustPlayerDamageLogs(t, log, phase);
-                    break;
+                    return _dmgSrc == DamageSource.All ? damageData.Damage  : damageData.ActorDamage;
                 case DamageType.Condition:
-                    dls = (_dmgSrc == DamageSource.All ? p.GetDamageLogs(t, log, phase) : p.GetJustPlayerDamageLogs(t, log, phase)).Where(x => x.IsCondi).ToList();
-                    break;
+                    return _dmgSrc == DamageSource.All ? damageData.CondiDamage : damageData.ActorCondiDamage;
                 case DamageType.Power:
-                    dls = (_dmgSrc == DamageSource.All ? p.GetDamageLogs(t, log, phase) : p.GetJustPlayerDamageLogs(t, log, phase)).Where(x => !x.IsCondi).ToList();
-                    break;
+                    return _dmgSrc == DamageSource.All ? damageData.PowerDamage : damageData.ActorPowerDamage;
             }
-            return dls.Sum(x => x.Damage);
+            return 0;
         }
 
         public List<DamageLog> GetDamageLogs(Player p, ParsedLog log, Target t, PhaseData phase)

--- a/LuckParser/Models/Statistics.cs
+++ b/LuckParser/Models/Statistics.cs
@@ -25,6 +25,13 @@ namespace LuckParser.Models
             public int CondiDamage;
             public int PowerDps;
             public int PowerDamage;
+            // Actor only
+            public int ActorDps;
+            public int ActorDamage;
+            public int ActorCondiDps;
+            public int ActorCondiDamage;
+            public int ActorPowerDps;
+            public int ActorPowerDamage;
         }
 
         public class FinalStats

--- a/LuckParser/Models/Statistics.cs
+++ b/LuckParser/Models/Statistics.cs
@@ -136,10 +136,10 @@ namespace LuckParser.Models
         {
             public int HitCount { get; }
             public int TotalHitCount { get; }
-            public int DamageGain { get; }
+            public double DamageGain { get; }
             public int TotalDamage { get; }
 
-            public DamageModifierData(int hitCount, int totalHitCount, int damageGain, int totalDamage)
+            public DamageModifierData(int hitCount, int totalHitCount, double damageGain, int totalDamage)
             {
                 HitCount = hitCount;
                 TotalHitCount = totalHitCount;

--- a/LuckParser/Resources/JS/damageModifierStats.js
+++ b/LuckParser/Resources/JS/damageModifierStats.js
@@ -249,7 +249,7 @@ var compileDamageModifiers = function () {
                     return null;
                 }
                 var hits = item[0] + " out of " + item[1] + " hits";
-                var gain = "Pure Damage: " + item[2];
+                var gain = "Pure Damage: " + Math.round(1000.0*item[2])/1000.0;
                 return hits + "<br>" + gain;
             },
             getCellValue: function (item) {


### PR DESCRIPTION
- fixed some potential rounding error
- fixed a bug in sum rows on damage mods tables
- fixed a reg in GetJustPlayerDamage
- made "moving" damage mod enabled by default