### PR TITLE
Success detection fallback

### DIFF
--- a/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
@@ -53,7 +53,7 @@ namespace GW2EIEvtcParser.EIData
                 _deads = new List<(long start, long end)>();
                 _downs = new List<(long start, long end)>();
                 _dcs = new List<(long start, long end)>();
-                AgentItem.GetAgentStatus(_deads, _downs, _dcs, log);
+                AgentItem.GetAgentStatus(_deads, _downs, _dcs, log.CombatData, log.FightData);
             }
             return (_deads, _downs, _dcs);
         }

--- a/GW2EIEvtcParser/EIData/PhaseData.cs
+++ b/GW2EIEvtcParser/EIData/PhaseData.cs
@@ -102,7 +102,7 @@ namespace GW2EIEvtcParser.EIData
             var dead = new List<(long start, long end)>();
             var down = new List<(long start, long end)>();
             var dc = new List<(long start, long end)>();
-            p.AgentItem.GetAgentStatus(dead, down, dc, log);
+            p.AgentItem.GetAgentStatus(dead, down, dc, log.CombatData, log.FightData);
             return DurationInMS -
                 dead.Sum(x =>
                 {

--- a/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
@@ -414,7 +414,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             var lastTargetDamages = new List<AbstractHealthDamageEvent>();
             foreach (AgentItem a in playerAgents)
             {
-                playerExits.AddRange(combatData.GetExitCombatEvents(a));
+                var playerDeadDCTimes = new List<long>(combatData.GetDeadEvents(a).Select(x => x.Time));
+                playerDeadDCTimes.AddRange(combatData.GetDespawnEvents(a).Select(x => x.Time));
+                playerExits.AddRange(combatData.GetExitCombatEvents(a).Where(x => !playerDeadDCTimes.Any(y => y >= x.Time - ParserHelper.ServerDelayConstant)));
             }
             foreach (NPC t in targets)
             {

--- a/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
@@ -449,7 +449,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         fightData.SetSuccess(true, lastDamageTaken.Time);
                     }
                 }
-                else if (fightData.FightEnd > targets.Max(x => x.LastAware) + 2000)
+                else if (fightData.FightEnd > targets.Max(x => x.LastAware) + ParserHelper.MinimumInCombatDuration)
                 {
                     fightData.SetSuccess(true, lastDamageTaken.Time);
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/FractalLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/FractalLogic.cs
@@ -70,10 +70,6 @@ namespace GW2EIEvtcParser.EncounterLogic
                 else
                 {
                     SetSuccessByDeath(combatData, fightData, playerAgents, true, GenericTriggerID);
-                    if (fightData.Success)
-                    {
-                        fightData.SetSuccess(true, Math.Min(fightData.FightEnd, lastDamageTaken.Time));
-                    }
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -87,7 +87,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                                 phase.Name = "Blue Knight";
                                 break;
                             default:
-                                throw new MissingKeyActorsException("Unknown phase target in MAMA");
+                                phase.Name = "Unknown";
+                                break;
                         }
                     }
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
@@ -94,7 +94,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 throw new MissingKeyActorsException("Arkk not found");
             }
-            var adjustedPlayers = new HashSet<AgentItem>(combatData.GetDamageTakenData(target.AgentItem).Where(x => playerAgents.Contains(x.From.GetFinalMaster())).Select(x => x.From.GetFinalMaster()));
+            HashSet<AgentItem> adjustedPlayers = GetParticipatingPlayerAgents(target, combatData, playerAgents);
             // missing buff apply events fallback, some phases will be missing
             // removes should be present
             if (SetSuccessByBuffCount(combatData, fightData, adjustedPlayers, target, 762, 10))

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using GW2EIEvtcParser.EIData;
+using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
 
 namespace GW2EIEvtcParser.EncounterLogic
