### PR TITLE
Combat replay mechanics list

### DIFF
--- a/GW2EIParser/Builders/HTMLBuilder.cs
+++ b/GW2EIParser/Builders/HTMLBuilder.cs
@@ -859,6 +859,7 @@ namespace GW2EIParser.Builders
                     {"${tmplCombatReplayPlayerSelect}", Properties.Resources.tmplCombatReplayPlayerSelect },
                     {"${tmplCombatReplayRangeSelect}", Properties.Resources.tmplCombatReplayRangeSelect },
                     {"${tmplCombatReplayAnimationControl}", Properties.Resources.tmplCombatReplayAnimationControl },
+                    {"${tmplCombatReplayMechanicsList}", Properties.Resources.tmplCombatReplayMechanicsList },
                 };
             foreach (KeyValuePair<string, string> entry in CRtemplates)
             {

--- a/GW2EIParser/GW2EIParser.csproj
+++ b/GW2EIParser/GW2EIParser.csproj
@@ -136,6 +136,7 @@
     <Content Include="Resources\combatReplayTemplates\tmplCombatReplayActorBuffStats.html" />
     <Content Include="Resources\combatReplayTemplates\tmplCombatReplayPlayerStats.html" />
     <Content Include="Resources\combatReplayTemplates\tmplCombatReplayStatusData.html" />
+    <Content Include="Resources\combatReplayTemplates\tmplCombatReplayMechanicsList.html" />
     <None Include="Resources\combatReplayTemplates\tmplCombatReplayPlayerSelect.html" />
     <None Include="Resources\combatReplayTemplates\tmplCombatReplayAnimationControl.html" />
     <Content Include="Resources\ei.css" />

--- a/GW2EIParser/Properties/Resources.Designer.cs
+++ b/GW2EIParser/Properties/Resources.Designer.cs
@@ -585,12 +585,12 @@ namespace GW2EIParser.Properties {
         ///   Looks up a localized string similar to &lt;div class=&quot;d-flex flex-column justify-content-end&quot; :style=&quot;{&apos;height&apos;: enemy ? &apos;80px&apos; : &apos;100px&apos;}&quot;&gt;
         ///    &lt;div v-if=&quot;data.enemies.length &gt; 0&quot; class=&quot;d-flex&quot;&gt;
         ///        &lt;div v-for=&quot;enemy in data.enemies&quot; class=&quot;boon-container&quot;&gt;
-        ///            &lt;img :src=&quot;enemy.buff.icon&quot; :title=&quot;enemy.buff.name&quot; :alt=&quot;enemy.buff.name&quot; class=&quot;icon&quot; /&gt;
+        ///            &lt;img :src=&quot;enemy.buff.icon&quot; :title=&quot;enemy.buff.name&quot; :alt=&quot;enemy.buff.name&quot; class=&quot;icon-s&quot; /&gt;
         ///            &lt;div v-if=&quot;enemy.state &gt; 1&quot; class=&quot;boon-number&quot;&gt;{{enemy.state}}&lt;/div&gt;
         ///        &lt;/div&gt;
         ///    &lt;/div&gt;
         ///    &lt;div v-if=&quot;data.others.length &gt; 0&quot; class=&quot;d-flex&quot;&gt;
-        ///        &lt;div v- [rest of string was truncated]&quot;;.
+        ///        &lt;div  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string tmplCombatReplayActorBuffStats {
             get {
@@ -617,11 +617,11 @@ namespace GW2EIParser.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &lt;div class=&quot;d-flex flex-column justify-content-center flex-wrap&quot;&gt;
+        ///   Looks up a localized string similar to &lt;div class=&quot;d-flex flex-column justify-content-center flex-wrap&quot; :style=&quot;{&apos;width&apos;: Math.max(canvas.x, canvas.y) + &apos;px&apos;}&quot;&gt;
         ///    &lt;p class=&quot;text-justify text-center&quot;&gt;Double click on canvas to restore viewpoint&lt;/p&gt;
         ///    &lt;div class=&quot;d-flex flex-column justify-content-center align-items-center&quot; :style=&quot;{&apos;width&apos;: &apos;100%&apos;, &apos;min-width&apos;: canvas.x + &apos;px&apos;, &apos;height&apos;: canvas.y + &apos;px&apos;, &apos;position&apos;: &apos;relative&apos;}&quot;&gt;
         ///        &lt;canvas :width=&quot;canvas.x + &apos;px&apos;&quot; :height=&quot;canvas.y + &apos;px&apos;&quot; id=&quot;main-canvas&quot; class=&quot;replay&quot;&gt;&lt;/canvas&gt;
-        ///        &lt;canvas :width=&quot;canvas.x + &apos;px&apos;&quot; :height=&quot;canvas.y [rest of string was truncated]&quot;;.
+        ///   [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string tmplCombatReplayAnimationControl {
             get {
@@ -657,6 +657,22 @@ namespace GW2EIParser.Properties {
         internal static string tmplCombatReplayDamageTable {
             get {
                 return ResourceManager.GetString("tmplCombatReplayDamageTable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;div class=&quot;d-flex flex-row flex-wrap justify-content-center&quot;&gt;
+        ///    &lt;ul class=&quot;nav nav-pills d-flex flex-row justify-content-center mb-1 w-100&quot;&gt;
+        ///        &lt;li class=&quot;nav-item&quot;&gt;
+        ///            &lt;a class=&quot;nav-link&quot; :class=&quot;{active: showMechanics}&quot; @click=&quot;showMechanics = !showMechanics&quot;&gt;Mechanics List&lt;/a&gt;
+        ///        &lt;/li&gt;
+        ///    &lt;/ul&gt;
+        ///    &lt;div v-if=&quot;showMechanics&quot; id=&quot;combat-replay-mechanics-list-container&quot; class=&quot;d-flex d-flex-row justify-content-center w-100&quot;&gt;
+        ///        &lt;table class=&quot;table table-sm table-striped ta [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string tmplCombatReplayMechanicsList {
+            get {
+                return ResourceManager.GetString("tmplCombatReplayMechanicsList", resourceCulture);
             }
         }
         

--- a/GW2EIParser/Properties/Resources.resx
+++ b/GW2EIParser/Properties/Resources.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-   <!-- 
+  <!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,267 +59,270 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-      <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-      <xsd:element name="root" msdata:IsDataSet="true">
-         <xsd:complexType>
-            <xsd:choice maxOccurs="unbounded">
-               <xsd:element name="metadata">
-                  <xsd:complexType>
-                     <xsd:sequence>
-                        <xsd:element name="value" type="xsd:string" minOccurs="0" />
-                     </xsd:sequence>
-                     <xsd:attribute name="name" use="required" type="xsd:string" />
-                     <xsd:attribute name="type" type="xsd:string" />
-                     <xsd:attribute name="mimetype" type="xsd:string" />
-                     <xsd:attribute ref="xml:space" />
-                  </xsd:complexType>
-               </xsd:element>
-               <xsd:element name="assembly">
-                  <xsd:complexType>
-                     <xsd:attribute name="alias" type="xsd:string" />
-                     <xsd:attribute name="name" type="xsd:string" />
-                  </xsd:complexType>
-               </xsd:element>
-               <xsd:element name="data">
-                  <xsd:complexType>
-                     <xsd:sequence>
-                        <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                        <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-                     </xsd:sequence>
-                     <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-                     <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-                     <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-                     <xsd:attribute ref="xml:space" />
-                  </xsd:complexType>
-               </xsd:element>
-               <xsd:element name="resheader">
-                  <xsd:complexType>
-                     <xsd:sequence>
-                        <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                     </xsd:sequence>
-                     <xsd:attribute name="name" type="xsd:string" use="required" />
-                  </xsd:complexType>
-               </xsd:element>
-            </xsd:choice>
-         </xsd:complexType>
-      </xsd:element>
-   </xsd:schema>
-   <resheader name="resmimetype">
-      <value>text/microsoft-resx</value>
-   </resheader>
-   <resheader name="version">
-      <value>2.0</value>
-   </resheader>
-   <resheader name="reader">
-      <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-   </resheader>
-   <resheader name="writer">
-      <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-   </resheader>
-   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-   <data name="combatreplay_js" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatreplay.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="ei_css" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\ei.css;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="ei_js" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\ei.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="commonsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\commons.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="globalJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\global.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="generalStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\generalStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="damageModifierStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\damageModifierStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="buffStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\buffStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="graphsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\graphs.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="layoutJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\layout.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="mechanicsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\mechanics.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="headerJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\header.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="playerStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\playerStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="combatReplayStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\combatReplayStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="combatReplayStatsUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\combatReplayUI.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="targetStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\JS\targetStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
-   </data>
-   <data name="tmplBuffStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplBuffStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplBuffStatsTarget" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplBuffStatsTarget.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplBuffTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplBuffTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageDistPlayer" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageDistPlayer.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageDistTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageDistTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageDistTarget" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageDistTarget.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageModifierTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageModifierTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageModifierStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageModifierStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageModifierPersStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageModifierPersStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDamageTaken" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDamageTaken.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDeathRecap" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDeathRecap.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDefenseTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDefenseTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplEncounter" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplEncounter.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplFood" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplFood.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplGameplayTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplGameplayTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplGeneralLayout" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplGeneralLayout.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplMechanicsTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplMechanicsTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplPersonalBuffTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplPersonalBuffTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplPhase" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplPhase.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplPlayers" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplPlayers.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplPlayerStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplPlayerStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplPlayerTab" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplPlayerTab.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplSimpleRotation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplSimpleRotation.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplSupportTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplSupportTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplTargets" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplTargets.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplTargetStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplTargetStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplTargetTab" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplTargetTab.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplDPSGraph" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplDPSGraph.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplGraphStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplGraphStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplPlayerTabGraph" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplPlayerTabGraph.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplTargetTabGraph" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplTargetTabGraph.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplTargetData" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplTargetData.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayDamageData" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayDamageData.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayStatusData" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayStatusData.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayDamageTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayDamageTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayPlayerStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayerStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayTargetStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayTargetStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayActorRotation" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayActorRotation.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayPlayerStatus" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayerStatus.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayTargetStatus" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayTargetStatus.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayTargetsStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayTargetsStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayPlayersStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayersStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayUI.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayPlayerSelect" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayerSelect.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayRangeSelect" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayRangeSelect.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayAnimationControl" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayAnimationControl.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplCombatReplayActorBuffStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\combatReplayTemplates\tmplCombatReplayActorBuffStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="tmplRotationLegend" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\htmlTemplates\tmplRotationLegend.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="template_html" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\template.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
-   </data>
-   <data name="theme_cosmo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\theme-cosmo.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-   </data>
-   <data name="theme_slate" type="System.Resources.ResXFileRef, System.Windows.Forms">
-      <value>..\Resources\theme-slate.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-   </data>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="combatreplay_js" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatreplay.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="ei_css" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ei.css;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="ei_js" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\ei.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="commonsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\commons.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="globalJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\global.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="generalStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\generalStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="damageModifierStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\damageModifierStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="buffStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\buffStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="graphsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\graphs.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="layoutJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\layout.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="mechanicsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\mechanics.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="headerJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\header.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="playerStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\playerStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="combatReplayStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\combatReplayStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="combatReplayStatsUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\combatReplayUI.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="targetStatsJS" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\JS\targetStats.js;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
+  <data name="tmplBuffStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplBuffStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplBuffStatsTarget" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplBuffStatsTarget.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplBuffTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplBuffTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageDistPlayer" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageDistPlayer.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageDistTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageDistTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageDistTarget" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageDistTarget.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageModifierTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageModifierTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageModifierStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageModifierStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageModifierPersStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageModifierPersStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDamageTaken" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDamageTaken.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDeathRecap" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDeathRecap.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDefenseTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDefenseTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplEncounter" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplEncounter.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplFood" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplFood.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplGameplayTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplGameplayTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplGeneralLayout" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplGeneralLayout.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplMechanicsTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplMechanicsTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplPersonalBuffTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplPersonalBuffTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplPhase" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplPhase.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplPlayers" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplPlayers.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplPlayerStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplPlayerStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplPlayerTab" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplPlayerTab.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplSimpleRotation" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplSimpleRotation.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplSupportTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplSupportTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplTargets" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplTargets.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplTargetStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplTargetStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplTargetTab" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplTargetTab.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplDPSGraph" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplDPSGraph.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplGraphStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplGraphStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplPlayerTabGraph" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplPlayerTabGraph.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplTargetTabGraph" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplTargetTabGraph.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplTargetData" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplTargetData.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayDamageData" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayDamageData.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayStatusData" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayStatusData.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayDamageTable" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayDamageTable.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayPlayerStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayerStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayTargetStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayTargetStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayActorRotation" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayActorRotation.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayPlayerStatus" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayerStatus.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayTargetStatus" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayTargetStatus.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayTargetsStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayTargetsStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayPlayersStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayersStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayUI" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayUI.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayPlayerSelect" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayPlayerSelect.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayRangeSelect" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayRangeSelect.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayAnimationControl" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayAnimationControl.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplCombatReplayActorBuffStats" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayActorBuffStats.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="tmplRotationLegend" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\htmlTemplates\tmplRotationLegend.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="template_html" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\template.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
+  <data name="theme_cosmo" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\theme-cosmo.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="theme_slate" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\theme-slate.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="tmplCombatReplayMechanicsList" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\combatReplayTemplates\tmplCombatReplayMechanicsList.html;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/GW2EIParser/Resources/JS/combatReplayUI.js
+++ b/GW2EIParser/Resources/JS/combatReplayUI.js
@@ -146,7 +146,7 @@ var compileCombatReplayUI = function () {
     });
 
     Vue.component("combat-replay-mechanics-list-component", {
-        props: ["light"],
+        props: ['selectedplayerid'],
         template: `${tmplCombatReplayMechanicsList}`,
         data: function () {
             var mechanicEvents = [];

--- a/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
+++ b/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
@@ -34,7 +34,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="event in filteredMechanicEvents" class="combat-replay-mechanics-list-row" @click="selectMechanic(event)">
+                <tr v-for="event in filteredMechanicEvents" class="combat-replay-mechanics-list-row" :class="{active: event.actor.id === selectedplayerid}" @click="selectMechanic(event)">
                     <td>{{(event.time / 1000).toFixed(2)}}s</td>
                     <td class="text-left" :title="event.mechanic.name">{{event.mechanic.shortName}}</td>
                     <td class="text-left">{{event.actor.name}}</td>

--- a/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
+++ b/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
@@ -1,0 +1,45 @@
+<div class="d-flex flex-row flex-wrap justify-content-center">
+    <ul class="nav nav-pills d-flex flex-row justify-content-center mb-1 w-100">
+        <li class="nav-item">
+            <a class="nav-link" :class="{active: showMechanics}" @click="showMechanics = !showMechanics">Mechanics List</a>
+        </li>
+    </ul>
+    <div v-if="showMechanics" id="combat-replay-mechanics-list-container" class="d-flex d-flex-row justify-content-center w-100">
+        <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th class="text-left combat-replay-mechanics-list-header position-relative">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" title="Filter Mechanics">
+                            Mechanic <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu p-2 font-weight-normal">
+                            <li v-for="(mechanic, index) in mechanicsList" :key="index">
+                                <input :id="'crml-mechanic-' + index" type="checkbox" v-model="mechanic.included" />
+                                <label :for="'crml-mechanic-' + index">{{mechanic.shortName}}</label>
+                            </li>
+                        </ul>
+                    </th>
+                    <th class="text-left combat-replay-mechanics-list-header position-relative">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown" title="Filter Actors">
+                            Actor <span class="caret"></span>
+                        </a>
+                        <ul class="dropdown-menu p-2 font-weight-normal">
+                            <li v-for="(actor, index) in actorsList" :key="index">
+                                <input :id="'crml-actor-' + index" type="checkbox" v-model="actor.included" />
+                                <label :for="'crml-actor-' + index">{{actor.name}}</label>
+                            </li>
+                        </ul>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="event in filteredMechanicEvents" class="combat-replay-mechanics-list-row" @click="selectMechanic(event)">
+                    <td>{{(event.time / 1000).toFixed(2)}}s</td>
+                    <td class="text-left" :title="event.mechanic.name">{{event.mechanic.shortName}}</td>
+                    <td class="text-left">{{event.actor.name}}</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayUI.html
+++ b/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayUI.html
@@ -11,6 +11,6 @@
         <combat-replay-status-data-component :time="animationStatus.time"
             :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID">
         </combat-replay-status-data-component>
-        <combat-replay-mechanics-list-component :light="light"></combat-replay-mechanics-list-component>
+        <combat-replay-mechanics-list-component :selectedplayerid="animationStatus.selectedPlayerID"></combat-replay-mechanics-list-component>
     </div>
 </div>

--- a/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayUI.html
+++ b/GW2EIParser/Resources/combatReplayTemplates/tmplCombatReplayUI.html
@@ -11,5 +11,6 @@
         <combat-replay-status-data-component :time="animationStatus.time"
             :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID">
         </combat-replay-status-data-component>
+        <combat-replay-mechanics-list-component :light="light"></combat-replay-mechanics-list-component>
     </div>
 </div>

--- a/GW2EIParser/Resources/ei.css
+++ b/GW2EIParser/Resources/ei.css
@@ -527,3 +527,16 @@ canvas {
 #bg-canvas {
     z-index: 1
 }
+
+#combat-replay-mechanics-list-container {
+    max-height: 800px;
+    overflow-y: scroll;
+}
+
+.combat-replay-mechanics-list-row {
+    cursor: pointer;
+}
+
+.combat-replay-mechanics-list-header > a:hover {
+    text-decoration: none;
+}


### PR DESCRIPTION
This adds a list of all mechanics that occur in the fight to the combat replay with the ability to click on them to seek to that moment in time.

I'm still working on figuring out the travis CI errors, ~~cleaning up the random reindentations in the commits, and rebasing into one commit on master~~ but I thought it would be good to solicit feedback on my current UI and JS style since both are a bit dubious.

<img width="340" alt="list" src="https://user-images.githubusercontent.com/2776089/67721390-c4071380-f9ac-11e9-8ffd-e20fb0fdfb97.png">

<img width="391" alt="filter dropdown" src="https://user-images.githubusercontent.com/2776089/67721384-c10c2300-f9ac-11e9-9ea6-e223d156a8d5.png">
