### PR TITLE
Html stuff

### DIFF
--- a/GW2EIBuilders/HTMLBuilder.cs
+++ b/GW2EIBuilders/HTMLBuilder.cs
@@ -79,7 +79,7 @@ namespace GW2EIBuilders
             html = html.Replace("'${logDataJson}'", ToJson(LogDataDto.BuildLogData(_log, _usedSkills, _usedBuffs, _usedDamageMods, _cr, _light, _parserVersion, _uploadLink)));
 
             _log.UpdateProgressWithCancellationCheck("HTML: building Graph Data");
-            html = html.Replace("'${graphDataJson}'", ToJson(ChartDataDto.BuildChartData(_log)));
+            html = html.Replace("'${graphDataJson}'", ToJson(new ChartDataDto(_log)));
 
             sw.Write(html);
             return;

--- a/GW2EIBuilders/HtmlModels/HtmlCharts/ActorChartDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlCharts/ActorChartDataDto.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using GW2EIEvtcParser;
+using GW2EIEvtcParser.EIData;
+
+namespace GW2EIBuilders.HtmlModels
+{
+    internal abstract class ActorChartDataDto
+    {
+        public List<object[]> HealthStates { get; }
+        public List<object[]> BarrierStates { get; }
+
+        public ActorChartDataDto(ParsedEvtcLog log, PhaseData phase, AbstractSingleActor actor, bool nullableHPStates)
+        {
+            HealthStates = ChartDataDto.BuildHealthStates(log, actor, phase, nullableHPStates);
+            BarrierStates = ChartDataDto.BuildBarrierStates(log, actor, phase);
+        }
+    }
+}

--- a/GW2EIBuilders/HtmlModels/HtmlCharts/ChartDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlCharts/ChartDataDto.cs
@@ -8,8 +8,8 @@ namespace GW2EIBuilders.HtmlModels
 {
     internal class ChartDataDto
     {
-        public List<PhaseChartDataDto> Phases { get; set; } = new List<PhaseChartDataDto>();
-        public List<MechanicChartDataDto> Mechanics { get; set; } = new List<MechanicChartDataDto>();
+        public List<PhaseChartDataDto> Phases { get; } = new List<PhaseChartDataDto>();
+        public List<MechanicChartDataDto> Mechanics { get; } = new List<MechanicChartDataDto>();
 
         private static List<object[]> BuildGraphStates(IReadOnlyList<Segment> segments, PhaseData phase, bool nullable, double defaultState)
         {
@@ -42,39 +42,16 @@ namespace GW2EIBuilders.HtmlModels
             return BuildGraphStates(npc.GetBreakbarPercentUpdates(log), phase, true, 100.0);
         }
 
-        public static ChartDataDto BuildChartData(ParsedEvtcLog log)
+        public ChartDataDto(ParsedEvtcLog log)
         {
-            var chartData = new ChartDataDto();
             var phaseChartData = new List<PhaseChartDataDto>();
             IReadOnlyList<PhaseData> phases = log.FightData.GetPhases(log);
             for (int i = 0; i < phases.Count; i++)
             {
-                var phaseData = new PhaseChartDataDto()
-                {
-                    Players = PlayerChartDataDto.BuildPlayersGraphData(log, i)
-                };
-                foreach (NPC target in phases[i].Targets)
-                {
-                    phaseData.Targets.Add(TargetChartDataDto.BuildTargetGraphData(log, i, target));
-                }
-                if (i == 0)
-                {
-                    phaseData.TargetsHealthStatesForCR = new List<List<object[]>>();
-                    phaseData.TargetsBreakbarPercentStatesForCR = new List<List<object[]>>();
-                    phaseData.TargetsBarrierStatesForCR = new List<List<object[]>>();
-                    foreach (NPC target in log.FightData.Logic.Targets)
-                    {
-                        phaseData.TargetsHealthStatesForCR.Add(BuildHealthStates(log, target, phases[0], false));
-                        phaseData.TargetsBreakbarPercentStatesForCR.Add(BuildBreakbarPercentStates(log, target, phases[0]));
-                        phaseData.TargetsBarrierStatesForCR.Add(BuildBarrierStates(log, target, phases[0]));
-                    }
-                }
-
-                phaseChartData.Add(phaseData);
+                phaseChartData.Add(new PhaseChartDataDto(log, phases[i], i == 0));
             }
-            chartData.Phases = phaseChartData;
-            chartData.Mechanics = MechanicChartDataDto.BuildMechanicsChartData(log);
-            return chartData;
+            Phases = phaseChartData;
+            Mechanics = MechanicChartDataDto.BuildMechanicsChartData(log);
         }
     }
 }

