### PR TITLE
Cairn stuff

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/Buff.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/Buff.cs
@@ -449,6 +449,7 @@ namespace GW2EIEvtcParser.EIData
                 new Buff("Unbridled Chaos", 56467, ParserHelper.Source.FightSpecific, BuffStackType.Stacking, 3, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/7/74/Unbridled_Chaos.png"),
                 // Cairn        
                 new Buff("Shared Agony", 38049, ParserHelper.Source.FightSpecific, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/5/53/Shared_Agony.png"),
+                new Buff("Enraged (Cairn)", 37675, ParserHelper.Source.FightSpecific, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/7/78/Vengeance_%28Mordrem%29.png"),
                 new Buff("Unseen Burden", 38153, ParserHelper.Source.FightSpecific, BuffStackType.Stacking , 99, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/b/b9/Unseen_Burden.png"),
                 // Ai, Keeper of the Peak
                 new Buff("Tidal Barrier", 61402, ParserHelper.Source.FightSpecific, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/b/b1/Primed_Bottle.png"),

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
@@ -57,6 +57,40 @@ namespace GW2EIEvtcParser.EncounterLogic
                             (11774, 4480, 14078, 5376));
         }
 
+        internal override List<PhaseData> GetPhases(ParsedEvtcLog log, bool requirePhases)
+        {
+            List<PhaseData> phases = GetInitialPhase(log);
+            NPC mainTarget = Targets.Find(x => x.ID == (int)ArcDPSEnums.TargetID.Cairn);
+            if (mainTarget == null)
+            {
+                throw new InvalidOperationException("Cairn not found");
+            }
+            phases[0].Targets.Add(mainTarget);
+            if (!requirePhases)
+            {
+                return phases;
+            }
+            /*BuffApplyEvent enrageApply;
+            if (false)
+            {
+                var normalPhase = new PhaseData(0, enrageApply.Time)
+                {
+                    Name = "Normal"
+                };
+                normalPhase.Targets.Add(mainTarget);
+
+                var enragePhase = new PhaseData(enrageApply.Time + 1, log.FightData.FightEnd)
+                {
+                    Name = "Enrage"
+                };
+                enragePhase.Targets.Add(mainTarget);
+
+                phases.Add(normalPhase);
+                phases.Add(enragePhase);
+            }*/
+            return phases;
+        }
+
         internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
         {
             List<AbstractCastEvent> cls = target.GetCastLogs(log, 0, log.FightData.FightEnd);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
@@ -149,20 +149,23 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
             else
             {
-                CombatItem impactInitialEnd = combatData.Find(x => x.IsActivation.EndCasting() && (x.Time - fightData.FightOffset) < 2000 && x.SrcAgent == target.Agent && x.SkillID == 38102);
-                // Action 4 from skill dump for 38102
-                if (impactInitialEnd != null)
+                // get first end casting
+                CombatItem firstCastEnd = combatData.FirstOrDefault(x => x.IsActivation.EndCasting() && (x.Time - fightData.FightOffset) < 2000 && x.SrcAgent == target.Agent);
+                // It has to Impact(38102), otherwise anomaly, player may have joined mid fight, do nothing
+                if (firstCastEnd != null && firstCastEnd.SkillID == 38102)
                 {
+                    // Action 4 from skill dump for 38102
+
                     // Adds around 10 to 15 ms diff compared to buff loss
-                    if (impactInitialEnd.BuffDmg > 0)
+                    if (firstCastEnd.BuffDmg > 0)
                     {
-                        var nonScaledToScaledRatio = (double)impactInitialEnd.Value / impactInitialEnd.BuffDmg;
-                        fightData.OverrideOffset(impactInitialEnd.Time - impactInitialEnd.Value + (long)Math.Round(nonScaledToScaledRatio * 1025) - 1);
+                        var nonScaledToScaledRatio = (double)firstCastEnd.Value / firstCastEnd.BuffDmg;
+                        fightData.OverrideOffset(firstCastEnd.Time - firstCastEnd.Value + (long)Math.Round(nonScaledToScaledRatio * 1025) - 1);
                     }
                     // Adds around 15 to 20 ms diff compared to buff loss
                     else
                     {
-                        fightData.OverrideOffset(impactInitialEnd.Time - impactInitialEnd.Value + 1025 - 1);
+                        fightData.OverrideOffset(firstCastEnd.Time - firstCastEnd.Value + 1025 - 1);
                     }
                 }
             }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
@@ -60,34 +60,36 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override List<PhaseData> GetPhases(ParsedEvtcLog log, bool requirePhases)
         {
             List<PhaseData> phases = GetInitialPhase(log);
-            NPC mainTarget = Targets.Find(x => x.ID == (int)ArcDPSEnums.TargetID.Cairn);
-            if (mainTarget == null)
+            NPC cairn = Targets.Find(x => x.ID == (int)ArcDPSEnums.TargetID.Cairn);
+            if (cairn == null)
             {
                 throw new InvalidOperationException("Cairn not found");
             }
-            phases[0].Targets.Add(mainTarget);
+            phases[0].Targets.Add(cairn);
+            List<AbstractHealthDamageEvent> test = log.PlayerList[0].GetDamageTakenLogs(null, log, 0, 6000);
+            List<EnterCombatEvent> test2 = log.CombatData.GetEnterCombatEvents(cairn.AgentItem);
             if (!requirePhases)
             {
                 return phases;
             }
-            /*BuffApplyEvent enrageApply;
-            if (false)
+            BuffApplyEvent enrageApply = log.CombatData.GetBuffData(37675).OfType<BuffApplyEvent>().FirstOrDefault(x => x.To == cairn.AgentItem);
+            if (enrageApply != null)
             {
                 var normalPhase = new PhaseData(0, enrageApply.Time)
                 {
-                    Name = "Normal"
+                    Name = "Calm"
                 };
-                normalPhase.Targets.Add(mainTarget);
+                normalPhase.Targets.Add(cairn);
 
                 var enragePhase = new PhaseData(enrageApply.Time + 1, log.FightData.FightEnd)
                 {
-                    Name = "Enrage"
+                    Name = "Angry"
                 };
-                enragePhase.Targets.Add(mainTarget);
+                enragePhase.Targets.Add(cairn);
 
                 phases.Add(normalPhase);
                 phases.Add(enragePhase);
-            }*/
+            }
             return phases;
         }
 
@@ -145,7 +147,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             CombatItem spawnProtectionLoss = combatData.Find(x => x.IsBuffRemove == ArcDPSEnums.BuffRemove.All && x.IsBuff != 0 && x.SrcAgent == target.Agent && x.SkillID == 34113);
             if (spawnProtectionLoss != null)
             {
-                fightData.OverrideOffset(spawnProtectionLoss.Time);
+                fightData.OverrideOffset(spawnProtectionLoss.Time - 1);
             }
             return fightData.FightOffset;
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
@@ -155,17 +155,17 @@ namespace GW2EIEvtcParser.EncounterLogic
                 if (firstCastEnd != null && firstCastEnd.SkillID == 38102)
                 {
                     // Action 4 from skill dump for 38102
-
+                    long actionHappened = 1025;
                     // Adds around 10 to 15 ms diff compared to buff loss
                     if (firstCastEnd.BuffDmg > 0)
                     {
                         var nonScaledToScaledRatio = (double)firstCastEnd.Value / firstCastEnd.BuffDmg;
-                        fightData.OverrideOffset(firstCastEnd.Time - firstCastEnd.Value + (long)Math.Round(nonScaledToScaledRatio * 1025) - 1);
+                        fightData.OverrideOffset(firstCastEnd.Time - firstCastEnd.Value + (long)Math.Round(nonScaledToScaledRatio * actionHappened) - 1);
                     }
                     // Adds around 15 to 20 ms diff compared to buff loss
                     else
                     {
-                        fightData.OverrideOffset(firstCastEnd.Time - firstCastEnd.Value + 1025 - 1);
+                        fightData.OverrideOffset(firstCastEnd.Time - firstCastEnd.Value + actionHappened - 1);
                     }
                 }
             }

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AbstractCastEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AbstractCastEvent.cs
@@ -21,10 +21,10 @@
 
         public double Acceleration { get; protected set; } = 0;
 
-        internal AbstractCastEvent(CombatItem startItem, AgentData agentData, SkillData skillData) : base(startItem.Time)
+        internal AbstractCastEvent(CombatItem baseItem, AgentData agentData, SkillData skillData) : base(baseItem.Time)
         {
-            Skill = skillData.Get(startItem.SkillID);
-            Caster = agentData.GetAgent(startItem.SrcAgent);
+            Skill = skillData.Get(baseItem.SkillID);
+            Caster = agentData.GetAgent(baseItem.SrcAgent);
         }
 
         internal AbstractCastEvent(long time, SkillItem skill, AgentItem caster) : base(time)

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AnimatedCastEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AnimatedCastEvent.cs
@@ -46,8 +46,8 @@ namespace GW2EIEvtcParser.ParsedData
                         Status = AnimationStatus.Full;
                         break;
                     case ArcDPSEnums.Activation.CancelFire:
-                        int nonScaledExpectedDuration = (int)Math.Round(ExpectedDuration / nonScaledToScaledRatio);
-                        SavedDuration = Math.Max(nonScaledExpectedDuration - ActualDuration, 0);
+                        int scaledExpectedDuration = (int)Math.Round(ExpectedDuration / nonScaledToScaledRatio);
+                        SavedDuration = Math.Max(scaledExpectedDuration - ActualDuration, 0);
                         Status = AnimationStatus.Reduced;
                         break;
                 }

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AnimatedCastEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AnimatedCastEvent.cs
@@ -17,16 +17,8 @@ namespace GW2EIEvtcParser.ParsedData
             //_effectHappenedDuration = startItem.Value;
         }
 