@@ -52,7 +54,13 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void CheckSuccess(CombatData combatData, AgentData agentData, FightData fightData, HashSet<AgentItem> playerAgents)
         {
-            SetSuccessByBuffCount(combatData, fightData, playerAgents, Targets.Find(x => x.ID == (int)ArcDPSEnums.TargetID.Artsariiv), 762, 4);
+            NPC target = Targets.Find(x => x.ID == (int)ArcDPSEnums.TargetID.Artsariiv);
+            if (target == null)
+            {
+                throw new MissingKeyActorsException("Artsariiv not found");
+            }
+            var adjustedPlayers = new HashSet<AgentItem>(combatData.GetDamageTakenData(target.AgentItem).Where(x => playerAgents.Contains(x.From.GetFinalMaster())).Select(x => x.From.GetFinalMaster()));
+            SetSuccessByBuffCount(combatData, fightData, adjustedPlayers, target, 762, 4);
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -59,8 +59,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 throw new MissingKeyActorsException("Artsariiv not found");
             }
-            var adjustedPlayers = new HashSet<AgentItem>(combatData.GetDamageTakenData(target.AgentItem).Where(x => playerAgents.Contains(x.From.GetFinalMaster())).Select(x => x.From.GetFinalMaster()));
-            SetSuccessByBuffCount(combatData, fightData, adjustedPlayers, target, 762, 4);
+            SetSuccessByBuffCount(combatData, fightData, GetParticipatingPlayerAgents(target, combatData, playerAgents), target, 762, 4);
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/ShatteredObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/ShatteredObservatory.cs
@@ -12,6 +12,15 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         }
 
+        protected static HashSet<AgentItem> GetParticipatingPlayerAgents(NPC target, CombatData combatData, HashSet<AgentItem> playerAgents)
+        {
+            if (target == null)
+            {
+                return new HashSet<AgentItem>();
+            }
+            return new HashSet<AgentItem>(combatData.GetDamageTakenData(target.AgentItem).Where(x => playerAgents.Contains(x.From.GetFinalMaster())).Select(x => x.From.GetFinalMaster()));
+        }
+
         /// <summary>
         /// Returns true if the buff count was not reached so that another method can be called, if necessary
         /// </summary>

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/ShatteredObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/ShatteredObservatory.cs
@@ -12,11 +12,14 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         }
 
-        protected static void SetSuccessByBuffCount(CombatData combatData, FightData fightData, HashSet<AgentItem> playerAgents, NPC target, long buffID, int count)
+        /// <summary>
+        /// Returns true if the buff count was not reached so that another method can be called, if necessary
+        /// </summary>
+        protected static bool SetSuccessByBuffCount(CombatData combatData, FightData fightData, HashSet<AgentItem> playerAgents, NPC target, long buffID, int count)
         {
             if (target == null)
             {
-                return;
+                return false;
             }
             List<AbstractBuffEvent> invulsTarget = GetFilteredList(combatData, buffID, target, true);
             if (invulsTarget.Count == count)
@@ -25,8 +28,10 @@ namespace GW2EIEvtcParser.EncounterLogic
                 if (!(last is BuffApplyEvent))
                 {
                     SetSuccessByCombatExit(new List<NPC> { target }, combatData, fightData, playerAgents);
+                    return false;
                 }
             }
+            return true;
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -103,7 +103,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                                 phase.Name = "Karde";
                                 break;
                             default:
-                                throw new MissingKeyActorsException("Unknown phase target in Sabetha");
+                                phase.Name = "Unknown";
+                                break;
                         }
                     }
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/River.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/River.cs
@@ -58,16 +58,12 @@ namespace GW2EIEvtcParser.EncounterLogic
                 if (ooc != null)
                 {
                     long time = 0;
-                    foreach (NPC mob in TrashMobs.Where(x => x.ID == (int)ArcDPSEnums.TrashID.SpiritHorde3))
+                    foreach (NPC mob in TrashMobs)
                     {
-                        DespawnEvent dspwnHorde = combatData.GetDespawnEvents(mob.AgentItem).LastOrDefault();
-                        if (dspwnHorde != null)
-                        {
-                            time = Math.Max(dspwnHorde.Time, time);
-                        }
+                        time = Math.Max(mob.LastAware, time);
                     }
                     DespawnEvent dspwn = combatData.GetDespawnEvents(desmina.AgentItem).LastOrDefault();
-                    if (time != 0 && dspwn == null && time <= desmina.LastAware)
+                    if (time != 0 && dspwn == null && time + 500 <= desmina.LastAware)
                     {
                         fightData.SetSuccess(true, time);
                     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -238,7 +238,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                                 phase.Name = "Wyvern";
                                 break;
                             default:
-                                throw new MissingKeyActorsException("Unknown phase target in Qadim");
+                                phase.Name = "Unknown";
+                                break;
                         }
                     }
                 }

