### PR TITLE
Html 

### DIFF
--- a/GW2EIBuilders/Resources/CR-JS/animator.js
+++ b/GW2EIBuilders/Resources/CR-JS/animator.js
@@ -57,6 +57,8 @@ class Animator {
         this.backwards = false;
         this.rangeControl = [{ enabled: false, radius: 180 }, { enabled: false, radius: 360 }, { enabled: false, radius: 720 }];
         this.highlightSelectedGroup = true;
+        this.displayMechanics = true;
+        this.displayTrashMobs = true;
         this.selectedGroup = -1;
         this.coneControl = {
             enabled: false,
@@ -282,6 +284,16 @@ class Animator {
 
     toggleHighlightSelectedGroup() {
         this.highlightSelectedGroup = !this.highlightSelectedGroup;
+        animateCanvas(noUpdateTime);
+    }
+
+    toggleTrashMobs() {
+        this.displayTrashMobs = !this.displayTrashMobs;
+        animateCanvas(noUpdateTime);
+    }
+
+    toggleMechanics() {
+        this.displayMechanics = !this.displayMechanics;
         animateCanvas(noUpdateTime);
     }
 
@@ -558,9 +570,12 @@ class Animator {
         for (let i = 0; i < animator.backgroundActorData.length; i++) {
             animator.backgroundActorData[i].draw();
         }
-        for (let i = 0; i < this.mechanicActorData.length; i++) {
-            this.mechanicActorData[i].draw();
+        if (this.displayMechanics) {
+            for (let i = 0; i < this.mechanicActorData.length; i++) {
+                this.mechanicActorData[i].draw();
+            }
         }
+        
         this.playerData.forEach(function (value, key, map) {
             if (!value.selected) {
                 value.draw();
@@ -569,12 +584,16 @@ class Animator {
                 }
             }
         });
-        this.trashMobData.forEach(function (value, key, map) {
-            value.draw();
-            if (_this.attachedActorData.has(key)) {
-                _this.attachedActorData.get(key).draw();
-            }
-        });
+        
+        if (this.displayTrashMobs) {
+            this.trashMobData.forEach(function (value, key, map) {
+                value.draw();
+                if (_this.attachedActorData.has(key)) {
+                    _this.attachedActorData.get(key).draw();
+                }
+            });
+        }
+        
         this.targetData.forEach(function (value, key, map) {
             value.draw();
             if (_this.attachedActorData.has(key)) {

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayExtraDecorations.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayExtraDecorations.html
@@ -1,8 +1,18 @@
 <template>
-    <div class="d-flex flex-column justify-content-center align-items-center">
-        <div class="form-check mb-2">
-            <input type="checkbox" class="form-check-input" id="subgroupCheck" checked v-on:change="getAnimator().toggleHighlightSelectedGroup()">
-            <label class="form-check-label" for="subgroupCheck">Highlight Selected Group</label>
+    <div class="d-flex flex-column justify-content-center align-items-center">     
+        <div class="d-flex flex-row justify-content-center">
+            <div class="form-check mb-2 mr-3">
+                <input type="checkbox" class="form-check-input" id="subgroupCheck" checked v-on:change="getAnimator().toggleHighlightSelectedGroup()">
+                <label class="form-check-label" for="subgroupCheck">Highlight Selected Group</label>
+            </div>
+            <div class="form-check mb-2 mr-3">
+                <input type="checkbox" class="form-check-input" id="trashCheck" checked v-on:change="getAnimator().toggleTrashMobs()">
+                <label class="form-check-label" for="trashCheck">Secondary NPCs</label>
+            </div>
+            <div class="form-check mb-2">
+                <input type="checkbox" class="form-check-input" id="mechanicsCheck" checked v-on:change="getAnimator().toggleMechanics()">
+                <label class="form-check-label" for="mechanicsCheck">Mechanics</label>
+            </div>
         </div>
         <div class="d-flex flex-row justify-content-center">
             <div class="mr-3">

--- a/GW2EIBuilders/Resources/ei.css
+++ b/GW2EIBuilders/Resources/ei.css
@@ -394,6 +394,26 @@ table.dataTable thead .sorting_desc_disabled:after {
     display: none;
 }
 
+.sub-cell { 
+    width: 20px ;
+}
+
+.prof-cell {
+    width: 5px;
+}
+
+.damage-cell {
+    width: 150px;
+}
+
+.stat-cell {
+    width: 120px;
+}
+
+.damage-dist-cell {
+    width: 100px;
+}
+
 table.dataTable thead .sorting_asc:before,
 table.dataTable thead .sorting_desc:after {
     right: 0.3em;

--- a/GW2EIBuilders/Resources/ei.css
+++ b/GW2EIBuilders/Resources/ei.css
@@ -221,10 +221,28 @@ body {
     cursor: pointer !important;
 }
 
+
 .player-cell {
     width: 125px;
     min-height: 90px;
-    border: 1px solid;
+}
+
+.theme-yeti .player-cell{
+    box-shadow: 
+    1px 0 0 0 #dee2e6, 
+    0 1px 0 0 #dee2e6, 
+    1px 1px 0 0 #dee2e6,
+    1px 0 0 0 #dee2e6 inset, 
+    0 1px 0 0 #dee2e6 inset;
+}
+
+.theme-slate .player-cell {
+    box-shadow: 
+    1px 0 0 0 rgb(10, 10, 10), 
+    0 1px 0 0 rgb(10, 10, 10), 
+    1px 1px 0 0 rgb(10, 10, 10),
+    1px 0 0 0 rgb(10, 10, 10) inset, 
+    0 1px 0 0 rgb(10, 10, 10) inset;
 }
 
 .player-cell-shorten {

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplBuffTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplBuffTable.html
@@ -5,10 +5,10 @@
         <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%" :id="id">
             <thead>
                 <tr>
-                    <th>Sub</th>
-                    <th></th>
+                    <th class="sub-cell">Sub</th>
+                    <th class="prof-cell"></th>
                     <th>Name</th>
-                    <th v-for="buff in buffs"
+                    <th class="stat-cell" v-for="buff in buffs"
                         :data-original-title="buff.name + (buff.description ? '<br> ' + buff.description : '')">
                         <img :src="buff.icon" :alt="buff.name" class="icon icon-hover">
                     </th>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDamageDistTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDamageDistTable.html
@@ -26,60 +26,60 @@
             <thead>
                 <tr>
                     <th class="text-left">Skill</th>
-                    <th>
+                    <th class="damage-dist-cell">
                         %
                     </th>
-                    <th data-original-title="Damage">
+                    <th class="damage-dist-cell" data-original-title="Damage">
                         <img src="https://wiki.guildwars2.com/images/thumb/6/6a/Damage.png/30px-Damage.png" alt="Damage"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Damage against barrier. Not necessarily included in total damage">
+                    <th class="damage-dist-cell" data-original-title="Damage against barrier. Not necessarily included in total damage">
                         <img src="https://wiki.guildwars2.com/images/thumb/c/cc/Barrier.png/30px-Barrier.png"
                             alt="Barrier Damage" class="icon icon-hover">
                     </th>
-                    <th data-original-title="Minimum">
+                    <th class="damage-dist-cell" data-original-title="Minimum">
                         Min
                     </th>
-                    <th data-original-title="Average">
+                    <th class="damage-dist-cell" data-original-title="Average">
                         Avg
                     </th>
-                    <th data-original-title="Maximum">
+                    <th class="damage-dist-cell" data-original-title="Maximum">
                         Max
                     </th>
-                    <th v-if="actor !== null">
+                    <th class="damage-dist-cell" v-if="actor !== null">
                         Cast
                     </th>
-                    <th>
+                    <th class="damage-dist-cell">
                         Hits
                     </th>
-                    <th v-if="actor !== null" data-original-title="Hits per Cast">
+                    <th class="damage-dist-cell" v-if="actor !== null" data-original-title="Hits per Cast">
                         <img src="https://wiki.guildwars2.com/images/thumb/5/53/Number_of_targets.png/20px-Number_of_targets.png"
                             alt="Hits per Cast" class="icon icon-hover">
                     </th>
-                    <th v-if="actor !== null" data-original-title="Damage divided by time spent in animation">
+                    <th class="damage-dist-cell" v-if="actor !== null" data-original-title="Damage divided by time spent in animation">
                         <img src="https://wiki.guildwars2.com/images/thumb/6/6a/Damage.png/30px-Damage.png" alt="Damage"
                             class="icon">
                         /
                         <img src="https://wiki.guildwars2.com/images/6/6e/Activation.png" alt="Activation Time"
                             class="icon">
                     </th>
-                    <th data-original-title="Percent time hits critical">
+                    <th class="damage-dist-cell" data-original-title="Percent time hits critical">
                         <img src="https://wiki.guildwars2.com/images/9/95/Critical_Chance.png" alt="Crits"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Percent time hits while flanking">
+                    <th class="damage-dist-cell" data-original-title="Percent time hits while flanking">
                         <img src="https://wiki.guildwars2.com/images/b/bb/Hunter%27s_Tactics.png" alt="Flank"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Percent time hits while glancing">
+                    <th class="damage-dist-cell" data-original-title="Percent time hits while glancing">
                         <img src="https://wiki.guildwars2.com/images/f/f9/Weakness.png" alt="Glance"
                             class="icon icon-hover">
                     </th>
-                    <th v-if="actor !== null" data-original-title="Time wasted interupting skill casts">
+                    <th class="damage-dist-cell" v-if="actor !== null" data-original-title="Time wasted interupting skill casts">
                         <img src="https://wiki.guildwars2.com/images/b/b3/Out_Of_Health_Potions.png" alt="Wasted"
                             class="icon icon-hover">
                     </th>
-                    <th v-if="actor !== null" data-original-title="Time saved(in seconds) interupting skill casts">
+                    <th class="damage-dist-cell" v-if="actor !== null" data-original-title="Time saved(in seconds) interupting skill casts">
                         <img src="https://wiki.guildwars2.com/images/e/eb/Ready.png" alt="Saved"
                             class="icon icon-hover">
                     </th>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDamageModifierTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDamageModifierTable.html
@@ -3,10 +3,10 @@
         <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%" :id="id">
             <thead>
                 <tr>
-                    <th>Sub</th>
-                    <th></th>
+                    <th class="sub-cell">Sub</th>
+                    <th class="prof-cell"></th>
                     <th class="text-left">Name</th>
-                    <th v-for="modifier in modifiers" :data-original-title="modifier.name + '<br>' + modifier.tooltip">
+                    <th class="stat-cell" v-for="modifier in modifiers" :data-original-title="modifier.name + '<br>' + modifier.tooltip">
                         <img :src="modifier.icon" :alt="modifier.name" class="icon icon-hover">
                     </th>
                 </tr>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDamageTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDamageTable.html
@@ -3,39 +3,39 @@
         <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%" id="dps-table">
             <thead>
                 <tr>
-                    <th>Sub</th>
-                    <th></th>
+                    <th class="sub-cell">Sub</th>
+                    <th class="prof-cell"></th>
                     <th class="text-left">Name</th>
                     <th>Account</th>
-                    <th v-show="!targetless" data-original-title="All">
+                    <th v-show="!targetless" data-original-title="All" class="damage-cell">
                         Target <img src="https://wiki.guildwars2.com/images/thumb/6/6a/Damage.png/30px-Damage.png" alt="All"
                             class="icon">
                     </th>
-                    <th v-show="!targetless" data-original-title="Power">
+                    <th v-show="!targetless" data-original-title="Power" class="damage-cell">
                         Target <img src="https://wiki.guildwars2.com/images/2/23/Power.png" alt="Power"
                              class="icon">
                     </th>
-                    <th v-show="!targetless" data-original-title="Condition">
+                    <th v-show="!targetless" data-original-title="Condition" class="damage-cell">
                         Target <img src="https://wiki.guildwars2.com/images/5/54/Condition_Damage.png" alt="Condition"
                         class="icon">
                     </th>
-                    <th v-show="!targetless" v-if="hasBreakbarDamage" data-original-title="Breakbar">
+                    <th v-show="!targetless" v-if="hasBreakbarDamage" data-original-title="Breakbar" class="damage-cell">
                         Target <img src="https://wiki.guildwars2.com/images/a/ae/Unshakable.png" alt="Breakbar"
                         class="icon">
                     </th>
-                    <th data-original-title="All">
+                    <th data-original-title="All" class="damage-cell">
                         All <img src="https://wiki.guildwars2.com/images/thumb/6/6a/Damage.png/30px-Damage.png" alt="All"
                         class="icon">
                     </th>
-                    <th data-original-title="Power">
+                    <th data-original-title="Power" class="damage-cell">
                         All <img src="https://wiki.guildwars2.com/images/2/23/Power.png" alt="Power"
                         class="icon">
                     </th>
-                    <th data-original-title="Condition">
+                    <th data-original-title="Condition" class="damage-cell">
                         All <img src="https://wiki.guildwars2.com/images/5/54/Condition_Damage.png" alt="Condition"
                         class="icon">
                     </th>
-                    <th v-if="hasBreakbarDamage" data-original-title="Breakbar">
+                    <th v-if="hasBreakbarDamage" data-original-title="Breakbar" class="damage-cell">
                         All <img src="https://wiki.guildwars2.com/images/a/ae/Unshakable.png" alt="Breakbar"
                         class="icon">
                     </th>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDefenseTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDefenseTable.html
@@ -3,48 +3,48 @@
         <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%" id="def-table">
             <thead>
                 <tr>
-                    <th>Sub</th>
-                    <th></th>
+                    <th class="sub-cell">Sub</th>
+                    <th class="prof-cell"></th>
                     <th class="text-left">Name</th>
                     <th>Account</th>
-                    <th data-original-title="Damage taken" >
+                    <th class="damage-cell" data-original-title="Damage taken" >
                         <img src="https://wiki.guildwars2.com/images/thumb/6/6a/Damage.png/30px-Damage.png" alt="Damage Taken"
                         class="icon icon-hover">
                     </th>
-                    <th data-original-title="Damage absorbed by barrier">
+                    <th class="damage-cell" data-original-title="Damage absorbed by barrier">
                         <img src="https://wiki.guildwars2.com/images/thumb/c/cc/Barrier.png/30px-Barrier.png" alt="Damage Barrier"
                         class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of times blocked an attack" >
+                    <th class="stat-cell" data-original-title="Number of times blocked an attack" >
                         <img src="https://wiki.guildwars2.com/images/e/e5/Aegis.png" alt="Blocked"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of times was invulnerable to damage">
+                    <th class="stat-cell" data-original-title="Number of times was invulnerable to damage">
                         <img src="https://wiki.guildwars2.com/images/e/eb/Determined.png" alt="Ivuln"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of times interrupted">
+                    <th class="stat-cell" data-original-title="Number of times interrupted">
                         <img src="https://wiki.guildwars2.com/images/7/79/Daze.png" alt="Interrupted"
                             
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of evades">
+                    <th class="stat-cell" data-original-title="Number of evades">
                         <img src="https://wiki.guildwars2.com/images/e/e2/Evade.png" alt="Evaded"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of dodge + mirage cloak" >
+                    <th class="stat-cell" data-original-title="Number of dodge + mirage cloak" >
                         <img src="https://wiki.guildwars2.com/images/b/b2/Dodge.png" alt="Dodge"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of hits missed against" >
+                    <th class="stat-cell" data-original-title="Number of hits missed against" >
                         <img src="https://wiki.guildwars2.com/images/3/33/Blinded.png" alt="Missed"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Times downed">
+                    <th class="stat-cell" data-original-title="Times downed">
                         <img src="https://wiki.guildwars2.com/images/c/c6/Downed_enemy.png" alt="Downs"
                              class="icon icon-hover">
                     </th>
-                    <th  data-original-title="Times died">
+                    <th class="stat-cell" data-original-title="Times died">
                         <img src="https://wiki.guildwars2.com/images/4/4a/Ally_death_%28interface%29.png" alt="Dead"
                             class="icon icon-hover">
                     </th>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplGameplayTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplGameplayTable.html
@@ -13,72 +13,72 @@
         <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%" id="dmg-table">
             <thead>
                 <tr>
-                    <th>Sub</th>
-                    <th></th>
+                    <th class="sub-cell">Sub</th>
+                    <th class="prof-cell"></th>
                     <th class="text-left">Name</th>
                     <th>Account</th>
-                    <th data-original-title="Percent time hits critical">
+                    <th class="stat-cell" data-original-title="Percent time hits critical">
                         <img src="https://wiki.guildwars2.com/images/9/95/Critical_Chance.png" alt="Crits"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Percent time hits while flanking">
+                    <th class="stat-cell" data-original-title="Percent time hits while flanking">
                         <img src="https://wiki.guildwars2.com/images/b/bb/Hunter%27s_Tactics.png" alt="Flank"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Percent time hits while glancing">
+                    <th class="stat-cell" data-original-title="Percent time hits while glancing">
                         <img src="https://wiki.guildwars2.com/images/f/f9/Weakness.png" alt="Glance"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of hits while blinded">
+                    <th class="stat-cell" data-original-title="Number of hits while blinded">
                         <img src="https://wiki.guildwars2.com/images/3/33/Blinded.png" alt="Miss"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Number of hits used to interupt">
+                    <th class="stat-cell" data-original-title="Number of hits used to interupt">
                         <img src="https://wiki.guildwars2.com/images/7/79/Daze.png" alt="Interupts"
                             
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Times the enemy was invulnerable to attacks">
+                    <th class="stat-cell" data-original-title="Times the enemy was invulnerable to attacks">
                         <img src="https://wiki.guildwars2.com/images/e/eb/Determined.png" alt="Ivuln"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Times the enemy evaded an attack">
+                    <th class="stat-cell" data-original-title="Times the enemy evaded an attack">
                         <img src="https://wiki.guildwars2.com/images/e/e2/Evade.png" alt="Evaded"
                              class="icon icon-hover">
                     </th>
-                    <th data-original-title="Times the enemy blocked an attack">
+                    <th class="stat-cell" data-original-title="Times the enemy blocked an attack">
                         <img src="https://wiki.guildwars2.com/images/e/e5/Aegis.png" alt="Blocked"
                              class="icon icon-hover">
                     </th>                  
-                    <th v-if="wvw" data-original-title="Number of times downed target">
+                    <th class="stat-cell" v-if="wvw" data-original-title="Number of times downed target">
                         <img src="https://wiki.guildwars2.com/images/c/c6/Downed_enemy.png"
                             alt="Downed" 
                             class="icon icon-hover">
                     </th>             
-                    <th v-if="wvw" data-original-title="Number of times killed target">
+                    <th class="stat-cell" v-if="wvw" data-original-title="Number of times killed target">
                         <img src="https://wiki.guildwars2.com/images/4/4a/Ally_death_%28interface%29.png"
                             alt="Killed" 
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Time wasted(in seconds) interupting skill casts">
+                    <th class="stat-cell" data-original-title="Time wasted(in seconds) interupting skill casts">
                         <img src="https://wiki.guildwars2.com/images/b/b3/Out_Of_Health_Potions.png" alt="Wasted"
                             
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Time saved(in seconds) interupting skill casts">
+                    <th class="stat-cell" data-original-title="Time saved(in seconds) interupting skill casts">
                         <img src="https://wiki.guildwars2.com/images/e/eb/Ready.png" alt="Saved"
                             
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Times weapon swapped">
+                    <th class="stat-cell" data-original-title="Times weapon swapped">
                         <img src="https://wiki.guildwars2.com/images/c/ce/Weapon_Swap_Button.png" alt="Swap"
                              class="icon icon-hover">
                     </th>
-                    <th  data-original-title="Average Distance to the center of the squad">
+                    <th class="stat-cell" data-original-title="Average Distance to the center of the squad">
                         <img src="https://wiki.guildwars2.com/images/e/ef/Commander_arrow_marker.png" alt="Stack Center"
                             class="icon icon-hover">
                     </th>
-                    <th v-if="hasCommander" data-original-title="Average Distance to the commander">
+                    <th class="stat-cell" v-if="hasCommander" data-original-title="Average Distance to the commander">
                         <img src="https://wiki.guildwars2.com/images/5/54/Commander_tag_%28blue%29.png"
                             alt="Stack Commander" 
                             class="icon icon-hover">

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplMechanicsTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplMechanicsTable.html
@@ -3,10 +3,10 @@
         <table v-if="playerMechHeader.length > 0" class="table table-sm table-striped table-hover" cellspacing="0" id="playermechs">
             <thead>
                 <tr>
-                    <th width="30px">Sub</th>
-                    <th width="30px"></th>
+                    <th class="sub-cell">Sub</th>
+                    <th class="prof-cell"></th>
                     <th class="text-left">Player</th>
-                    <th v-for="mech in playerMechHeader" :data-original-title="mech.description">
+                    <th class="stat-cell" v-for="mech in playerMechHeader" :data-original-title="mech.description">
                         {{ mech.shortName}}
                     </th>
                 </tr>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplSupportTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplSupportTable.html
@@ -3,23 +3,23 @@
         <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%" id="sup-table">
             <thead>
                 <tr>
-                    <th>Sub</th>
-                    <th></th>
+                    <th class="sub-cell">Sub</th>
+                    <th class="prof-cell"></th>
                     <th class="text-left">Name</th>
                     <th>Account</th>
-                    <th data-original-title="Condition Cleanse on Others" >
+                    <th class="stat-cell" data-original-title="Condition Cleanse on Others" >
                         <img src="https://wiki.guildwars2.com/images/1/12/Healing_Spring.png" alt="Condition Cleanse on Others"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Condition Cleanse on Self" >
+                    <th class="stat-cell" data-original-title="Condition Cleanse on Self" >
                         <img src="https://wiki.guildwars2.com/images/e/ec/Mending.png" alt="Condition Cleanse on Self"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Boon Strips" >
+                    <th class="stat-cell" data-original-title="Boon Strips" >
                         <img src="https://wiki.guildwars2.com/images/e/ec/Banish_Enchantment.png" alt="Boon Strips"
                             class="icon icon-hover">
                     </th>
-                    <th data-original-title="Resurrects" >
+                    <th class="stat-cell" data-original-title="Resurrects" >
                         <img src="https://wiki.guildwars2.com/images/3/3d/Downed_ally.png" alt="Resurrects"
                             class="icon icon-hover">
                     </th>
@@ -66,7 +66,7 @@
         },
         mixins: [numberComponent],
         mounted() {
-            initTable("#sup-table", 4, "desc");
+            initTable("#sup-table", 1, "desc");
         },
         updated() {
             updateTable("#sup-table");


### PR DESCRIPTION
- Restored the look and feel of the player seelction tab
- Added a option to hide mechanics and secondary npcs on CR
- Normalized table cell sizes so they stop varying so wildly
- Support table sorts by profession by default (like gameplay stats table)