### PR TITLE
Fix NullReferenceException in GetMechanicData

### DIFF
--- a/LuckParser/Models/FightLogic/FightLogic.cs
+++ b/LuckParser/Models/FightLogic/FightLogic.cs
@@ -13,7 +13,7 @@ namespace LuckParser.Models.Logic
         public enum ParseMode { Raid, Fractal, Golem, WvW, Unknown };
 
         private CombatReplayMap _map;
-        protected readonly List<Mechanic> MechanicList; //Resurrects (start), Resurrect
+        public readonly List<Mechanic> MechanicList; //Resurrects (start), Resurrect
         public ParseMode Mode { get; protected set; } = ParseMode.Unknown;
         public bool HasCombatReplayMap { get; protected set; } = false;
         public string Extension { get; protected set; }
@@ -46,9 +46,15 @@ namespace LuckParser.Models.Logic
             }
         }
 
-        public MechanicData GetMechanicData(ParsedLog log)
+        public void ComputeMechanics(ParsedLog log)
         {
-            return new MechanicData(MechanicList, log);
+            MechanicData mechData = log.MechanicData;
+            Dictionary<ushort, DummyActor> regroupedMobs = new Dictionary<ushort, DummyActor>();
+            foreach (Mechanic mech in MechanicList)
+            {
+                mech.CheckMechanic(log, regroupedMobs);
+            }
+            mechData.ProcessMechanics(log);
         }
 
         protected virtual CombatReplayMap GetCombatMapInternal()

--- a/LuckParser/Models/ParseModels/Mechanics/MechanicData.cs
+++ b/LuckParser/Models/ParseModels/Mechanics/MechanicData.cs
@@ -12,23 +12,16 @@ namespace LuckParser.Models.ParseModels
         private readonly List<HashSet<Mechanic>> _presentMechanics = new List<HashSet<Mechanic>>();
         private readonly List<List<DummyActor>> _enemyList = new List<List<DummyActor>>();
 
-        public MechanicData(List<Mechanic> fightMechanics, ParsedLog log)
+        public MechanicData(FightData fightData)
         {
+            List<Mechanic> fightMechanics = fightData.Logic.MechanicList;
             foreach(Mechanic m in fightMechanics)
             {
                 Add(m, new List<MechanicLog>());
             }
-            CombatData combatData = log.CombatData;
-            HashSet<ushort> playersIds = log.PlayerIDs;
-            Dictionary<ushort, DummyActor> regroupedMobs = new Dictionary<ushort, DummyActor>();
-            foreach (Mechanic mech in fightMechanics)
-            {
-                mech.CheckMechanic(log, regroupedMobs);
-            }
-            ProcessMechanics(log);
         }
 
-        private void ProcessMechanics(ParsedLog log)
+        public void ProcessMechanics(ParsedLog log)
         {
             if (_presentMechanics.Count > 0)
             {

--- a/LuckParser/Parser/ParsedLog.cs
+++ b/LuckParser/Parser/ParsedLog.cs
@@ -51,7 +51,8 @@ namespace LuckParser.Parser
             Boons = new BoonsContainer(logData.GW2Version);
             BoonSourceFinder = Boon.GetBoonSourceFinder(logData.GW2Version, Boons);
             DamageModifiers = new DamageModifiersContainer(logData.GW2Version);
-            MechanicData = FightData.Logic.GetMechanicData(this);
+            MechanicData = new MechanicData(fightData);
+            FightData.Logic.ComputeMechanics(this);
             Statistics = new Statistics(this);
             LegacyTarget = target;
         }


### PR DESCRIPTION
The refactoring from #372 causes NullReferenceExceptions when parsing logs.
This PR restores some of the old logic.

```
Unhandled Exception: LuckParser.Exceptions.CancellationException ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at LuckParser.Models.ParseModels.PlayerStatusMechanic.CheckMechanic(ParsedLog log, Dictionary`2 regroupedMobs) in /build/LuckParser/Models/ParseModels/Mechanics/PlayerStatusMechanic.cs:line 57
   at LuckParser.Models.ParseModels.MechanicData..ctor(List`1 fightMechanics, ParsedLog log) in /build/LuckParser/Models/ParseModels/Mechanics/MechanicData.cs:line 24
   at LuckParser.Parser.ParsedLog..ctor(LogData logData, FightData fightData, AgentData agentData, SkillData skillData, CombatData combatData, List`1 playerList, Target target) in /build/LuckParser/Parser/ParsedLog.cs:line 53
   at LuckParser.Parser.ParsingController.ParseLog(GridRow row, String evtc) in /build/LuckParser/Parser/ParsingController.cs:line 72
   at LuckParser.ConsoleProgram.ParseLog(Object logFile) in /build/LuckParser/ConsoleProgram.cs:line 76
   --- End of inner exception stack trace ---
   at LuckParser.ConsoleProgram.ParseLog(Object logFile) in /build/LuckParser/ConsoleProgram.cs:line 253
   at LuckParser.ConsoleProgram..ctor(IEnumerable`1 logFiles) in /build/LuckParser/ConsoleProgram.cs:line 21
   at LuckParser.Program.Main(String[] args) in /build/LuckParser/Program.cs:line 63
```