-        internal AnimatedCastEvent(CombatItem startItem, CombatItem endItem, AgentData agentData, SkillData skillData) : this(startItem, agentData, skillData)
+        private void SetAcceleration(CombatItem endItem)
         {
-            ActualDuration = endItem.Value;
-            _scaledActualDuration = endItem.BuffDmg;
-            if (Skill.ID == SkillItem.DodgeId)
-            {
-                ExpectedDuration = 750;
-                ActualDuration = 750;
-                _scaledActualDuration = 0;
-            }
             double nonScaledToScaledRatio = 1.0;
             if (_scaledActualDuration > 0)
             {
@@ -63,16 +55,44 @@ namespace GW2EIEvtcParser.ParsedData
             Acceleration = Math.Round(Acceleration, ParserHelper.AccelerationDigit);
         }
 
-        internal AnimatedCastEvent(CombatItem startItem, AgentData agentData, SkillData skillData, long logEnd) : this(startItem, agentData, skillData)
+        internal AnimatedCastEvent(AgentData agentData, SkillData skillData, CombatItem endItem) : base (endItem, agentData, skillData)
+        {
+            ActualDuration = endItem.Value;
+            ExpectedDuration = ActualDuration;
+            Time -= ActualDuration;
+            _scaledActualDuration = endItem.BuffDmg;
+            if (Skill.ID == SkillItem.DodgeId)
+            {
+                ExpectedDuration = 750;
+                ActualDuration = 750;
+                _scaledActualDuration = 0;
+            }
+            SetAcceleration(endItem);
+        }
+
+        internal AnimatedCastEvent(CombatItem startItem, AgentData agentData, SkillData skillData, CombatItem endItem) : this(startItem, agentData, skillData)
+        {
+            ActualDuration = endItem.Value;
+            _scaledActualDuration = endItem.BuffDmg;
+            if (Skill.ID == SkillItem.DodgeId)
+            {
+                ExpectedDuration = 750;
+                ActualDuration = 750;
+                _scaledActualDuration = 0;
+            }
+            SetAcceleration(endItem);
+        }
+
+        internal AnimatedCastEvent(CombatItem startItem, AgentData agentData, SkillData skillData, long maxEnd) : this(startItem, agentData, skillData)
         {
             if (Skill.ID == SkillItem.DodgeId)
             {
                 ExpectedDuration = 750;
             }
             ActualDuration = ExpectedDuration;
-            if (ActualDuration + Time > logEnd)
+            if (ActualDuration + Time > maxEnd)
             {
-                ActualDuration = (int)(logEnd - Time);
+                ActualDuration = (int)(maxEnd - Time);
             }
         }
     }

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AnimatedCastEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/CastEvents/AnimatedCastEvent.cs
@@ -26,11 +26,11 @@ namespace GW2EIEvtcParser.ParsedData
                 if (nonScaledToScaledRatio > 1.0)
                 {
                     // faster
-                    Acceleration = (nonScaledToScaledRatio - 1.0) / 0.66;
+                    Acceleration = (nonScaledToScaledRatio - 1.0) / 0.5;
                 }
                 else
                 {
-                    Acceleration = -(1.0 - nonScaledToScaledRatio) / 0.5;
+                    Acceleration = -nonScaledToScaledRatio / 0.6;
                 }
                 Acceleration = Math.Max(Math.Min(Acceleration, 1.0), -1.0);
             }

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/CombatEventFactory.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/CombatEventFactory.cs
@@ -285,8 +285,13 @@ namespace GW2EIEvtcParser.ParsedData
                     {
                         if (startItem != null && startItem.SkillID == c.SkillID)
                         {
-                            res.Add(new AnimatedCastEvent(startItem, c, agentData, skillData));
+                            res.Add(new AnimatedCastEvent(startItem, agentData, skillData, c));
                             startItem = null;
+                        } 
+                        // missing start
+                        else
+                        {
+                            res.Add(new AnimatedCastEvent(agentData, skillData, c));
                         }
                     }
                 }


### PR DESCRIPTION
- Added enrage phases for Cairn
- Noticed the "spawn protection check" was not always working when logs start sooner than expected as the buff remove event is missing, as such, implemented two fallbacks to this method, both using first Impact(38102) cast end event. From the skill dump, the effect of the cast happens at 1025 ms:
   - If scaled duration is present, use the scaled/nonScaled ratio to transform 1025. Get the fight offset by doing logStart - actualDuration + effectHappened
   - If scaled duration is not present (old logs), simply do logStart - actualDuration + 1025

From my measurements, the first fallback adds between 10ms  and 15 ms to the fight while the 2nd adds 15ms to 20ms. The difference shouldn't be big as Cairn never starts with quickness.
- Also added AnimatedCastEvents for when the first seen activation is an EndCasting(). As such skills which started before log start but ended after it will appear on your rotation. It'll have proper acceleration and saved time values (in CANCEL_FIRE situations) with logs that have scaled durations.