--- a/GW2EIBuilders/HtmlModels/HtmlCharts/MechanicChartDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlCharts/MechanicChartDataDto.cs
@@ -8,11 +8,20 @@ namespace GW2EIBuilders.HtmlModels
 {
     internal class MechanicChartDataDto
     {
-        public string Symbol { get; set; }
-        public int Size { get; set; }
-        public string Color { get; set; }
-        public List<List<List<object>>> Points { get; set; }
-        public bool Visible { get; set; }
+        public string Symbol { get; }
+        public int Size { get; }
+        public string Color { get; }
+        public List<List<List<object>>> Points { get; }
+        public bool Visible { get; }
+
+        private MechanicChartDataDto(ParsedEvtcLog log, Mechanic mech)
+        {
+            Color = mech.PlotlySetting.Color;
+            Symbol = mech.PlotlySetting.Symbol;
+            Size = mech.PlotlySetting.Size;
+            Visible = (mech.SkillId == SkillItem.DeathId || mech.SkillId == SkillItem.DownId);
+            Points = BuildMechanicGraphPointData(log, log.MechanicData.GetMechanicLogs(log, mech), mech.IsEnemyMechanic);
+        }
 
         private static List<List<object>> GetMechanicChartPoints(IReadOnlyList<MechanicEvent> mechanicLogs, PhaseData phase, ParsedEvtcLog log, bool enemyMechanic)
         {
@@ -74,16 +83,7 @@ namespace GW2EIBuilders.HtmlModels
             var mechanicsChart = new List<MechanicChartDataDto>();
             foreach (Mechanic mech in log.MechanicData.GetPresentMechanics(log, log.FightData.FightStart, log.FightData.FightEnd))
             {
-                IReadOnlyList<MechanicEvent> mechanicLogs = log.MechanicData.GetMechanicLogs(log, mech);
-                var dto = new MechanicChartDataDto
-                {
-                    Color = mech.PlotlySetting.Color,
-                    Symbol = mech.PlotlySetting.Symbol,
-                    Size = mech.PlotlySetting.Size,
-                    Visible = (mech.SkillId == SkillItem.DeathId || mech.SkillId == SkillItem.DownId),
-                    Points = BuildMechanicGraphPointData(log, mechanicLogs, mech.IsEnemyMechanic)
-                };
-                mechanicsChart.Add(dto);
+                mechanicsChart.Add(new MechanicChartDataDto(log, mech));
             }
             return mechanicsChart;
         }

--- a/GW2EIBuilders/HtmlModels/HtmlCharts/PhaseChartDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlCharts/PhaseChartDataDto.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using GW2EIEvtcParser;
+using GW2EIEvtcParser.EIData;
 
 namespace GW2EIBuilders.HtmlModels
 {
@@ -10,5 +12,26 @@ namespace GW2EIBuilders.HtmlModels
         public List<List<object[]>> TargetsHealthStatesForCR { get; set; } = null;
         public List<List<object[]>> TargetsBreakbarPercentStatesForCR { get; set; } = null;
         public List<List<object[]>> TargetsBarrierStatesForCR { get; set; } = null;
+
+        public PhaseChartDataDto(ParsedEvtcLog log, PhaseData phase, bool addCRData)
+        {
+            Players = PlayerChartDataDto.BuildPlayersGraphData(log, phase);
+            foreach (NPC target in phase.Targets)
+            {
+               Targets.Add(new TargetChartDataDto(log, phase, target));
+            }
+            if (addCRData)
+            {
+                TargetsHealthStatesForCR = new List<List<object[]>>();
+                TargetsBreakbarPercentStatesForCR = new List<List<object[]>>();
+                TargetsBarrierStatesForCR = new List<List<object[]>>();
+                foreach (NPC target in log.FightData.Logic.Targets)
+                {
+                    TargetsHealthStatesForCR.Add(ChartDataDto.BuildHealthStates(log, target, phase, false));
+                    TargetsBreakbarPercentStatesForCR.Add(ChartDataDto.BuildBreakbarPercentStates(log, target, phase));
+                    TargetsBarrierStatesForCR.Add(ChartDataDto.BuildBarrierStates(log, target, phase));
+                }
+            }
+        }
     }
 }

--- a/GW2EIBuilders/HtmlModels/HtmlCharts/PlayerChartDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlCharts/PlayerChartDataDto.cs
@@ -4,14 +4,12 @@ using GW2EIEvtcParser.EIData;
 
 namespace GW2EIBuilders.HtmlModels
 {
-    internal class PlayerChartDataDto
+    internal class PlayerChartDataDto : ActorChartDataDto
     {
         public PlayerDamageChartDto<int> Damage { get;}
         public PlayerDamageChartDto<double> BreakbarDamage { get; }
-        public List<object[]> HealthStates { get; }
-        public List<object[]> BarrierStates { get; }
 
-        private PlayerChartDataDto(ParsedEvtcLog log, PhaseData phase, Player p)
+        private PlayerChartDataDto(ParsedEvtcLog log, PhaseData phase, Player p) : base(log, phase, p, true)
         {
             Damage = new PlayerDamageChartDto<int>()
             {
@@ -23,8 +21,6 @@ namespace GW2EIBuilders.HtmlModels
                 Total = p.Get1SBreakbarDamageList(log, phase.Start, phase.End, null),
                 Targets = new List<IReadOnlyList<double>>()
             };
-            HealthStates = ChartDataDto.BuildHealthStates(log, p, phase, true);
-            BarrierStates = ChartDataDto.BuildBarrierStates(log, p, phase);
             foreach (NPC target in phase.Targets)
             {
                 Damage.Targets.Add(p.Get1SDamageList(log, phase.Start, phase.End, target));

--- a/GW2EIBuilders/HtmlModels/HtmlCharts/TargetChartDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlCharts/TargetChartDataDto.cs
@@ -6,21 +6,17 @@ namespace GW2EIBuilders.HtmlModels
 {
     internal class TargetChartDataDto
     {
-        public IReadOnlyList<int> Total { get; set; }
-        public List<object[]> HealthStates { get; set; }
-        public List<object[]> BreakbarPercentStates { get; set; }
-        public List<object[]> BarrierStates { get; set; }
+        public IReadOnlyList<int> Total { get; }
+        public List<object[]> HealthStates { get; }
+        public List<object[]> BreakbarPercentStates { get; }
+        public List<object[]> BarrierStates { get; }
 
-        public static TargetChartDataDto BuildTargetGraphData(ParsedEvtcLog log, int phaseIndex, NPC target)
+        public TargetChartDataDto(ParsedEvtcLog log, PhaseData phase, NPC target)
         {
-            PhaseData phase = log.FightData.GetPhases(log)[phaseIndex];
-            return new TargetChartDataDto
-            {
-                Total = target.Get1SDamageList(log, phase.Start, phase.End, null),
-                HealthStates = ChartDataDto.BuildHealthStates(log, target, phase, false),
-                BreakbarPercentStates = ChartDataDto.BuildBreakbarPercentStates(log, target, phase),
-                BarrierStates = ChartDataDto.BuildBarrierStates(log, target, phase),
-            };
+            Total = target.Get1SDamageList(log, phase.Start, phase.End, null);
+            HealthStates = ChartDataDto.BuildHealthStates(log, target, phase, false);
+            BreakbarPercentStates = ChartDataDto.BuildBreakbarPercentStates(log, target, phase);
+            BarrierStates = ChartDataDto.BuildBarrierStates(log, target, phase);
         }
     }
 }

--- a/GW2EIBuilders/HtmlModels/HtmlCharts/TargetChartDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlCharts/TargetChartDataDto.cs
@@ -4,19 +4,15 @@ using GW2EIEvtcParser.EIData;
 
 namespace GW2EIBuilders.HtmlModels
 {
-    internal class TargetChartDataDto
+    internal class TargetChartDataDto : ActorChartDataDto
     {
         public IReadOnlyList<int> Total { get; }
-        public List<object[]> HealthStates { get; }
         public List<object[]> BreakbarPercentStates { get; }
-        public List<object[]> BarrierStates { get; }
 
-        public TargetChartDataDto(ParsedEvtcLog log, PhaseData phase, NPC target)
+        public TargetChartDataDto(ParsedEvtcLog log, PhaseData phase, NPC target) : base(log, phase, target, false)
         {
             Total = target.Get1SDamageList(log, phase.Start, phase.End, null);
-            HealthStates = ChartDataDto.BuildHealthStates(log, target, phase, false);
             BreakbarPercentStates = ChartDataDto.BuildBreakbarPercentStates(log, target, phase);
-            BarrierStates = ChartDataDto.BuildBarrierStates(log, target, phase);
         }
     }
 }

--- a/GW2EIBuilders/JsonModels/JsonLog.cs
+++ b/GW2EIBuilders/JsonModels/JsonLog.cs
@@ -360,7 +360,7 @@ namespace GW2EIBuilders.JsonModels
                 foreach (Buff fractalInstab in log.StatisticsHelper.PresentFractalInstabilities)
                 {
                     presentFractalInstabilities.Add(fractalInstab.ID);
-                    if (!BuffMap.ContainsKey("b" + fractalInstab.ID))
+                    if (!buffMap.ContainsKey("b" + fractalInstab.ID))
                     {
                         buffMap["b" + fractalInstab.ID] = new BuffDesc(fractalInstab, log);
                     }

--- a/GW2EIBuilders/Resources/JS/functions.js
+++ b/GW2EIBuilders/Resources/JS/functions.js
@@ -450,61 +450,32 @@ function getActorGraphLayout(images, color, hasBuffs) {
     };
 }
 
-function computeTargetHealthData(graph, targets, phase, data, yaxis) {
-    for (var i = 0; i < graph.targets.length; i++) {
-        var health = graph.targets[i].healthStates;
-        var hpTexts = [];
-        var times = [];
-        var target = targets[phase.targets[i]];
-        for (var j = 0; j < health.length; j++) {
-            hpTexts[j] = health[j][1] + "% hp - " + target.name;
-            times[j] = health[j][0];
-        }
-        var res = {
-            x: times,
-            text: hpTexts,
-            mode: 'lines',
-            line: {
-                dash: 'dashdot',
-                shape: 'hv'
-            },
-            hoverinfo: 'text',
-            name: target.name + ' health',
-        };
-        if (yaxis) {
-            res.yaxis = yaxis;
-        }
-        data.push(res);
-    }
-    return graph.targets.length;
-}
-
-function computeTargetBreakbarData(graph, targets, phase, data, yaxis) {
+function _computeTargetGraphData(graph, targets, phase, data, yaxis, jsonGraphName, percentName, graphName, visible) {
     var count = 0;
     for (var i = 0; i < graph.targets.length; i++) {
-        var breakbar = graph.targets[i].breakbarPercentStates;
-        if (!breakbar) {
+        var graphData = graph.targets[i][jsonGraphName];
+        if (!graphData) {
             continue;
         }
         count++;
-        var breakbarTexts = [];
+        var texts = [];
         var times = [];
         var target = targets[phase.targets[i]];
-        for (var j = 0; j < breakbar.length; j++) {
-            breakbarTexts[j] = breakbar[j][1] + "% breakbar - " + target.name;
-            times[j] = breakbar[j][0];
+        for (var j = 0; j < graphData.length; j++) {
+          texts[j] = graphData[j][1] + "% " + percentName + " - " + target.name;
+          times[j] = graphData[j][0];
         }
         var res = {
-            x: times,
-            text: breakbarTexts,
-            mode: 'lines',
-            line: {
-                dash: 'dashdot',
-                shape: 'hv'
-            },
-            hoverinfo: 'text',
-            visible: phase.breakbarPhase ? true : "legendonly",
-            name: target.name + ' breakbar',
+          x: times,
+          text: texts,
+          mode: "lines",
+          line: {
+            dash: "dashdot",
+            shape: "hv",
+          },
+          hoverinfo: "text",
+          visible: visible ? true : "legendonly",
+          name: target.name + " " + graphName,
         };
         if (yaxis) {
             res.yaxis = yaxis;
@@ -512,6 +483,18 @@ function computeTargetBreakbarData(graph, targets, phase, data, yaxis) {
         data.push(res);
     }
     return count;
+}
+
+function computeTargetHealthData(graph, targets, phase, data, yaxis) {
+    return _computeTargetGraphData(graph, targets, phase, data, yaxis, "healthStates", "hp", "health", true);
+}
+
+function computeTargetBarrierData(graph, targets, phase, data, yaxis) {
+    return _computeTargetGraphData(graph, targets, phase, data, yaxis, "barrierStates", "barrier", "barrier", false);
+}
+
+function computeTargetBreakbarData(graph, targets, phase, data, yaxis) {
+    return _computeTargetGraphData(graph, targets, phase, data, yaxis, "breakbarPercentStates", "breakbar", "breakbar", phase.breakbarPhase);
 }
 
 function computePlayerHealthData(healthGraph, data, yaxis) {

--- a/GW2EIBuilders/Resources/JS/functions.js
+++ b/GW2EIBuilders/Resources/JS/functions.js
@@ -497,33 +497,6 @@ function computeTargetBreakbarData(graph, targets, phase, data, yaxis) {
     return _computeTargetGraphData(graph, targets, phase, data, yaxis, "breakbarPercentStates", "breakbar", "breakbar", phase.breakbarPhase);
 }
 
-function computePlayerHealthData(healthGraph, data, yaxis) {
-    var health = healthGraph;
-    var hpTexts = [];
-    var times = [];
-    for (var j = 0; j < health.length; j++) {
-        hpTexts[j] = health[j][1] + "% hp - Player";
-        times[j] = health[j][0];
-    }
-    var res = {
-        x: times,
-        text: hpTexts,
-        mode: 'lines',
-        line: {
-            dash: 'dashdot',
-            shape: 'hv'
-        },
-        hoverinfo: 'text',
-        name: 'Player health',
-        visible: 'legendonly',
-    };
-    if (yaxis) {
-        res.yaxis = yaxis;
-    }
-    data.push(res);
-    return 1;
-}
-
 function computeBuffData(buffData, data) {
     if (buffData) {
         for (var i = 0; i < buffData.length; i++) {

--- a/GW2EIBuilders/Resources/JS/functions.js
+++ b/GW2EIBuilders/Resources/JS/functions.js
@@ -1,10 +1,11 @@
 /*jshint esversion: 6 */
 "use strict";
-function computeGradient(left, percent) {
+
+function computeGradient(left, percent, right) {
     var template = "linear-gradient(to right, $fill$, $middle$, $black$)";
     var res = percent;
     var fillPercent = left + " " + res + "%";
-    var blackPercent = "black " + (100 - res) + "%";
+    var blackPercent = right + " " + (100 - res) + "%";
     var middle = res + "%";
     template = template.replace("$fill$", fillPercent);
     template = template.replace("$black$", blackPercent);

--- a/GW2EIBuilders/Resources/JS/mixins.js
+++ b/GW2EIBuilders/Resources/JS/mixins.js
@@ -41,7 +41,7 @@ var graphComponent = {
         return {
             graphdata: {
                 dpsmode: 0,
-                graphmode: GraphType.DPS,
+                graphmode: logData.wvw ? GraphType.Damage : GraphType.DPS,
             },
             layout: {},
             dpsCache: new Map(),

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageData.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageData.html
@@ -1,6 +1,9 @@
 <template>
     <div class="d-flex flex-column justify-content-center">
-        <combat-replay-damage-stats-component :time="time" :playerindex="playerindex">
+        <dps-graph-mode-selector-component :data="graphdata"
+            :phaseduration="this.phase.end - this.phase.start" :phasehassubphases="false" :ignorebreakbar="false">
+        </dps-graph-mode-selector-component>
+        <combat-replay-damage-stats-component :time="time" :playerindex="playerindex" :graphdata="graphdata">
         </combat-replay-damage-stats-component>
     </div>
 </template>
@@ -9,7 +12,18 @@
     Vue.component("combat-replay-damage-data-component", {
         template: `${template}`,
         props: ["time", "selectedplayer", "selectedplayerid"],
+        data: function () {
+            return {
+                graphdata: {
+                    dpsmode: 0,
+                    graphmode: GraphType.DPS,
+                }
+            };
+        },
         computed: {
+            phase: function () {
+                return logData.phases[0];
+            },
             playerindex: function () {
                 if (this.selectedplayer) {
                     for (var i = 0; i < logData.players.length; i++) {

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageData.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageData.html
@@ -1,7 +1,7 @@
 <template>
     <div class="d-flex flex-column justify-content-center">
         <dps-graph-mode-selector-component :data="graphdata"
-            :phaseduration="this.phase.end - this.phase.start" :phasehassubphases="false" :ignorebreakbar="false">
+            :phaseduration="this.phase.end - this.phase.start" :phasehassubphases="false" :ignorebreakbar="false" :style="{'width': selectorWidth}">
         </dps-graph-mode-selector-component>
         <combat-replay-damage-stats-component :time="time" :playerindex="playerindex" :graphdata="graphdata">
         </combat-replay-damage-stats-component>
@@ -23,6 +23,9 @@
         computed: {
             phase: function () {
                 return logData.phases[0];
+            },
+            selectorWidth: function () {
+                return  (273 + this.phase.targets.length * 130) + 'px';
             },
             playerindex: function () {
                 if (this.selectedplayer) {

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageTable.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageTable.html
@@ -1,18 +1,8 @@
 <template>
     <div>
-        <ul class="nav nav-pills d-flex flex-row justify-content-center">
-            <li class="nav-item">
-                <a class="nav-link" @click="damageMode = graphModeEnum.Damage" :class="{active: damageMode === graphModeEnum.Damage}">Damage</a>
-            </li>
-            <li class="nav-item">
-                <a class="nav-link" @click="damageMode = graphModeEnum.DPS" :class="{active: damageMode === graphModeEnum.DPS}">DPS</a>
-            </li>
-            <li v-if="hasBreakbarDamage" class="nav-item">
-                <a class="nav-link" @click="damageMode = graphModeEnum.BreakbarDamage" :class="{active: damageMode === graphModeEnum.BreakbarDamage}">Breakbar Damage</a>
-            </li>
-        </ul>
         <div class="scrollable-cr-dps-table">
-            <table class="table table-sm table-striped table-hover"  cellspacing="0" width="100%" id="combat-replay-dps-table">
+            <table class="table table-sm table-striped table-hover" cellspacing="0" width="100%"
+                id="combat-replay-dps-table">
                 <thead>
                     <tr>
                         <th class="cr-dps-table-icon-col"></th>
@@ -65,41 +55,40 @@
                     </tr>
                 </tfoot>
             </table>
-        </div>     
+        </div>
+
     </div>
-    
 </template>
 
 <script>
     Vue.component("combat-replay-damage-stats-component", {
         mixins: [timeRefreshComponent, numberComponent],
-        props: ["playerindex"],
+        props: ["playerindex", "graphdata"],
         template: `${template}`,
         data: function () {
             return {
-                targetless: logData.targetless,
-                damageMode: GraphType.DPS
+                targetless: logData.targetless
             };
         },
         methods: {
-            tableRound: function(value) {
-                return this.damageMode == GraphType.BreakbarDamage ? this.round1(value) : this.round(value)
+            tableRound: function (value) {
+                return this.graphdata.graphmode == GraphType.BreakbarDamage ? this.round1(value) : this.round(value)
             }
         },
         created() {
             var i, cacheID;
             for (var j = 0; j < this.targets.length; j++) {
                 var activeTargets = [j];
-                cacheID = getDPSGraphCacheID(0, this.damageMode, activeTargets, 0, null);
+                cacheID = getDPSGraphCacheID(this.graphdata.dpsmode, this.graphdata.graphmode, activeTargets, 0, null);
                 // compute dps for all players
                 for (i = 0; i < logData.players.length; i++) {
-                    computePlayerDPS(logData.players[i], this.graph[i].damage, 0, null, activeTargets, cacheID, this.phase.times, this.damageMode);
+                    computePlayerDPS(logData.players[i], this.graph[i].damage, this.graphdata.dpsmode, null, activeTargets, cacheID, this.phase.times, this.graphdata.graphmode);
                 }
             }
-            cacheID = getDPSGraphCacheID(0, this.damageMode, this.targets, 0, null);
+            cacheID = getDPSGraphCacheID(this.graphdata.dpsmode, this.graphdata.graphmode, this.targets, 0, null);
             // compute dps for all players
             for (i = 0; i < logData.players.length; i++) {
-                computePlayerDPS(logData.players[i], this.graph[i].damage, 0, null, this.targets, cacheID, this.phase.times, this.damageMode);
+                computePlayerDPS(logData.players[i], this.graph[i].damage, this.graphdata.dpsmode, null, this.targets, cacheID, this.phase.times, this.graphdata.graphmode);
             }
         },
         mounted() {
@@ -118,10 +107,10 @@
             graph: function () {
                 return graphData.phases[0].players;
             },
-            graphModeEnum: function() {
+            graphModeEnum: function () {
                 return GraphType;
             },
-            hasBreakbarDamage: function() {
+            hasBreakbarDamage: function () {
                 return logData.hasBreakbarDamage;
             },
             tableData: function () {
@@ -141,7 +130,7 @@
                     var target = logData.targets[this.targets[j]];
                     cols.push(target);
                 }
-                var damageArrayToUse = this.damageMode === GraphType.BreakbarDamage ? "breakbarDamage" : "damage";
+                var damageArrayToUse = this.graphdata.graphmode === GraphType.BreakbarDamage ? "breakbarDamage" : "damage";
                 for (i = 0; i < this.graph.length; i++) {
                     var cacheID, data, cur, next;
                     var player = logData.players[i];
@@ -150,22 +139,22 @@
                     // targets
                     for (j = 0; j < this.targets.length; j++) {
                         var activeTargets = [j];
-                        cacheID = getDPSGraphCacheID(0, this.damageMode, activeTargets, 0, null);
-                        data = computePlayerDPS(player, graphData[damageArrayToUse], 0, null, activeTargets, cacheID, this.phase.times, this.damageMode).dps.target;
+                        cacheID = getDPSGraphCacheID(this.graphdata.dpsmode, this.graphdata.graphmode, activeTargets, 0, null);
+                        data = computePlayerDPS(player, graphData[damageArrayToUse], this.graphdata.dpsmode, null, activeTargets, cacheID, this.phase.times, this.graphdata.graphmode).dps.target;
                         cur = data[curTime];
                         next = data[curTime + 1];
                         if (typeof next !== "undefined") {
-                            dps[j] = cur + (tS - curTime) * (next - cur)/(nextTime - curTime);
+                            dps[j] = cur + (tS - curTime) * (next - cur) / (nextTime - curTime);
                         } else {
                             dps[j] = cur;
                         }
                     }
-                    cacheID = getDPSGraphCacheID(0, this.damageMode, this.targets, 0, null);
-                    data = computePlayerDPS(player, graphData[damageArrayToUse], 0, null, this.targets, cacheID, this.phase.times, this.damageMode).dps.total;
+                    cacheID = getDPSGraphCacheID(this.graphdata.dpsmode, this.graphdata.graphmode, this.targets, 0, null);
+                    data = computePlayerDPS(player, graphData[damageArrayToUse], this.graphdata.dpsmode, null, this.targets, cacheID, this.phase.times, this.graphdata.graphmode).dps.total;
                     cur = data[curTime];
                     next = data[curTime + 1];
                     if (typeof next !== "undefined") {
-                        dps[j] = cur + (tS - curTime) * (next - cur)/(nextTime - curTime);
+                        dps[j] = cur + (tS - curTime) * (next - cur) / (nextTime - curTime);
                     } else {
                         dps[j] = cur;
                     }

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayPlayerStatus.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayPlayerStatus.html
@@ -1,12 +1,18 @@
 <template>
-    <div class="player-status" :style="{'background': getGradient(time, status)}">
+    <div class="player-status" :style="{'background': getHPGradient(time, status)}">
         <h6 class="actor-shorten text-center" :title="player.name">
             <img :src="player.icon" :alt="player.profession" height="18" width="18">
             {{player.name}}
         </h6>
         <p v-if="hasHealth" class="text-right cr-hp-display cr-hp-display-player">
-            {{(Math.round(100*getPercent(time))/100).toFixed(2)}} %
+            {{(Math.round(100*getHPPercent(time))/100).toFixed(2)}} %
         </p>
+        <p v-if="hasBarrier" class="text-right cr-barrier-display cr-barrier-display-player">
+            {{(Math.round(100*getBarrierPercent(time))/100).toFixed(2)}} %
+        </p>      
+        <div v-if="hasBarrier" class="cr-barrier" :style="{'background': getBarrierGradient(time, status)}">
+
+        </div>
     </div>
 </template>
 
@@ -15,16 +21,25 @@
         props: ["playerindex", "time"],
         template: `${template}`,
         methods: {         
-            getPercent: function (time) {
+            getHPPercent: function (time) {
                 if (!this.hasHealth) {
                     return 100;
                 }
                 return findState(this.healths, time/1000.0, 0, this.healths.length - 1);
             },
-            getGradient: function (time, status) {
+            getBarrierPercent: function (time) {
+                if (!this.hasBarrier) {
+                    return 0;
+                }
+                return findState(this.barriers, time/1000.0, 0, this.barriers.length - 1);
+            },
+            getHPGradient: function (time, status) {
                 var color = status === 0 ? 'black' : status === 1 ? 'red' : status === 2 ? 'grey' : 'green';
-                return computeGradient(color, this.getPercent(time));
-            }
+                return computeGradient(color, this.getHPPercent(time), 'black');
+            },    
+            getBarrierGradient: function (time, status) {
+                return computeGradient('rgba(0,0,0,0)', 100 - this.getBarrierPercent(time), 'rgba(228,148,97, 0.5)' );
+            }, 
         },
         computed: {
             phase: function () {
@@ -36,6 +51,9 @@
             healths: function () {
                 return graphData.phases[0].players[this.playerindex].healthStates;
             },
+            barriers: function () {
+                return graphData.phases[0].players[this.playerindex].barrierStates;
+            },
             status: function () {
                 var crPData = animator.playerData.get(this.player.uniqueID);
                 var icon = crPData.getIcon(this.time);
@@ -43,6 +61,9 @@
             },
             hasHealth: function () {
                 return !!this.healths;
+            },
+            hasBarrier: function () {
+                return !!this.barriers;
             }
         }
     });

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStatus.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStatus.html
@@ -1,13 +1,17 @@
 <template>
     <div class="d-flex d-flex flex-column justify-content-center align-items-center">
-        <div class="target-status" :style="{'background': getGradient(time)}">
+        <div class="target-status" :style="{'background': getHPGradient(time)}">
             <h6 class="actor-shorten text-center" :title="target.name + ' - ' + target.health + ' health'">
                 <img :src="target.icon" height="18" width="18">
                 {{target.name}}
             </h6>
             <p class="text-right cr-hp-display cr-hp-display-target">
-                {{(Math.round(100*getPercent(time))/100).toFixed(2)}} %
+                {{(Math.round(100*getHPPercent(time))/100).toFixed(2)}} %
             </p>
+            <p v-if="hasBarrier" class="text-right cr-barrier-display cr-barrier-display-target">
+                {{(Math.round(100*getBarrierPercent(time))/100).toFixed(2)}} %
+            </p>
+            <div v-if="hasBarrier" class="cr-barrier" :style="{'background': getBarrierGradient(time, status)}"></div>
         </div>
         <div v-if="hasBreakbarPercent" class="cr-breakbar-display mb-4">
             <div class="cr-breakbar-bar" :style="{'background': getBreakbarGradient(time)}">
@@ -17,7 +21,8 @@
             </div>
             <div style="transform: translate(0px, -22px);">
                 <ul class="nav nav-pills d-flex flex-row flex-wrap justify-content-center scale65">
-                    <li class="nav-item" v-for="(phase, id) in breakbarPhases" @click="updatePhaseTime(phase.start * 1000, phase.end * 1000, phase.name)"
+                    <li class="nav-item" v-for="(phase, id) in breakbarPhases"
+                        @click="updatePhaseTime(phase.start * 1000, phase.end * 1000, phase.name)"
                         :data-original-title="phase.durationS + ' seconds'">
                         <a class="nav-link">{{id + 1}} </a>
                     </li>
@@ -38,16 +43,25 @@
                 }
                 return findState(this.breakbarPercent, time / 1000.0, 0, this.breakbarPercent.length - 1);
             },
-            getPercent: function (time) {
+            getHPPercent: function (time) {
                 return findState(this.healths, time / 1000.0, 0, this.healths.length - 1);
             },
-            getGradient: function (time) {
-                return computeGradient("green", this.getPercent(time));
+            getBarrierPercent: function (time) {
+                if (!this.hasBarrier) {
+                    return 0;
+                }
+                return findState(this.barriers, time/1000.0, 0, this.barriers.length - 1);
+            },
+            getHPGradient: function (time) {
+                return computeGradient("green", this.getHPPercent(time), 'black');
             },
             getBreakbarGradient: function (time) {
                 var color = findState(this.breakbarStates, time / 1000.0, 0, this.breakbarStates.length - 1) ? "#20B2AA" : "#888888";
-                return computeGradient(color, this.getBreakbarPercent(time));
-            },
+                return computeGradient(color, this.getBreakbarPercent(time), 'black');
+            },   
+            getBarrierGradient: function (time, status) {
+                return computeGradient('rgba(0,0,0,0)', 100 - this.getBarrierPercent(time), 'rgba(228,148,97, 0.5)' );
+            }, 
             updatePhaseTime: function (min, max, name) {
                 animator.updateTime(min);
                 sliderDelimiter.min = min;
@@ -70,7 +84,7 @@
                     // 2 seconds for colors
                     res.push([phase.start + 2, true]);
                     res.push([phase.end, false]);
-                    if (i === phases.length - 1) {                   
+                    if (i === phases.length - 1) {
                         res.push([this.phase.end, false]);
                     }
                 }
@@ -91,8 +105,14 @@
             breakbarPercent: function () {
                 return graphData.phases[0].targetsBreakbarPercentStatesForCR[this.targetindex];
             },
+            barriers: function () {
+                return graphData.phases[0].targetsBarrierStatesForCR[this.targetindex];
+            },
             hasBreakbarPercent: function () {
                 return !!this.breakbarPercent;
+            },
+            hasBarrier: function () {
+                return !!this.barriers;
             },
             target: function () {
                 return logData.targets[this.targetindex];

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayUI.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayUI.html
@@ -1,6 +1,6 @@
 <template>
     <div class="d-flex mt-2 justify-content-center">
-        <div class="d-flex flex-column align-items-center mr-2" style="margin-left: auto; min-width:450px; max-width:550px;">
+        <div class="d-flex flex-column align-items-center mr-2" style="margin-left: auto; min-width:450px;">
             <combat-replay-damage-data-component :time="animationStatus.time"
                 :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID">
             </combat-replay-damage-data-component>
@@ -8,7 +8,7 @@
             <combat-replay-extra-decorations-component :light="light"></combat-replay-extra-decorations-component>
         </div>
         <combat-replay-animation-control-component :light="light" :animated="animationStatus.animated"></combat-replay-animation-control-component>
-        <div class="d-flex flex-column align-items-center ml-2" style="margin-right: auto;min-width:450px;max-width:550px;">
+        <div class="d-flex flex-column align-items-center ml-2" style="margin-right: auto;min-width:450px;">
             <combat-replay-status-data-component :time="animationStatus.time"
                 :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID">
             </combat-replay-status-data-component>

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayUI.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayUI.html
@@ -1,6 +1,6 @@
 <template>
     <div class="d-flex mt-2 justify-content-center">
-        <div class="d-flex flex-column align-items-center mr-2" style="margin-left: auto; min-width:450px;">
+        <div class="d-flex flex-column align-items-center mr-2" style="margin-left: auto; min-width:450px; max-width:550px;">
             <combat-replay-damage-data-component :time="animationStatus.time"
                 :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID">
             </combat-replay-damage-data-component>
@@ -8,7 +8,7 @@
             <combat-replay-extra-decorations-component :light="light"></combat-replay-extra-decorations-component>
         </div>
         <combat-replay-animation-control-component :light="light" :animated="animationStatus.animated"></combat-replay-animation-control-component>
-        <div class="d-flex flex-column align-items-center ml-2" style="margin-right: auto;min-width:450px;">
+        <div class="d-flex flex-column align-items-center ml-2" style="margin-right: auto;min-width:450px;max-width:550px;">
             <combat-replay-status-data-component :time="animationStatus.time"
                 :selectedplayer="animationStatus.selectedPlayer" :selectedplayerid="animationStatus.selectedPlayerID">
             </combat-replay-status-data-component>

--- a/GW2EIBuilders/Resources/ei.css
+++ b/GW2EIBuilders/Resources/ei.css
@@ -135,8 +135,22 @@
     width: 45px;
 }
 
+.cr-barrier-display {
+    font-size: 0.65rem;
+    top: -43px;
+    position: relative;
+    width: 45px;
+}
+
 .cr-breakbar-bar {
     color: #DDDDDD;
+}
+
+.cr-barrier { 
+    position: relative;
+    width: 100%;
+    height: 100%;
+    top: -96px;
 }
 
 .cr-breakbar-display {
@@ -147,11 +161,19 @@
 }
 
 .cr-hp-display-player {
+    left: 0%;
+}
+
+.cr-barrier-display-player {
     left: 53%;
 }
 
 .cr-hp-display-target {
-    left: 82%;
+    left: 0%;
+}
+
+.cr-barrier-display-target {
+    left: 77%;
 }
 
 h6.actor-shorten {

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDPSGraph.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDPSGraph.html
@@ -9,6 +9,16 @@
 </template>
 
 <script>
+    function addPoints(res, graph, maxDPS) {
+        if (!graph) {
+            return;
+        }
+        var points = [];
+        for (var j = 0; j < graph.length; j++) {
+            points[j] = graph[j][1] * maxDPS / 100.0;
+        }
+        res.push(points);
+    }
     Vue.component("dps-graph-component", {
         props: ["activetargets", 'mode', 'phaseindex', 'playerindex', 'light'],
         template: `${template}`,       
@@ -95,6 +105,8 @@
             });
             // targets health
             computeTargetHealthData(this.graph, logData.targets, this.phase, this.data, null);  
+            // targets barrier
+            computeTargetBarrierData(this.graph, logData.targets, this.phase, this.data, null);  
             // targets breakbar          
             computeTargetBreakbarData(this.graph, logData.targets, this.phase, this.data, null);
             // mechanics
@@ -281,39 +293,29 @@
                 var offset = 0;
                 for (i = 0; i < logData.players.length; i++) {
                     var pDPS = dpsData.playerDPS[i];
-                    res[offset++] = (this.mode === 0 ? pDPS.total : (this.mode === 1 ? pDPS.target : pDPS.cleave));
+                    res.push((this.mode === 0 ? pDPS.total : (this.mode === 1 ? pDPS.target : pDPS.cleave)));
                 }
-                res[offset++] = (this.mode === 0 ? dpsData.allDPS.total : (this.mode === 1 ? dpsData.allDPS.target : dpsData.allDPS.cleave));
+                res.push((this.mode === 0 ? dpsData.allDPS.total : (this.mode === 1 ? dpsData.allDPS.target : dpsData.allDPS.cleave)));
                 var maxDPS = (this.mode === 0 ? dpsData.maxDPS.total : (this.mode === 1 ? dpsData.maxDPS.target : dpsData.maxDPS.cleave));
                 var hps = [];
                 for (i = 0; i < this.graph.targets.length; i++) {
                     var health = this.graph.targets[i].healthStates;
-                    var hpPoints = [];
-                    for (j = 0; j < health.length; j++) {
-                        hpPoints[j] = health[j][1] * maxDPS / 100.0;
-                    }
-                    hps[i] = hpPoints;
-                    res[offset++] = hpPoints;
+                    addPoints(res, health, maxDPS);
+                }       
+                for (i = 0; i < this.graph.targets.length; i++) {
+                    var barrier = this.graph.targets[i].barrierStates;
+                    addPoints(res, barrier, maxDPS);
                 }
-                {
-                    for (i = 0; i < this.graph.targets.length; i++) {
-                        var breakbar = this.graph.targets[i].breakbarPercentStates;
-                        if (!breakbar) {
-                            continue;
-                        }
-                        var brPoints = [];
-                        for (j = 0; j < breakbar.length; j++) {
-                            brPoints[j] = breakbar[j][1] * maxDPS / 100.0;
-                        }
-                        res[offset++] = brPoints;
-                    }
+                for (i = 0; i < this.graph.targets.length; i++) {
+                    var breakbar = this.graph.targets[i].breakbarPercentStates;
+                    addPoints(res, breakbar, maxDPS);
                 }
                 
                 for (i = 0; i < graphData.mechanics.length; i++) {
                     var mech = graphData.mechanics[i];
                     var mechData = logData.mechanicMap[i];
                     var chart = [];
-                    res[offset++] = chart;
+                    res.push(chart);
                     var time, pts, k, ftime, y, yp1;
                     if (mechData.enemyMech) {
                         for (j = 0; j < mech.points[this.phaseindex].length; j++) {

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDamageDistTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDamageDistTable.html
@@ -1,22 +1,22 @@
 <template>
     <div>
-        <div v-if="actor !== null">
+        <div v-if="actor !== null" class="mb-1 mt-1">
             <div v-if="isminion">
-                <p>
+                <p style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedDamage/dmgdist.totalDamage)}}% of its master's total
                     {{istarget ? 'Target' :''}} damage ({{dmgdist.contributedDamage}})
                 </p>
-                <p v-if="hasBreakbarDamage && dmgdist.contributedBreakbarDamage > 0">
+                <p v-if="hasBreakbarDamage && dmgdist.contributedBreakbarDamage > 0" style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedBreakbarDamage/dmgdist.totalBreakbarDamage)}}% of its master's total
                     {{istarget ? 'Target' :''}} breakbar damage ({{round1(dmgdist.contributedBreakbarDamage)}})
                 </p>
             </div>
             <div v-else>
-                <p>
+                <p style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedDamage/dmgdist.totalDamage)}}% of their total {{istarget ?
                         'Target' :''}} damage ({{dmgdist.contributedDamage}})
                 </p>              
-                <p v-if="hasBreakbarDamage && dmgdist.contributedBreakbarDamage > 0">
+                <p v-if="hasBreakbarDamage && dmgdist.contributedBreakbarDamage > 0" style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedBreakbarDamage/dmgdist.totalBreakbarDamage)}}% of their total
                     {{istarget ? 'Target' :''}} breakbar damage ({{round1(dmgdist.contributedBreakbarDamage)}})
                 </p>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplPlayerTabGraph.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplPlayerTabGraph.html
@@ -1,7 +1,7 @@
 <template>
-    <div>     
-        <dps-graph-mode-selector-component :data="graphdata"
-            :phaseduration="this.phase.end - this.phase.start" :phasehassubphases="!!this.phase.subPhases" :ignorebreakbar="false">
+    <div>
+        <dps-graph-mode-selector-component :data="graphdata" :phaseduration="this.phase.end - this.phase.start"
+            :phasehassubphases="!!this.phase.subPhases" :ignorebreakbar="false">
         </dps-graph-mode-selector-component>
         <h3 class="text-center mt-1 mb-1">{{graphname}}</h3>
         <graph-component :id="graphid" :layout="layout" :data="computeData"></graph-component>
@@ -10,6 +10,43 @@
 </template>
 
 <script>
+
+    function _computePlayerGraphData(graph, data, yaxis, graphName, percentName) {
+        if (!graph) {
+            return 0;
+        }
+        var texts = [];
+        var times = [];
+        for (var j = 0; j < graph.length; j++) {
+            texts[j] = graph[j][1] + "%" + percentName + " - Player";
+            times[j] = graph[j][0];
+        }
+        var res = {
+            x: times,
+            text: texts,
+            mode: 'lines',
+            line: {
+                dash: 'dashdot',
+                shape: 'hv'
+            },
+            hoverinfo: 'text',
+            name: 'Player ' + graphName,
+            visible: 'legendonly',
+        };
+        if (yaxis) {
+            res.yaxis = yaxis;
+        }
+        data.push(res);
+        return 1;
+    }
+
+    function computePlayerHealthData(healthGraph, data, yaxis) {
+        return _computePlayerGraphData(healthGraph, data, yaxis, "health", "hp");
+    }
+
+    function computePlayerBarrierData(barrierGraph, data, yaxis) {
+        return _computePlayerGraphData(barrierGraph, data, yaxis, "barrier", "barrier");
+    }
 
     function addPoints(res, graph, maxDPS) {
         if (!graph) {
@@ -24,7 +61,7 @@
 
     Vue.component("player-graph-tab-component", {
         props: ["playerindex", "phaseindex", "activetargets", "light"],
-        template: `${template}`,  
+        template: `${template}`,
         mixins: [graphComponent],
         data: function () {
             return {
@@ -63,9 +100,8 @@
             this.playerOffset += computeTargetBreakbarData(this.graph, logData.targets, this.phase, this.data, 'y3');
             this.playerOffset += computeTargetBarrierData(this.graph, logData.targets, this.phase, this.data, 'y3');
             this.playerOffset += computeTargetHealthData(this.graph, logData.targets, this.phase, this.data, 'y3');
-            if (this.healthGraph) {
-                this.playerOffset += computePlayerHealthData(this.healthGraph, this.data, 'y3');
-            }
+            this.playerOffset += computePlayerBarrierData(this.barrierGraph, this.data, 'y3');
+            this.playerOffset += computePlayerHealthData(this.healthGraph, this.data, 'y3');
             this.data.push({
                 x: this.phase.times,
                 y: [],
@@ -120,6 +156,9 @@
             healthGraph: function () {
                 return this.graph.players[this.playerindex].healthStates;
             },
+            barrierGraph: function () {
+                return this.graph.players[this.playerindex].barrierStates;
+            },
             graphid: function () {
                 return "playergraph-" + this.playerindex + '-' + this.phaseindex;
             },
@@ -132,7 +171,7 @@
                     case -1:
                         name = "Phase " + name;
                         break;
-                    default:                       
+                    default:
                         name = this.graphdata.dpsmode + "s " + name;
                         break;
                 }
@@ -206,9 +245,8 @@
                 for (var i = 0; i < this.graph.targets.length; i++) {
                     addPoints(res, this.graph.targets[i].healthStates, dpsData.maxDPS);
                 }
-                if (this.healthGraph) {
-                    addPoints(res, this.healthGraph, dpsData.maxDPS);
-                }
+                addPoints(res, this.barrierGraph, dpsData.maxDPS);
+                addPoints(res, this.healthGraph, dpsData.maxDPS);
                 this.dataCache.set(cacheID, res);
                 return res;
             },

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplPlayerTabGraph.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplPlayerTabGraph.html
@@ -10,6 +10,18 @@
 </template>
 
 <script>
+
+    function addPoints(res, graph, maxDPS) {
+        if (!graph) {
+            return;
+        }
+        var points = [];
+        for (var j = 0; j < graph.length; j++) {
+            points[j] = graph[j][1] * maxDPS / 100.0;
+        }
+        res.push(points);
+    }
+
     Vue.component("player-graph-tab-component", {
         props: ["playerindex", "phaseindex", "activetargets", "light"],
         template: `${template}`,  
@@ -49,6 +61,7 @@
             var hasBuffs = oldOffset !== this.playerOffset;
             this.graphOffset = this.playerOffset;
             this.playerOffset += computeTargetBreakbarData(this.graph, logData.targets, this.phase, this.data, 'y3');
+            this.playerOffset += computeTargetBarrierData(this.graph, logData.targets, this.phase, this.data, 'y3');
             this.playerOffset += computeTargetHealthData(this.graph, logData.targets, this.phase, this.data, 'y3');
             if (this.healthGraph) {
                 this.playerOffset += computePlayerHealthData(this.healthGraph, this.data, 'y3');
@@ -179,38 +192,22 @@
                 if (this.dataCache.has(cacheID)) {
                     return this.dataCache.get(cacheID);
                 }
-                var offset = 0;
                 var dpsData = this.computeDPSData();
                 var res = [];
-                res[offset++] = dpsData.playerDPS.total;
-                res[offset++] = dpsData.playerDPS.target;
-                res[offset++] = dpsData.playerDPS.cleave;
+                res.push(dpsData.playerDPS.total);
+                res.push(dpsData.playerDPS.target);
+                res.push(dpsData.playerDPS.cleave);
                 for (var i = 0; i < this.graph.targets.length; i++) {
-                    var breakbar = this.graph.targets[i].breakbarPercentStates;
-                    if (!breakbar) {
-                        continue;
-                    }
-                    var brPoints = [];
-                    for (var j = 0; j < breakbar.length; j++) {
-                        brPoints[j] = breakbar[j][1] * dpsData.maxDPS / 100.0;
-                    }
-                    res[offset++] = brPoints;
+                    addPoints(res, this.graph.targets[i].breakbarPercentStates, dpsData.maxDPS);
                 }
                 for (var i = 0; i < this.graph.targets.length; i++) {
-                    var health = this.graph.targets[i].healthStates;
-                    var hpPoints = [];
-                    for (var j = 0; j < health.length; j++) {
-                        hpPoints[j] = health[j][1] * dpsData.maxDPS / 100.0;
-                    }
-                    res[offset++] = hpPoints;
+                    addPoints(res, this.graph.targets[i].barrierStates, dpsData.maxDPS);
+                }
+                for (var i = 0; i < this.graph.targets.length; i++) {
+                    addPoints(res, this.graph.targets[i].healthStates, dpsData.maxDPS);
                 }
                 if (this.healthGraph) {
-                    var health = this.healthGraph;
-                    var hpPoints = [];
-                    for (var j = 0; j < health.length; j++) {
-                        hpPoints[j] = health[j][1] * dpsData.maxDPS / 100.0;
-                    }
-                    res[offset++] = hpPoints;
+                    addPoints(res, this.healthGraph, dpsData.maxDPS);
                 }
                 this.dataCache.set(cacheID, res);
                 return res;

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplTargetTabGraph.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplTargetTabGraph.html
@@ -1,7 +1,7 @@
 <template>
-    <div>     
-        <dps-graph-mode-selector-component :data="graphdata" 
-            :phaseduration="this.phase.end - this.phase.start" :phasehassubphases="!!this.phase.subPhases" :ignorebreakbar="true">
+    <div>
+        <dps-graph-mode-selector-component :data="graphdata" :phaseduration="this.phase.end - this.phase.start"
+            :phasehassubphases="!!this.phase.subPhases" :ignorebreakbar="true">
         </dps-graph-mode-selector-component>
         <h3 class="text-center mt-1 mb-1">{{graphname}}</h3>
         <graph-component :id="graphid" :layout="layout" :data="computeData"></graph-component>
@@ -30,7 +30,7 @@
             } else if (phasebreaks && phasebreaks[j]) {
                 left = j;
             }
-            right = j;    
+            right = j;
             if (graphMode === GraphType.CenteredDPS) {
                 if (lim > 0) {
                     right = Math.min(Math.round(time + lim), end - 1);
@@ -44,7 +44,7 @@
                 } else {
                     right = end - 1;
                 }
-            }  
+            }
             var div = graphMode !== GraphType.Damage && graphMode !== GraphType.BreakbarDamage ? Math.max(times[right] - times[left], 1) : 1;
             totalDamage = damageData[right] - damageData[left];
             totalDPS[j] = Math.round(totalDamage / (div));
@@ -61,9 +61,43 @@
         return res;
     }
 
+    function addLayout(data, target, states, percentName, graphName, visible) {
+        var texts = [];
+        var times = [];
+        for (var j = 0; j < states.length; j++) {
+            texts[j] = states[j][1] + "% " + percentName;
+            times[j] = states[j][0];
+        }
+        var res = {
+            x: times,
+            text: texts,
+            mode: 'lines',
+            line: {
+                dash: 'dashdot',
+                shape: 'hv'
+            },
+            hoverinfo: 'text',
+            visible: visible ? true : 'legendonly',
+            name: target.name + ' ' + graphName,
+            yaxis: 'y3'
+        };
+        data.push(res);
+    }
+
+    function addPoints(res, graph, maxDPS) {
+        if (!graph) {
+            return;
+        }
+        var points = [];
+        for (var j = 0; j < graph.length; j++) {
+            points[j] = graph[j][1] * maxDPS / 100.0;
+        }
+        res.push(points);
+    }
+
     Vue.component("target-graph-tab-component", {
         props: ["targetindex", "phaseindex", 'light'],
-        template: `${template}`,   
+        template: `${template}`,
         mixins: [graphComponent],
         data: function () {
             return {
@@ -99,49 +133,17 @@
             var hasBuffs = oldOffset !== this.targetOffset;
             if (this.hasBreakbarStates) {
                 var breakbarStates = this.graph.targets[this.phaseTargetIndex].breakbarPercentStates;
-                var breakbarTexts = [];
-                var times = [];
-                for (var j = 0; j < breakbarStates.length; j++) {
-                    breakbarTexts[j] = breakbarStates[j][1] + "% breakbar";
-                    times[j] = breakbarStates[j][0];
-                }
-                var res = {
-                    x: times,
-                    text: breakbarTexts,
-                    mode: 'lines',
-                    line: {
-                        dash: 'dashdot',
-                        shape: 'hv'
-                    },
-                    hoverinfo: 'text',
-                    visible: this.phase.breakbarPhase ? true : 'legendonly',
-                    name: this.target.name + ' breakbar',
-                    yaxis: 'y3'
-                };
-                this.data.push(res);
+                addLayout(this.data, this.target, breakbarStates, "breakbar", "breakbar", this.phase.breakbarPhase);
+                this.targetOffset++;
+            }
+            if (this.hasBarrierStates) {
+                var barrierStates = this.graph.targets[this.phaseTargetIndex].barrierStates;
+                addLayout(this.data, this.target, barrierStates, "barrier", "barrier", false);
                 this.targetOffset++;
             }
             {
                 var health = this.graph.targets[this.phaseTargetIndex].healthStates;
-                var hpTexts = [];
-                var times = [];
-                for (var j = 0; j < health.length; j++) {
-                    hpTexts[j] = health[j][1] + "% hp";
-                    times[j] = health[j][0];
-                }
-                var res = {
-                    x: times,
-                    text: hpTexts,
-                    mode: 'lines',
-                    line: {
-                        dash: 'dashdot',
-                        shape: 'hv'
-                    },
-                    hoverinfo: 'text',
-                    name: this.target.name + ' health',
-                    yaxis: 'y3'
-                };
-                this.data.push(res);
+                addLayout(this.data, this.target, health, "hp", "health", true);
                 this.targetOffset++;
             }
             this.data.push({
@@ -159,8 +161,11 @@
             computePhaseMarkups(this.layout.shapes, this.layout.annotations, this.phase, this.light ? '#495057' : '#cccccc');
         },
         computed: {
-            hasBreakbarStates: function() {
+            hasBreakbarStates: function () {
                 return !!this.graph.targets[this.phaseTargetIndex].breakbarPercentStates;
+            },
+            hasBarrierStates: function () {
+                return !!this.graph.targets[this.phaseTargetIndex].barrierStates;
             },
             target: function () {
                 return logData.targets[this.targetindex];
@@ -186,7 +191,7 @@
                     case -1:
                         name = "Phase " + name;
                         break;
-                    default:                       
+                    default:
                         name = this.graphdata.dpsmode + "s " + name;
                         break;
                 }
@@ -208,10 +213,8 @@
                 this.layout.yaxis3.title = graphTypeEnumToString(this.graphdata.graphmode);
                 var res = this.data;
                 var data = this.computeDPSRelatedData();
-                this.data[this.targetOffset].y = data[0];
-                this.data[this.targetOffset - 1].y = data[1];
-                if (data[2]) {
-                    this.data[this.targetOffset - 2].y = data[2];
+                for (var i = 0; i < data.length; i++) {
+                    this.data[this.targetOffset - i].y = data[i];
                 }
                 return res;
             }
@@ -243,19 +246,15 @@
                 res[0] = dpsData.dps;
                 {
                     var health = this.graph.targets[this.phaseTargetIndex].healthStates;
-                    var hpPoints = [];
-                    for (var j = 0; j < health.length; j++) {
-                        hpPoints[j] = health[j][1] * dpsData.maxDPS / 100.0;
-                    }
-                    res[1] = hpPoints;
+                    addPoints(res, health, dpsData.maxDPS);
+                }
+                if (this.hasBarrierStates) {
+                    var barrierStates = this.graph.targets[this.phaseTargetIndex].barrierStates;                   
+                    addPoints(res, barrierStates, dpsData.maxDPS);
                 }
                 if (this.hasBreakbarStates) {
                     var breakbarStates = this.graph.targets[this.phaseTargetIndex].breakbarPercentStates;
-                    var breakbarPoints = [];
-                    for (var j = 0; j < breakbarStates.length; j++) {
-                        breakbarPoints[j] = breakbarStates[j][1] * dpsData.maxDPS / 100.0;
-                    }
-                    res[2] = breakbarPoints;
+                    addPoints(res, breakbarStates, dpsData.maxDPS);
                 }
                 this.dataCache.set(cacheID, res);
                 return res;

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplTargetTabGraph.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplTargetTabGraph.html
@@ -62,6 +62,9 @@
     }
 
     function addLayout(data, target, states, percentName, graphName, visible) {
+        if (!states) {
+            return 0;
+        }
         var texts = [];
         var times = [];
         for (var j = 0; j < states.length; j++) {
@@ -82,6 +85,7 @@
             yaxis: 'y3'
         };
         data.push(res);
+        return 1;
     }
 
     function addPoints(res, graph, maxDPS) {
@@ -131,21 +135,9 @@
             var oldOffset = this.targetOffset;
             this.targetOffset += computeBuffData(this.target.details.boonGraph[this.phaseindex], this.data);
             var hasBuffs = oldOffset !== this.targetOffset;
-            if (this.hasBreakbarStates) {
-                var breakbarStates = this.graph.targets[this.phaseTargetIndex].breakbarPercentStates;
-                addLayout(this.data, this.target, breakbarStates, "breakbar", "breakbar", this.phase.breakbarPhase);
-                this.targetOffset++;
-            }
-            if (this.hasBarrierStates) {
-                var barrierStates = this.graph.targets[this.phaseTargetIndex].barrierStates;
-                addLayout(this.data, this.target, barrierStates, "barrier", "barrier", false);
-                this.targetOffset++;
-            }
-            {
-                var health = this.graph.targets[this.phaseTargetIndex].healthStates;
-                addLayout(this.data, this.target, health, "hp", "health", true);
-                this.targetOffset++;
-            }
+            this.targetOffset += addLayout(this.data, this.target, this.breakbarStates, "breakbar", "breakbar", this.phase.breakbarPhase);
+            this.targetOffset += addLayout(this.data, this.target, this.barrierStates, "barrier", "barrier", false);
+            this.targetOffset += addLayout(this.data, this.target, this.healthStates, "hp", "health", true);
             this.data.push({
                 x: this.phase.times,
                 y: [],
@@ -161,11 +153,14 @@
             computePhaseMarkups(this.layout.shapes, this.layout.annotations, this.phase, this.light ? '#495057' : '#cccccc');
         },
         computed: {
-            hasBreakbarStates: function () {
-                return !!this.graph.targets[this.phaseTargetIndex].breakbarPercentStates;
+            healthStates: function () {
+                return this.graph.targets[this.phaseTargetIndex].healthStates;
             },
-            hasBarrierStates: function () {
-                return !!this.graph.targets[this.phaseTargetIndex].barrierStates;
+            breakbarStates: function () {
+                return this.graph.targets[this.phaseTargetIndex].breakbarPercentStates;
+            },
+            barrierStates: function () {
+                return this.graph.targets[this.phaseTargetIndex].barrierStates;
             },
             target: function () {
                 return logData.targets[this.targetindex];
@@ -242,20 +237,10 @@
                     return this.dataCache.get(cacheID);
                 }
                 var dpsData = this.computeDPSData();
-                var res = [];
-                res[0] = dpsData.dps;
-                {
-                    var health = this.graph.targets[this.phaseTargetIndex].healthStates;
-                    addPoints(res, health, dpsData.maxDPS);
-                }
-                if (this.hasBarrierStates) {
-                    var barrierStates = this.graph.targets[this.phaseTargetIndex].barrierStates;                   
-                    addPoints(res, barrierStates, dpsData.maxDPS);
-                }
-                if (this.hasBreakbarStates) {
-                    var breakbarStates = this.graph.targets[this.phaseTargetIndex].breakbarPercentStates;
-                    addPoints(res, breakbarStates, dpsData.maxDPS);
-                }
+                var res = [dpsData.dps];
+                addPoints(res, this.healthStates, dpsData.maxDPS);               
+                addPoints(res, this.barrierStates, dpsData.maxDPS);
+                addPoints(res, this.breakbarStates, dpsData.maxDPS);
                 this.dataCache.set(cacheID, res);
                 return res;
             },

--- a/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
@@ -100,6 +100,10 @@ namespace GW2EIEvtcParser.EIData
             if (_barrierUpdates == null)
             {
                 _barrierUpdates = Segment.FromStates(log.CombatData.GetBarrierUpdateEvents(AgentItem).Select(x => x.ToState()).ToList(), 0, log.FightData.FightEnd);
+                if (!_barrierUpdates.Any(x => x.Value > 0))
+                {
+                    _barrierUpdates.Clear();
+                }
             }
             return _barrierUpdates;
         }

--- a/GW2EIEvtcParser/EIData/Buffs/Buff.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/Buff.cs
@@ -254,8 +254,8 @@ namespace GW2EIEvtcParser.EIData
                 new Buff("Spawn Protection?", 34113, ParserHelper.Source.Common, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/e/eb/Determined.png"),
                 new Buff("Stun", 872, ParserHelper.Source.Common, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/9/97/Stun.png"),
                 new Buff("Daze", 833, ParserHelper.Source.Common, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/7/79/Daze.png"),
-                new Buff("Exposed (48209)", 48209, ParserHelper.Source.Common, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/f/f4/Exposed_%28effect%29.png"),
-                new Buff("Exposed (31589)", 31589, ParserHelper.Source.Common, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/f/f4/Exposed_%28effect%29.png"),
+                new Buff("Exposed (48209)", 48209, ParserHelper.Source.Common, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/6/6b/Exposed.png"),
+                new Buff("Exposed (31589)", 31589, ParserHelper.Source.Common, BuffNature.GraphOnlyBuff,"https://wiki.guildwars2.com/images/6/6b/Exposed.png"),
                 new Buff("Unblockable",36781, ParserHelper.Source.Common, BuffStackType.StackingConditionalLoss, 25, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/f/f0/Unblockable_%28effect%29.png",102321 , ulong.MaxValue),
                 //Auras
                 new Buff("Chaos Aura", 10332, ParserHelper.Source.Common, BuffNature.SupportBuffTable,"https://wiki.guildwars2.com/images/e/ec/Chaos_Aura.png"),

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
@@ -47,8 +47,8 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<int>
             {
-                (int)ArcDPSEnums.TargetID.Kenut,
-                (int)ArcDPSEnums.TargetID.Nikare
+                (int)ArcDPSEnums.TargetID.Nikare,
+                (int)ArcDPSEnums.TargetID.Kenut
             };
         }
 

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/BarrierUpdateEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/BarrierUpdateEvent.cs
@@ -1,4 +1,5 @@
-﻿using GW2EIEvtcParser.Interfaces;
+﻿using System;
+using GW2EIEvtcParser.Interfaces;
 
 namespace GW2EIEvtcParser.ParsedData
 {
@@ -8,7 +9,11 @@ namespace GW2EIEvtcParser.ParsedData
 
         internal BarrierUpdateEvent(CombatItem evtcItem, AgentData agentData) : base(evtcItem, agentData)
         {
-            BarrierPercent = evtcItem.DstAgent / 100.0;
+            BarrierPercent = Math.Round(evtcItem.DstAgent / 100.0, 2);
+            if (BarrierPercent > 100.0)
+            {
+                BarrierPercent = 0;
+            }
         }
 
         public (long start, double value) ToState()

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/BreakbarPercentEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/BreakbarPercentEvent.cs
@@ -19,7 +19,7 @@ namespace GW2EIEvtcParser.ParsedData
             BreakbarPercent = Math.Round(100.0 * BitConverter.ToSingle(bytes, 0), 2);
             if (BreakbarPercent > 100.0)
             {
-                BreakbarPercent = 0;
+                BreakbarPercent = 100;
             }
         }
 

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/BreakbarPercentEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/BreakbarPercentEvent.cs
@@ -17,6 +17,10 @@ namespace GW2EIEvtcParser.ParsedData
                 bytes[offset++] = bt;
             }
             BreakbarPercent = Math.Round(100.0 * BitConverter.ToSingle(bytes, 0), 2);
+            if (BreakbarPercent > 100.0)
+            {
+                BreakbarPercent = 0;
+            }
         }
 
         public (long start, double value) ToState()

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/HealthUpdateEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/HealthUpdateEvent.cs
@@ -12,7 +12,7 @@ namespace GW2EIEvtcParser.ParsedData
             HPPercent = Math.Round(evtcItem.DstAgent / 100.0, 2);
             if (HPPercent > 100.0)
             {
-                HPPercent = 0;
+                HPPercent = 100;
             }
         }
 

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/HealthUpdateEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/HealthUpdateEvent.cs
@@ -1,4 +1,5 @@
-﻿using GW2EIEvtcParser.Interfaces;
+﻿using System;
+using GW2EIEvtcParser.Interfaces;
 
 namespace GW2EIEvtcParser.ParsedData
 {
@@ -8,7 +9,11 @@ namespace GW2EIEvtcParser.ParsedData
 
         internal HealthUpdateEvent(CombatItem evtcItem, AgentData agentData) : base(evtcItem, agentData)
         {
-            HPPercent = evtcItem.DstAgent / 100.0;
+            HPPercent = Math.Round(evtcItem.DstAgent / 100.0, 2);
+            if (HPPercent > 100.0)
+            {
+                HPPercent = 0;
+            }
         }
 
         public (long start, double value) ToState()

--- a/GW2EIParser.tst/GW2EIParser.tst.csproj
+++ b/GW2EIParser.tst/GW2EIParser.tst.csproj
@@ -17,15 +17,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NoRewards|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>

--- a/GW2EIParser.tst/StabilityTestEvtc.cs
+++ b/GW2EIParser.tst/StabilityTestEvtc.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using GW2EIEvtcParser;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIParser.Exceptions;
@@ -17,7 +15,7 @@ namespace GW2EIParser.tst
     [TestFixture]
     public class StabilityTestEvtc
     {
-        private static bool Loop(BlockingCollection<string> failed, BlockingCollection<string> messages, string file)
+        private static bool Loop(List<string> failed, List<string> messages, string file)
         {
             try
             {
@@ -53,7 +51,7 @@ namespace GW2EIParser.tst
             return true;
         }
 
-        private static void GenerateCrashData(BlockingCollection<string> failed, BlockingCollection<string> messages, string type, bool copy)
+        private static void GenerateCrashData(List<string> failed, List<string> messages, string type, bool copy)
         {
             string testLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "/../../GW2EIParser.tst/EvtcLogs/Crashes/";
 
@@ -107,10 +105,10 @@ namespace GW2EIParser.tst
             }
             Assert.IsTrue(Directory.Exists(testLocation), "Test Directory missing");
 
-            var failed = new BlockingCollection<string>();
-            var messages = new BlockingCollection<string>();
+            var failed = new List<string>();
+            var messages = new List<string>();
             var toCheck = Directory.EnumerateFiles(testLocation, "*.evtc", SearchOption.AllDirectories).ToList();
-            Parallel.ForEach(toCheck, file => Loop(failed, messages, file));
+            toCheck.ForEach(file => Loop(failed, messages, file));
 
             GenerateCrashData(failed, messages, "evtc", true);
 
@@ -126,10 +124,10 @@ namespace GW2EIParser.tst
                 Directory.CreateDirectory(testLocation);
             }
             Assert.IsTrue(Directory.Exists(testLocation), "Test Directory missing");
-            var failed = new BlockingCollection<string>();
-            var messages = new BlockingCollection<string>();
+            var failed = new List<string>();
+            var messages = new List<string>();
             var toCheck = Directory.EnumerateFiles(testLocation, "*.evtc.zip", SearchOption.AllDirectories).ToList();
-            Parallel.ForEach(toCheck, file => Loop(failed, messages, file));
+            toCheck.ForEach(file => Loop(failed, messages, file));
 
             GenerateCrashData(failed, messages, "evtczip", true);
 
@@ -146,10 +144,10 @@ namespace GW2EIParser.tst
             }
             Assert.IsTrue(Directory.Exists(testLocation), "Test Directory missing");
 
-            var failed = new BlockingCollection<string>();
-            var messages = new BlockingCollection<string>();
+            var failed = new List<string>();
+            var messages = new List<string>();
             var toCheck = Directory.EnumerateFiles(testLocation, "*.zevtc", SearchOption.AllDirectories).ToList();
-            Parallel.ForEach(toCheck, file => Loop(failed, messages, file));
+            toCheck.ForEach(file => Loop(failed, messages, file));
 
             GenerateCrashData(failed, messages, "zevtc", true);
 
@@ -164,9 +162,9 @@ namespace GW2EIParser.tst
             {
                 Directory.CreateDirectory(testLocation);
             }
-            var failed = new BlockingCollection<string>();
+            var failed = new List<string>();
             int failedCount = 0;
-            var messages = new BlockingCollection<string>();
+            var messages = new List<string>();
             var toCheck = Directory.EnumerateFiles(testLocation, "*.zevtc", SearchOption.AllDirectories).ToList();
             foreach (string file in toCheck)
             {


### PR DESCRIPTION
- Added target barrier graphs to main dps graphs, target graphs and player graphs
- Added player barrier graphs to player graphs
- Barrier is now shown on Combat Replay health bars
- Possibility to use the same options as graphs on Combat Replay damage table (4s, 10s, centered dps, etc)
- HTML chart builder c# code refactoring
- HTML chart js code refactoring