### PR TITLE
Instant cast

### DIFF
--- a/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
@@ -90,7 +90,7 @@ namespace GW2EIEvtcParser.EIData
                 }
                 foreach (KeyValuePair<long, Minions> pair in auxMinions)
                 {
-                    if (pair.Value.GetDamageLogs(null, log, 0, log.FightData.FightEnd).Count > 0 || pair.Value.GetCastLogs(log, 0, log.FightData.FightEnd).Any(x => x.SkillId != SkillItem.WeaponSwapId))
+                    if (pair.Value.GetDamageLogs(null, log, 0, log.FightData.FightEnd).Count > 0 || pair.Value.GetCastLogs(log, 0, log.FightData.FightEnd).Any(x => x.SkillId != SkillItem.WeaponSwapId && x.SkillId != SkillItem.MirageCloakDodgeId))
                     {
                         _minions[pair.Value.AgentItem.UniqueID] = pair.Value;
                     }
@@ -112,7 +112,7 @@ namespace GW2EIEvtcParser.EIData
                 }
                 foreach (KeyValuePair<string, Minions> pair in auxGadgetMinions)
                 {
-                    if (pair.Value.GetDamageLogs(null, log, 0, log.FightData.FightEnd).Count > 0 || pair.Value.GetCastLogs(log, 0, log.FightData.FightEnd).Any(x => x.SkillId != SkillItem.WeaponSwapId))
+                    if (pair.Value.GetDamageLogs(null, log, 0, log.FightData.FightEnd).Count > 0 || pair.Value.GetCastLogs(log, 0, log.FightData.FightEnd).Any(x => x.SkillId != SkillItem.WeaponSwapId && x.SkillId != SkillItem.MirageCloakDodgeId))
                     {
                         _minions[pair.Value.AgentItem.UniqueID] = pair.Value;
                     }

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGainCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGainCastFinder.cs
@@ -39,13 +39,13 @@ namespace GW2EIEvtcParser.EIData
                         if (_triggerCondition(bae, combatData))
                         {
                             lastTime = bae.Time;
-                            res.Add(new InstantCastEvent(bae.Time, skillData.Get(SkillID), bae.To));
+                            res.Add(new InstantCastEvent(bae.Time - 1, skillData.Get(SkillID), bae.To));
                         }
                     }
                     else
                     {
                         lastTime = bae.Time;
-                        res.Add(new InstantCastEvent(bae.Time, skillData.Get(SkillID), bae.To));
+                        res.Add(new InstantCastEvent(bae.Time - 1, skillData.Get(SkillID), bae.To));
                     }
                 }
             }

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGainCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGainCastFinder.cs
@@ -29,6 +29,10 @@ namespace GW2EIEvtcParser.EIData
                 long lastTime = int.MinValue;
                 foreach (BuffApplyEvent bae in pair.Value)
                 {
+                    if (bae.Initial)
+                    {
+                        continue;
+                    }
                     if (bae.Time - lastTime < ICD)
                     {
                         lastTime = bae.Time;

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGiveCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGiveCastFinder.cs
@@ -38,13 +38,13 @@ namespace GW2EIEvtcParser.EIData
                         if (_triggerCondition(bae, combatData))
                         {
                             lastTime = bae.Time;
-                            res.Add(new InstantCastEvent(bae.Time, skillData.Get(SkillID), bae.By));
+                            res.Add(new InstantCastEvent(bae.Time - 1, skillData.Get(SkillID), bae.By));
                         }
                     }
                     else
                     {
                         lastTime = bae.Time;
-                        res.Add(new InstantCastEvent(bae.Time, skillData.Get(SkillID), bae.By));
+                        res.Add(new InstantCastEvent(bae.Time - 1, skillData.Get(SkillID), bae.By));
                     }
                 }
             }

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGiveCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/BuffGiveCastFinder.cs
@@ -28,6 +28,10 @@ namespace GW2EIEvtcParser.EIData
                 long lastTime = int.MinValue;
                 foreach (BuffApplyEvent bae in pair.Value)
                 {
+                    if (bae.Initial)
+                    {
+                        continue;
+                    }
                     if (bae.Time - lastTime < ICD)
                     {
                         lastTime = bae.Time;

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/BuffLossCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/BuffLossCastFinder.cs
@@ -40,13 +40,13 @@ namespace GW2EIEvtcParser.EIData
                         if (_triggerCondition(brae, combatData))
                         {
                             lastTime = brae.Time;
-                            res.Add(new InstantCastEvent(brae.Time, skillData.Get(SkillID), brae.To));
+                            res.Add(new InstantCastEvent(brae.Time - 1, skillData.Get(SkillID), brae.To));
                         }
                     }
                     else
                     {
                         lastTime = brae.Time;
-                        res.Add(new InstantCastEvent(brae.Time, skillData.Get(SkillID), brae.To));
+                        res.Add(new InstantCastEvent(brae.Time - 1, skillData.Get(SkillID), brae.To));
                     }
                 }
             }

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/DamageCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/DamageCastFinder.cs
@@ -43,13 +43,13 @@ namespace GW2EIEvtcParser.EIData
                         if (_triggerCondition(de, combatData))
                         {
                             lastTime = de.Time;
-                            res.Add(new InstantCastEvent(de.Time, skillData.Get(SkillID), de.From));
+                            res.Add(new InstantCastEvent(de.Time - 1, skillData.Get(SkillID), de.From));
                         }
                     }
                     else
                     {
                         lastTime = de.Time;
-                        res.Add(new InstantCastEvent(de.Time, skillData.Get(SkillID), de.From));
+                        res.Add(new InstantCastEvent(de.Time - 1, skillData.Get(SkillID), de.From));
                     }
                 }
             }

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/WeaponSwapCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/WeaponSwapCastFinder.cs
@@ -1,0 +1,64 @@
+﻿using GW2EIEvtcParser.ParsedData;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GW2EIEvtcParser.EIData
+{
+    internal class WeaponSwapCastFinder : InstantCastFinder
+    {
+        public delegate bool WeaponSwapCastChecker(WeaponSwapEvent evt, CombatData combatData);
+        private readonly WeaponSwapCastChecker _triggerCondition;
+
+        private readonly long _swappedTo;
+        public WeaponSwapCastFinder(long skillID, long swappedTo, long icd, WeaponSwapCastChecker checker = null) : base(skillID, icd)
+        {
+            NotAccurate = true;
+            _triggerCondition = checker;
+            _swappedTo = swappedTo;
+        }
+
+        public WeaponSwapCastFinder(long skillID, long swappedTo, long icd, ulong minBuild, ulong maxBuild, WeaponSwapCastChecker checker = null) : base(skillID, icd, minBuild, maxBuild)
+        {
+            NotAccurate = true;
+            _triggerCondition = checker;
+            _swappedTo = swappedTo;
+        }
+
+        public override List<InstantCastEvent> ComputeInstantCast(CombatData combatData, SkillData skillData, AgentData agentData)
+        {
+            var res = new List<InstantCastEvent>();
+            foreach (AgentItem playerAgent in agentData.GetAgentByType(AgentItem.AgentType.Player))
+            {
+                List<WeaponSwapEvent> swaps = combatData.GetWeaponSwapData(playerAgent);
+                long lastTime = int.MinValue;
+                foreach (WeaponSwapEvent swap in swaps)
+                {
+                    if (swap.SwappedTo != _swappedTo)
+                    {
+                        continue;
+                    }
+                    if (swap.Time - lastTime < ICD)
+                    {
+                        lastTime = swap.Time;
+                        continue;
+                    }
+                    if (_triggerCondition != null)
+                    {
+                        if (_triggerCondition(swap, combatData))
+                        {
+                            lastTime = swap.Time;
+                            res.Add(new InstantCastEvent(swap.Time - 1, skillData.Get(SkillID), swap.Caster));
+                        }
+                    }
+                    else
+                    {
+                        lastTime = swap.Time;
+                        res.Add(new InstantCastEvent(swap.Time - 1, skillData.Get(SkillID), swap.Caster));
+                    }
+                }
+            }
+            return res;
+        }
+    }
+}

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/WeaponSwapCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/WeaponSwapCastFinder.cs
@@ -7,7 +7,7 @@ namespace GW2EIEvtcParser.EIData
 {
     internal class WeaponSwapCastFinder : InstantCastFinder
     {
-        public delegate bool WeaponSwapCastChecker(WeaponSwapEvent evt, CombatData combatData);
+        public delegate bool WeaponSwapCastChecker(WeaponSwapEvent evt, CombatData combatData, SkillData skillData);
         private readonly WeaponSwapCastChecker _triggerCondition;
 
         private readonly long _swappedTo;
@@ -45,7 +45,7 @@ namespace GW2EIEvtcParser.EIData
                     }
                     if (_triggerCondition != null)
                     {
-                        if (_triggerCondition(swap, combatData))
+                        if (_triggerCondition(swap, combatData, skillData))
                         {
                             lastTime = swap.Time;
                             res.Add(new InstantCastEvent(swap.Time - 1, skillData.Get(SkillID), swap.Caster));

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/WeaponSwapCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/WeaponSwapCastFinder.cs
@@ -13,14 +13,12 @@ namespace GW2EIEvtcParser.EIData
         private readonly long _swappedTo;
         public WeaponSwapCastFinder(long skillID, long swappedTo, long icd, WeaponSwapCastChecker checker = null) : base(skillID, icd)
         {
-            NotAccurate = true;
             _triggerCondition = checker;
             _swappedTo = swappedTo;
         }
 
         public WeaponSwapCastFinder(long skillID, long swappedTo, long icd, ulong minBuild, ulong maxBuild, WeaponSwapCastChecker checker = null) : base(skillID, icd, minBuild, maxBuild)
         {
-            NotAccurate = true;
             _triggerCondition = checker;
             _swappedTo = swappedTo;
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -9,6 +9,8 @@ namespace GW2EIEvtcParser.EIData
 {
     internal static class ElementalistHelper
     {
+        // TODO - add glyph of elemental power stuff
+
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
             new BuffGainCastFinder(5492, 5585, EIData.InstantCastFinder.DefaultICD), // Fire
@@ -17,13 +19,14 @@ namespace GW2EIEvtcParser.EIData
             new BuffGainCastFinder(5495, 5580, EIData.InstantCastFinder.DefaultICD), // Earth
             new DamageCastFinder(5539, 5539, EIData.InstantCastFinder.DefaultICD), // Arcane Blast
             new BuffGiveCastFinder(5635, 5582, EIData.InstantCastFinder.DefaultICD), // Arcane Power
-            //new BuffGainCastFinder(5641, 5640, InstantCastFinder.DefaultICD), // Arcane Shield - indiscernable from lesser version
+            new BuffGainCastFinder(5641, 5640, EIData.InstantCastFinder.DefaultICD), // Arcane Shield
             new DamageCastFinder(22572, 22572, EIData.InstantCastFinder.DefaultICD), // Arcane Wave
             new BuffGainCastFinder(5543, 5543, EIData.InstantCastFinder.DefaultICD), // Mist Form
             new DamageCastFinder(5572, 5572, EIData.InstantCastFinder.DefaultICD), // Signet of Air
             new DamageCastFinder(56883, 56883, EIData.InstantCastFinder.DefaultICD), // Sunspot
             new DamageCastFinder(56885, 56885, EIData.InstantCastFinder.DefaultICD), // Earth Blast
             new DamageCastFinder(5561, 5561, EIData.InstantCastFinder.DefaultICD), // Lightning Strike
+            new DamageCastFinder(24305, 24305, EIData.InstantCastFinder.DefaultICD), // Lightning Rod
         };
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/WeaverHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/WeaverHelper.cs
@@ -21,7 +21,7 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
             new BuffGainCastFinder(40183, 42086, EIData.InstantCastFinder.DefaultICD), // Primordial Stance
-            //new BuffGainCastFinder(44926, ???, 500), // Stone Resonance, lesser stone resonance makes thing complicated
+            new BuffGainCastFinder(44926, 45097, 500), // Stone Resonance
             new BuffGainCastFinder(44612, 42683, EIData.InstantCastFinder.DefaultICD), // Unravel
             // Fire       
             new BuffGainCastFinder(FireDual, FireDual, EIData.InstantCastFinder.DefaultICD),
@@ -86,6 +86,7 @@ namespace GW2EIEvtcParser.EIData
                 new Buff("Molten Armor",43586, ParserHelper.Source.Weaver, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/7/71/Lava_Skin.png"),
                 new Buff("Weaver's Prowess",42061, ParserHelper.Source.Weaver, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/7/75/Weaver%27s_Prowess.png"),
                 new Buff("Elements of Rage",42416, ParserHelper.Source.Weaver, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/a/a2/Elements_of_Rage.png"),
+                new Buff("Stone Resonance",45097, ParserHelper.Source.Weaver, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/5/57/Stone_Resonance.png"),
         };
 
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
@@ -15,6 +15,10 @@ namespace GW2EIEvtcParser.EIData
             //new BuffLossCastFinder(9120,9119,InstantCastFinder.DefaultICD), // Virtue of Resolve
             //new BuffLossCastFinder(9118,9113,InstantCastFinder.DefaultICD), // Virtue of Courage
             new DamageCastFinder(9247,9247, EIData.InstantCastFinder.DefaultICD), // Judge's Intervention
+            new DamageCastFinder(30255,30255, EIData.InstantCastFinder.DefaultICD), // Wrath of Justice
+            new DamageCastFinder(9101,9101, EIData.InstantCastFinder.DefaultICD), // Smiter's Boon
+            new DamageCastFinder(9245,9245, EIData.InstantCastFinder.DefaultICD), // Smite Condition
+            new DamageCastFinder(9097,9097, EIData.InstantCastFinder.DefaultICD), // Symbol of Blades
             new DamageCastFinder(21795, 21795, EIData.InstantCastFinder.DefaultICD), // Glacial Heart
             new DamageCastFinder(22499, 22499, EIData.InstantCastFinder.DefaultICD), // Shattered Aegis
         };

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
@@ -9,6 +9,8 @@ namespace GW2EIEvtcParser.EIData
     {
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
+            new BuffGainCastFinder(29830, 30136, EIData.InstantCastFinder.DefaultICD), // Continuum Split
+            new BuffLossCastFinder(30747, 30136, EIData.InstantCastFinder.DefaultICD), // Continuum Shift
         };
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -25,7 +25,6 @@ namespace GW2EIEvtcParser.EIData
             ), // Signet of Midnight
             new BuffGainCastFinder(10197, 10198, EIData.InstantCastFinder.DefaultICD), // Portal Entre
             new DamageCastFinder(30192, 30192, EIData.InstantCastFinder.DefaultICD), // Lesser Phantasmal Defender
-            new BuffGainCastFinder(10192, 10243, EIData.InstantCastFinder.DefaultICD, 0, 92715), // Distortion
             new BuffGainCastFinder(10192, 10243, EIData.InstantCastFinder.DefaultICD, 92715, 97950, (evt, combatData) => {
                 var buffsLossToCheck = new List<long>
                 {

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
@@ -13,7 +14,7 @@ namespace GW2EIEvtcParser.EIData
         {
             new DamageCastFinder(10212, 10212, EIData.InstantCastFinder.DefaultICD), // Power spike
             new BuffLossCastFinder(10233, 10233, EIData.InstantCastFinder.DefaultICD, (brae, combatData) => {
-                return combatData.GetBuffData(brae.To).Exists(x => 
+                return combatData.GetBuffData(brae.To).Exists(x =>
                                     x is BuffApplyEvent bae &&
                                     bae.BuffID == 13017 &&
                                     Math.Abs(bae.AppliedDuration - 2000) <= ParserHelper.ServerDelayConstant &&
@@ -22,6 +23,58 @@ namespace GW2EIEvtcParser.EIData
                                  );
                 }
             ), // Signet of Midnight
+            new BuffGainCastFinder(10197, 10198, EIData.InstantCastFinder.DefaultICD), // Portal Entre
+            new DamageCastFinder(30192, 30192, EIData.InstantCastFinder.DefaultICD), // Lesser Phantasmal Defender
+            new BuffGainCastFinder(10192, 10243, EIData.InstantCastFinder.DefaultICD, 0, 92715), // Distortion
+            new BuffGainCastFinder(10192, 10243, EIData.InstantCastFinder.DefaultICD, 92715, 97950, (evt, combatData) => {
+                var buffsLossToCheck = new List<long>
+                {
+                    10235, 30739, 21751, 10231, 10246, 10233
+                }; // signets
+                foreach (long buffID in buffsLossToCheck)
+                {
+                    if (combatData.GetBuffData(buffID).Where(x => x.Time >= evt.Time - ParserHelper.ServerDelayConstant && x.Time <= evt.Time + ParserHelper.ServerDelayConstant && x is BuffRemoveAllEvent).Any())
+                    {
+                        return false;
+                    }
+                }
+                return true;
+
+            }), // Distortion
+            new BuffGainCastFinder(10192, 10243, EIData.InstantCastFinder.DefaultICD, 97950, 104844, (evt, combatData) => {
+                if (evt.To.Prof == "Chronomancer")
+                {
+                    return false;
+                }
+                var buffsLossToCheck = new List<long>
+                {
+                    10235, 30739, 21751, 10231, 10246, 10233
+                }; // signets
+                foreach (long buffID in buffsLossToCheck)
+                {
+                    if (combatData.GetBuffData(buffID).Where(x => x.Time >= evt.Time - ParserHelper.ServerDelayConstant && x.Time <= evt.Time + ParserHelper.ServerDelayConstant && x is BuffRemoveAllEvent).Any())
+                    {
+                        return false;
+                    }
+                }
+                return true;
+
+            }), // Distortion
+            new BuffGainCastFinder(10192, 10243, EIData.InstantCastFinder.DefaultICD, 104844, ulong.MaxValue, (evt, combatData) => {
+                var buffsLossToCheck = new List<long>
+                {
+                    10235, 30739, 21751, 10231, 10246, 10233
+                }; // signets
+                foreach (long buffID in buffsLossToCheck)
+                {
+                    if (combatData.GetBuffData(buffID).Where(x => x.Time >= evt.Time - ParserHelper.ServerDelayConstant && x.Time <= evt.Time + ParserHelper.ServerDelayConstant && x is BuffRemoveAllEvent).Any()) 
+                    {
+                        return false;
+                    }
+                }
+                return true;
+                
+            }), // Distortion
         };
 
 
@@ -54,6 +107,7 @@ namespace GW2EIEvtcParser.EIData
                 new Buff("Illusionary Counter",10278, ParserHelper.Source.Mesmer, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/e/e5/Illusionary_Counter.png"),
                 new Buff("Illusionary Riposte",10279, ParserHelper.Source.Mesmer, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/9/91/Illusionary_Riposte.png"),
                 new Buff("Illusionary Leap",10353, ParserHelper.Source.Mesmer, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/1/18/Illusionary_Leap.png"),
+                new Buff("Portal Weaving",10198, ParserHelper.Source.Mesmer, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/8/81/Portal_Entre.png"),
                 //traits
                 new Buff("Fencer's Finesse", 30426 , ParserHelper.Source.Mesmer, BuffStackType.Stacking, 10, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/e/e7/Fencer%27s_Finesse.png"),
                 new Buff("Illusionary Defense",49099, ParserHelper.Source.Mesmer, BuffStackType.Stacking, 5, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/e/e0/Illusionary_Defense.png"),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
@@ -11,6 +11,7 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
             new DamageCastFinder(45449, 45449, EIData.InstantCastFinder.DefaultICD), // Jaunt
+            new BuffGainCastFinder(SkillItem.MirageCloakDodgeId, 40408, EIData.InstantCastFinder.DefaultICD), // Mirage Cloak
         };
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>
@@ -21,22 +22,5 @@ namespace GW2EIEvtcParser.EIData
         {
                 new Buff("Mirage Cloak",40408, ParserHelper.Source.Mirage, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/a/a5/Mirage_Cloak_%28effect%29.png"),
         };
-
-
-        public static List<InstantCastEvent> TranslateMirageCloak(List<AbstractBuffEvent> buffs, SkillData skillData)
-        {
-            var res = new List<InstantCastEvent>();
-            long cloakStart = 0;
-            foreach (AbstractBuffEvent ba in buffs.Where(x => x is BuffApplyEvent))
-            {
-                if (ba.Time - cloakStart > 10)
-                {
-                    var dodgeLog = new InstantCastEvent(ba.Time, skillData.Get(SkillItem.MirageCloakDodgeId), ba.To.GetFinalMaster());
-                    res.Add(dodgeLog);
-                    cloakStart = ba.Time;
-                }
-            }
-            return res;
-        }
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
@@ -21,6 +21,7 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<Buff> Buffs = new List<Buff>
         {
                 new Buff("Mirage Cloak",40408, ParserHelper.Source.Mirage, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/a/a5/Mirage_Cloak_%28effect%29.png"),
+                new Buff("False Oasis",40802, ParserHelper.Source.Mirage, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/3/32/False_Oasis.png"),
         };
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -14,10 +14,9 @@ namespace GW2EIEvtcParser.EIData
             new DamageCastFinder(29560, 29560, EIData.InstantCastFinder.DefaultICD), // Spiteful Spirit
             new DamageCastFinder(13907, 13907, EIData.InstantCastFinder.DefaultICD), // Lesser Enfeeble
             new DamageCastFinder(13906, 13906, EIData.InstantCastFinder.DefaultICD), // Lesser Spinal Shivers
-            new BuffGainCastFinder(10583, 10582, EIData.InstantCastFinder.DefaultICD), // Spectral Armor
+            new BuffGainCastFinder(10583, 10582, EIData.InstantCastFinder.DefaultICD, 94051, ulong.MaxValue), // Spectral Armor
             new BuffGainCastFinder(10685, 15083, EIData.InstantCastFinder.DefaultICD, 0, 94051), // Spectral Walk
             new BuffGainCastFinder(10685, 53476, EIData.InstantCastFinder.DefaultICD, 94051, ulong.MaxValue), // Spectral Walk
-            //new BuffGainCastFinder(10635,???, 80647, ulong.MaxValue), // Lich's Gaze
         };
 
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -138,7 +138,6 @@ namespace GW2EIEvtcParser.EIData
                     case "Mirage":
                         MesmerHelper.InstantCastFinder.ForEach(x => instantCastFinders.Add(x));
                         MirageHelper.InstantCastFinder.ForEach(x => instantCastFinders.Add(x));
-                        res.AddRange(MirageHelper.TranslateMirageCloak(combatData.GetBuffData(40408), skillData));
                         break;
                     //
                     case "Thief":

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/HeraldHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/HeraldHelper.cs
@@ -14,6 +14,7 @@ namespace GW2EIEvtcParser.EIData
             new BuffGainCastFinder(27014, 28243, EIData.InstantCastFinder.DefaultICD), // Facet of Elements
             new BuffGainCastFinder(26644, 27376, EIData.InstantCastFinder.DefaultICD), // Facet of Strength
             new BuffGainCastFinder(27760, 27983, EIData.InstantCastFinder.DefaultICD), // Facet of Chaos
+            new DamageCastFinder(46857, 46857, EIData.InstantCastFinder.DefaultICD), // Call of the Dragon
         };
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
@@ -11,6 +11,7 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
             new BuffGainCastFinder(41858, 44272, EIData.InstantCastFinder.DefaultICD), // Legendary Renegade Stance
+            new DamageCastFinder(46849, 46849, EIData.InstantCastFinder.DefaultICD), // Call of the Renegade
         };
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -17,6 +17,12 @@ namespace GW2EIEvtcParser.EIData
             new BuffLossCastFinder(28382, 27581, 500), // Relinquish Power
             new BuffGainCastFinder(26557, 27273, EIData.InstantCastFinder.DefaultICD), // Vengeful Hammers
             new BuffLossCastFinder(26956, 27273, EIData.InstantCastFinder.DefaultICD), // Release Hammers
+            new BuffGainCastFinder(27975, 26596, EIData.InstantCastFinder.DefaultICD), // Rite of the Great Dwarf
+            new BuffGainCastFinder(27975, 33330, EIData.InstantCastFinder.DefaultICD), // Rite of the Great Dwarf (traited)
+            new DamageCastFinder(59591, 59591, EIData.InstantCastFinder.DefaultICD, 102321, ulong.MaxValue), // Invoking Torment
+            new DamageCastFinder(46854, 46854, EIData.InstantCastFinder.DefaultICD), // Call of the Assassin
+            new DamageCastFinder(46843, 46843, EIData.InstantCastFinder.DefaultICD), // Call of the Dwarf
+            new DamageCastFinder(46856, 46856, EIData.InstantCastFinder.DefaultICD), // Call of the Demon
         };
 
 
@@ -38,6 +44,7 @@ namespace GW2EIEvtcParser.EIData
         {         
                 new Buff("Vengeful Hammers", 27273, ParserHelper.Source.Revenant, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/c/c8/Vengeful_Hammers.png"),
                 new Buff("Rite of the Great Dwarf", 26596, ParserHelper.Source.Revenant, BuffNature.DefensiveBuffTable, "https://wiki.guildwars2.com/images/6/69/Rite_of_the_Great_Dwarf.png"),
+                new Buff("Rite of the Great Dwarf (Traited)", 33330, ParserHelper.Source.Revenant, BuffNature.DefensiveBuffTable, "https://wiki.guildwars2.com/images/6/69/Rite_of_the_Great_Dwarf.png"),
                 new Buff("Embrace the Darkness", 28001, ParserHelper.Source.Revenant, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/5/51/Embrace_the_Darkness.png"),
                 new Buff("Enchanted Daggers", 28557, ParserHelper.Source.Revenant, BuffStackType.Stacking, 25, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/f/fa/Enchanted_Daggers.png"),
                 new Buff("Phase Traversal", 28395, ParserHelper.Source.Revenant, BuffStackType.Stacking, 25, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/f/f2/Phase_Traversal.png"),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -17,8 +17,6 @@ namespace GW2EIEvtcParser.EIData
             new BuffLossCastFinder(28382, 27581, 500), // Relinquish Power
             new BuffGainCastFinder(26557, 27273, EIData.InstantCastFinder.DefaultICD), // Vengeful Hammers
             new BuffLossCastFinder(26956, 27273, EIData.InstantCastFinder.DefaultICD), // Release Hammers
-            new BuffGainCastFinder(27975, 26596, EIData.InstantCastFinder.DefaultICD), // Rite of the Great Dwarf
-            new BuffGainCastFinder(27975, 33330, EIData.InstantCastFinder.DefaultICD), // Rite of the Great Dwarf (traited)
             new DamageCastFinder(59591, 59591, EIData.InstantCastFinder.DefaultICD, 102321, ulong.MaxValue), // Invoking Torment
             new DamageCastFinder(46854, 46854, EIData.InstantCastFinder.DefaultICD), // Call of the Assassin
             new DamageCastFinder(46843, 46843, EIData.InstantCastFinder.DefaultICD), // Call of the Dwarf

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
@@ -10,6 +10,7 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
             new DamageCastFinder(31289, 31289, 500, 97950, ulong.MaxValue), // King of Fires
+            new BuffGainCastFinder(30189, 29466, EIData.InstantCastFinder.DefaultICD), // Blood Reckoning
         };
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
@@ -10,7 +10,6 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
             new DamageCastFinder(31289, 31289, 500, 97950, ulong.MaxValue), // King of Fires
-            new BuffGainCastFinder(30189, 29466, EIData.InstantCastFinder.DefaultICD), // Blood Reckoning
         };
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
+using static GW2EIEvtcParser.EIData.DamageModifier;
 
 namespace GW2EIEvtcParser.EIData
 {
@@ -16,7 +17,8 @@ namespace GW2EIEvtcParser.EIData
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>
         {
-
+            new BuffDamageModifierTarget(NumberOfBoonsID, "Pure Strike (boons)", "7% crit damage", DamageSource.NoPets, 7.0, DamageType.Power, DamageType.All, ParserHelper.Source.Spellbreaker, ByPresence, "https://wiki.guildwars2.com/images/7/76/Pure_Strike_%28trait%29.png", DamageModifierMode.All, (dEvt) => dEvt.HasCrit),
+            new BuffDamageModifierTarget(NumberOfBoonsID, "Pure Strike (no boons)", "14% crit damage", DamageSource.NoPets, 14.0, DamageType.Power, DamageType.All, ParserHelper.Source.Spellbreaker, ByAbsence, "https://wiki.guildwars2.com/images/7/76/Pure_Strike_%28trait%29.png", DamageModifierMode.All, (dEvt) => dEvt.HasCrit),
         };
 
         internal static readonly List<Buff> Buffs = new List<Buff>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/WarriorHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/WarriorHelper.cs
@@ -13,7 +13,9 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<InstantCastFinder> InstantCastFinder = new List<InstantCastFinder>()
         {
             new DamageCastFinder(14268, 14268, EIData.InstantCastFinder.DefaultICD, 84794, ulong.MaxValue), // Reckless Impact
-            new BuffGainCastFinder(45534, 45534, EIData.InstantCastFinder.DefaultICD), // Berserker Stance
+            new BuffGainCastFinder(14406, 14453, EIData.InstantCastFinder.DefaultICD), // Berserker Stance
+            new BuffGainCastFinder(14412, 34778, EIData.InstantCastFinder.DefaultICD), // Balanced Stance
+            new BuffGainCastFinder(14392, 787, EIData.InstantCastFinder.DefaultICD), // Endure Pain
         };
 
         private static HashSet<AgentItem> GetBannerAgents(Dictionary<long, List<AbstractBuffEvent>> buffData, long id, HashSet<AgentItem> playerAgents)

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -20,10 +20,12 @@ namespace GW2EIEvtcParser.ParsedData
         public const long AliveId = -6;
         public const long RespawnId = -7;
 
-        private const int FirstLandSet = 4;
-        private const int SecondLandSet = 5;
-        private const int FirstWaterSet = 0;
-        private const int SecondWaterSet = 1;
+        public const int FirstLandSet = 4;
+        public const int SecondLandSet = 5;
+        public const int FirstWaterSet = 0;
+        public const int SecondWaterSet = 1;
+        public const int TransformSet = 3;
+        public const int KitSet = 2;
         private static readonly Dictionary<long, string> _overrideNames = new Dictionary<long, string>()
         {
             {ResurrectId, "Resurrect"},
@@ -194,13 +196,13 @@ namespace GW2EIEvtcParser.ParsedData
         // Fields
         public long ID { get; private set; }
         //public int Range { get; private set; } = 0;
-        public bool AA => _apiSkill?.Slot == "Weapon_1" || _apiSkill?.Slot == "Downed_1";
+        public bool AA => ApiSkill?.Slot == "Weapon_1" || ApiSkill?.Slot == "Downed_1";
 
         public bool IsSwap => ID == WeaponSwapId || ElementalistHelper.IsElementalSwap(ID) || RevenantHelper.IsLegendSwap(ID);
         public string Name { get; private set; }
         public string Icon { get; private set; }
         private WeaponDescriptor _weaponDescriptor;
-        private readonly GW2APISkill _apiSkill;
+        internal GW2APISkill ApiSkill { get; }
         private SkillInfoEvent _skillInfo { get; set; }
 
         // Constructor
@@ -209,7 +211,7 @@ namespace GW2EIEvtcParser.ParsedData
         {
             this.ID = ID;
             Name = name.Replace("\0", "");
-            _apiSkill = GW2APIController.GetAPISkill(ID);
+            ApiSkill = GW2APIController.GetAPISkill(ID);
             CompleteItem();
         }
 
@@ -270,21 +272,21 @@ namespace GW2EIEvtcParser.ParsedData
             }
             if (_weaponDescriptor.WeaponSlot == WeaponDescriptor.Hand.Dual)
             {
-                weapons[id] = _apiSkill.WeaponType;
-                weapons[id + 1] = _apiSkill.DualWield;
+                weapons[id] = ApiSkill.WeaponType;
+                weapons[id + 1] = ApiSkill.DualWield;
             }
             else if (_weaponDescriptor.WeaponSlot == WeaponDescriptor.Hand.TwoHand)
             {
-                weapons[id] = _apiSkill.WeaponType;
+                weapons[id] = ApiSkill.WeaponType;
                 weapons[id + 1] = "2Hand";
             }
             else if (_weaponDescriptor.WeaponSlot == WeaponDescriptor.Hand.MainHand)
             {
-                weapons[id] = _apiSkill.WeaponType;
+                weapons[id] = ApiSkill.WeaponType;
             }
             else
             {
-                weapons[id + 1] = _apiSkill.WeaponType;
+                weapons[id + 1] = ApiSkill.WeaponType;
             }
             return true;
         }
@@ -303,9 +305,9 @@ namespace GW2EIEvtcParser.ParsedData
             {
                 Name = name;
             }
-            else if (_apiSkill != null)
+            else if (ApiSkill != null)
             {
-                Name = _apiSkill.Name;
+                Name = ApiSkill.Name;
                 /*if (_apiSkill.Facts != null)
                 {
                     foreach (GW2APIFact fact in _apiSkill.Facts)
@@ -323,11 +325,11 @@ namespace GW2EIEvtcParser.ParsedData
             }
             else
             {
-                Icon = _apiSkill != null ? _apiSkill.Icon : DefaultIcon;
+                Icon = ApiSkill != null ? ApiSkill.Icon : DefaultIcon;
             }
-            if (_apiSkill != null && _apiSkill.Type == "Weapon" && _apiSkill.WeaponType != "None" && _apiSkill.Professions.Count > 0 && (_apiSkill.Categories == null || (_apiSkill.Categories.Count == 1 && (_apiSkill.Categories[0] == "Phantasm" || _apiSkill.Categories[0] == "DualWield"))))
+            if (ApiSkill != null && ApiSkill.Type == "Weapon" && ApiSkill.WeaponType != "None" && ApiSkill.Professions.Count > 0 && (ApiSkill.Categories == null || (ApiSkill.Categories.Count == 1 && (ApiSkill.Categories[0] == "Phantasm" || ApiSkill.Categories[0] == "DualWield"))))
             {
-                _weaponDescriptor = new WeaponDescriptor(_apiSkill);
+                _weaponDescriptor = new WeaponDescriptor(ApiSkill);
             }
 #if DEBUG
             Name += " (" + ID + ")";

--- a/GW2EIGW2API/GW2API/GW2APISkill.cs
+++ b/GW2EIGW2API/GW2API/GW2APISkill.cs
@@ -44,9 +44,9 @@ namespace GW2EIGW2API.GW2API
         [JsonProperty(PropertyName = "prev_chain")]
         public int PrevChain { get; internal set; }
         [JsonProperty(PropertyName = "transform_skills")]
-        public List<int> TransformSkills { get; internal set; }
+        public List<long> TransformSkills { get; internal set; }
         [JsonProperty(PropertyName = "bundle_skills")]
-        public List<int> BundleSkills { get; internal set; }
+        public List<long> BundleSkills { get; internal set; }
 
         [JsonProperty(PropertyName = "toolbelt_skill")]
         public int ToolbeltSkill { get; internal set; }


### PR DESCRIPTION
- Fixed a reg on Mirage Cloak due to instant cast
- Migrated Mirage Cloak detection to instant cast finders
- Added Mirage Cloak check for minions
- Removed BuffInitial from buff apply based instant cast finders
- Added WeaponSwapCastFinder
- Added several new instant cast detection, most notables being Engineer kits and Mesmer distortion
- Completed buffs and damage mods while working on instant casts