--- a/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
@@ -165,26 +165,26 @@ namespace GW2EIEvtcParser.ParsedData
             }
         }
 
-        public void GetAgentStatus(List<(long start, long end)> dead, List<(long start, long end)> down, List<(long start, long end)> dc, ParsedEvtcLog log)
+        internal void GetAgentStatus(List<(long start, long end)> dead, List<(long start, long end)> down, List<(long start, long end)> dc, CombatData combatData, FightData fightData)
         {
             var status = new List<AbstractStatusEvent>();
-            status.AddRange(log.CombatData.GetDownEvents(this));
-            status.AddRange(log.CombatData.GetAliveEvents(this));
-            status.AddRange(log.CombatData.GetDeadEvents(this));
-            status.AddRange(log.CombatData.GetSpawnEvents(this));
-            status.AddRange(log.CombatData.GetDespawnEvents(this));
+            status.AddRange(combatData.GetDownEvents(this));
+            status.AddRange(combatData.GetAliveEvents(this));
+            status.AddRange(combatData.GetDeadEvents(this));
+            status.AddRange(combatData.GetSpawnEvents(this));
+            status.AddRange(combatData.GetDespawnEvents(this));
             status = status.OrderBy(x => x.Time).ToList();
             for (int i = 0; i < status.Count - 1; i++)
             {
                 AbstractStatusEvent cur = status[i];
                 AbstractStatusEvent next = status[i + 1];
-                AddValueToStatusList(dead, down, dc, cur, next, log.FightData.FightEnd, i);
+                AddValueToStatusList(dead, down, dc, cur, next, fightData.FightEnd, i);
             }
             // check last value
             if (status.Count > 0)
             {
                 AbstractStatusEvent cur = status.Last();
-                AddValueToStatusList(dead, down, dc, cur, null, log.FightData.FightEnd, status.Count - 1);
+                AddValueToStatusList(dead, down, dc, cur, null, fightData.FightEnd, status.Count - 1);
             }
         }
 

--- a/GW2EIEvtcParser/ParserHelpers/ParserHelper.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserHelper.cs
@@ -41,6 +41,7 @@ namespace GW2EIEvtcParser
         internal const long ServerDelayConstant = 10;
         internal const long BuffSimulatorDelayConstant = 50;
         internal const long WeaponSwapDelayConstant = 75;
+        internal const long MinimumInCombatDuration = 2200;
 
         internal const int PhaseTimeLimit = 1000;
 

--- a/GW2EIEvtcParser/ParserHelpers/ParserSettings.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserSettings.cs
@@ -23,7 +23,7 @@ namespace GW2EIEvtcParser
             ParsePhases = parsePhases;
             ParseCombatReplay = parseCombatReplay;
             ComputeDamageModifiers = computeDamageModifiers;
-            TooShortLimit = Math.Max(tooShortLimit, 2200);
+            TooShortLimit = Math.Max(tooShortLimit, ParserHelper.MinimumInCombatDuration);
             DetailedWvWParse = detailledWvW;
         }
     }


### PR DESCRIPTION
- Reworked SetSuccessByCombatExit (+ the similar algorithm for Deimos)
- Some refactoring for Arts and Arkk + reduced player agents to avoid non contributing players
- Reworked River of Souls missing reward success detection