### PR TITLE
Custom source directories

### DIFF
--- a/GW2EIBuilders/HTMLBuilder.cs
+++ b/GW2EIBuilders/HTMLBuilder.cs
@@ -129,14 +129,14 @@ namespace GW2EIBuilders
             {
                 string cssFilename = "EliteInsights-" + _scriptVersion + ".css";
                 string cssPath = Path.Combine(path, cssFilename);
-                string cssPrePath = ".";
+                string cssPrePath = "./" + cssFilename;
 
                 // Setting: External Scripts Path
                 // overwrite cssPath (create directory) if files should be placed on different location
                 // settings.externalHtmlScriptsPath is set by the user
-                if (!string.IsNullOrWhiteSpace(_externalScriptsPath) && !IsInvalidExternalScriptPath(_externalScriptsPath))
+                if (!string.IsNullOrWhiteSpace(_externalScriptsPath))
                 {
-                    string htmlExternalScriptsPath = Path.Combine(path, _externalScriptsPath);
+                    string htmlExternalScriptsPath = _externalScriptsPath;
                     bool validPath = false;
 
                     if (!System.IO.Directory.Exists(htmlExternalScriptsPath))
@@ -184,14 +184,14 @@ namespace GW2EIBuilders
                 // If the user set a Cdn url we replace the externalScriptsPath with the proper cdn url
                 if (!string.IsNullOrWhiteSpace(_externalScriptsCdn))
                 {
-                    cssPrePath = _externalScriptsCdn.EndsWith("/") && _externalScriptsCdn.Length > 1 ? _externalScriptsCdn.Substring(0, _externalScriptsCdn.Length - 1) : _externalScriptsCdn;
+                    cssPrePath = (_externalScriptsCdn.EndsWith("/") && _externalScriptsCdn.Length > 1 ? _externalScriptsCdn.Substring(0, _externalScriptsCdn.Length - 1) : _externalScriptsCdn) + "/" + cssFilename;
                 }
                 else
                 {
-                    cssPrePath = _externalScriptsPath;
+                    cssPrePath = _externalScriptsPath + @"\" + cssFilename;
                 }
 
-                return "<link rel=\"stylesheet\" type=\"text/css\" href=\"" + cssPrePath + "/" + cssFilename + "?version=" + _scriptVersionRev + "\">";
+                return "<link rel=\"stylesheet\" type=\"text/css\" href=\"" + cssPrePath + "?version=" + _scriptVersionRev + "\">";
             }
             else
             {
@@ -207,14 +207,14 @@ namespace GW2EIBuilders
             {
                 string scriptFilename = "EliteInsights-" + _scriptVersion + ".js";
                 string scriptPath = Path.Combine(path, scriptFilename);
-                string scriptPrePath = ".";
+                string scriptPrePath = "./" + scriptFilename;
 
                 // Setting: External Scripts Path
-                // overwrite cssPath (create directory) if files should be placed on different location
+                // overwrite scriptPath (create directory) if files should be placed on different location
                 // settings.externalHtmlScriptsPath is set by the user
-                if (!string.IsNullOrWhiteSpace(_externalScriptsPath) && !IsInvalidExternalScriptPath(_externalScriptsPath))
+                if (!string.IsNullOrWhiteSpace(_externalScriptsPath))
                 {
-                    string htmlExternalScriptsPath = Path.Combine(path, _externalScriptsPath);
+                    string htmlExternalScriptsPath = _externalScriptsPath;
                     bool validPath = false;
 
                     if (!System.IO.Directory.Exists(htmlExternalScriptsPath))
@@ -262,14 +262,14 @@ namespace GW2EIBuilders
                 // If the user set a Cdn url we replace the externalScriptsPath with the proper cdn url
                 if (!string.IsNullOrWhiteSpace(_externalScriptsCdn))
                 {
-                    scriptPrePath = _externalScriptsCdn.EndsWith("/") && _externalScriptsCdn.Length > 1 ? _externalScriptsCdn.Substring(0, _externalScriptsCdn.Length-1) : _externalScriptsCdn;
+                    scriptPrePath = (_externalScriptsCdn.EndsWith("/") && _externalScriptsCdn.Length > 1 ? _externalScriptsCdn.Substring(0, _externalScriptsCdn.Length-1) : _externalScriptsCdn) + "/" + scriptFilename;
                 }
                 else
                 {
-                    scriptPrePath = _externalScriptsPath;
+                    scriptPrePath = _externalScriptsPath + @"\" + scriptFilename;
                 }
 
-                return "<script src=\"" + scriptPrePath + "/" + scriptFilename + "?version=" + _scriptVersionRev + "\"></script>";
+                return "<script src=\"" + scriptPrePath + "?version=" + _scriptVersionRev + "\"></script>";
             }
             else
             {
@@ -286,12 +286,6 @@ namespace GW2EIBuilders
             };
             return JsonConvert.SerializeObject(value, settings);
         }
-
-        private static bool IsInvalidExternalScriptPath(string path)
-        {
-            return new List<string> { @"\", "\"", "/", ":", "?", "<", ">", "|" }.Any(path.Contains);
-        }
-
 
         internal static string GetLink(string name)
         {

--- a/GW2EIBuilders/HTMLBuilder.cs
+++ b/GW2EIBuilders/HTMLBuilder.cs
@@ -184,7 +184,7 @@ namespace GW2EIBuilders
                 // If the user set a Cdn url we replace the externalScriptsPath with the proper cdn url
                 if (!string.IsNullOrWhiteSpace(_externalScriptsCdn))
                 {
-                    cssPrePath = _externalScriptsCdn;
+                    cssPrePath = _externalScriptsCdn.EndsWith("/") && _externalScriptsCdn.Length > 1 ? _externalScriptsCdn.Substring(0, _externalScriptsCdn.Length - 1) : _externalScriptsCdn;
                 }
                 else
                 {
@@ -227,7 +227,7 @@ namespace GW2EIBuilders
                         catch
                         {
                             // something went wrong on creating the external folder (invalid chars?)      
-                            // this will skip the saving in this path and continue with css files in the root path for the report
+                            // this will skip the saving in this path and continue with script files in the root path for the report
                         }
                     }
                     else
@@ -262,7 +262,7 @@ namespace GW2EIBuilders
                 // If the user set a Cdn url we replace the externalScriptsPath with the proper cdn url
                 if (!string.IsNullOrWhiteSpace(_externalScriptsCdn))
                 {
-                    scriptPrePath = _externalScriptsCdn;
+                    scriptPrePath = _externalScriptsCdn.EndsWith("/") && _externalScriptsCdn.Length > 1 ? _externalScriptsCdn.Substring(0, _externalScriptsCdn.Length-1) : _externalScriptsCdn;
                 }
                 else
                 {

--- a/GW2EIBuilders/HTMLSettings.cs
+++ b/GW2EIBuilders/HTMLSettings.cs
@@ -7,10 +7,16 @@
 
         public bool ExternalHTMLScripts { get; }
 
-        public HTMLSettings(bool htmlLightTheme, bool externalHTMLScripts)
+        public string ExternalHtmlScriptsPath { get; set; }
+
+        public string ExternalHtmlScriptsCdn { get; set; }
+
+        public HTMLSettings(bool htmlLightTheme, bool externalHTMLScripts, string externalHTMLScriptsPath, string externalHTMLScriptsCdn)
         {
             HTMLLightTheme = htmlLightTheme;
             ExternalHTMLScripts = externalHTMLScripts;
+            ExternalHtmlScriptsPath = externalHTMLScriptsPath;
+            ExternalHtmlScriptsCdn = externalHTMLScriptsCdn;
         }
     }
 }

--- a/GW2EIParser/App.config
+++ b/GW2EIParser/App.config
@@ -103,6 +103,12 @@
          <setting name="DetailledWvW" serializeAs="String">
             <value>False</value>
          </setting>
+         <setting name="HtmlExternalScriptsPath" serializeAs="String">
+            <value />
+         </setting>
+         <setting name="HtmlExternalScriptsCdn" serializeAs="String">
+            <value />
+         </setting>
       </GW2EIParser.Properties.Settings>
    </userSettings>
    <runtime>

--- a/GW2EIParser/ProgramHelper.cs
+++ b/GW2EIParser/ProgramHelper.cs
@@ -363,7 +363,7 @@ namespace GW2EIParser
                 using (var fs = new FileStream(outputFile, FileMode.Create, FileAccess.Write))
                 using (var sw = new StreamWriter(fs))
                 {
-                    var builder = new HTMLBuilder(log, new HTMLSettings(Properties.Settings.Default.LightTheme, Properties.Settings.Default.HtmlExternalScripts), htmlAssets, ParserVersion, uploadresult);
+                    var builder = new HTMLBuilder(log, new HTMLSettings(Properties.Settings.Default.LightTheme, Properties.Settings.Default.HtmlExternalScripts, Properties.Settings.Default.HtmlExternalScriptsPath, Properties.Settings.Default.HtmlExternalScriptsCdn), htmlAssets, ParserVersion, uploadresult);
                     builder.CreateHTML(sw, saveDirectory.FullName);
                 }
                 operation.UpdateProgressWithCancellationCheck("HTML created");

--- a/GW2EIParser/Properties/Settings.Designer.cs
+++ b/GW2EIParser/Properties/Settings.Designer.cs
@@ -229,7 +229,37 @@ namespace GW2EIParser.Properties {
                 this["HtmlExternalScripts"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string HtmlExternalScriptsPath
+        {
+            get
+            {
+                return ((string)(this["HtmlExternalScriptsPath"]));
+            }
+            set
+            {
+                this["HtmlExternalScriptsPath"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string HtmlExternalScriptsCdn
+        {
+            get
+            {
+                return ((string)(this["HtmlExternalScriptsCdn"]));
+            }
+            set
+            {
+                this["HtmlExternalScriptsCdn"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]

--- a/GW2EIParser/Properties/Settings.settings
+++ b/GW2EIParser/Properties/Settings.settings
@@ -95,5 +95,11 @@
     <Setting Name="DetailledWvW" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="HtmlExternalScriptsPath" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+    <Setting Name="HtmlExternalScriptsCdn" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/GW2EIParser/Settings/SettingsForm.Designer.cs
+++ b/GW2EIParser/Settings/SettingsForm.Designer.cs
@@ -61,6 +61,8 @@
             this.ChkAnonymous = new System.Windows.Forms.CheckBox();
             this.ChkHtmlExternalScripts = new System.Windows.Forms.CheckBox();
             this.ChkDetailledWvW = new System.Windows.Forms.CheckBox();
+            this.LblHtmlExternalScriptsCdn = new System.Windows.Forms.Label();
+            this.LblHtmlExternalScriptsPath = new System.Windows.Forms.Label();
             this.TxtHtmlExternalScriptsCdn = new System.Windows.Forms.TextBox();
             this.TxtHtmlExternalScriptsPath = new System.Windows.Forms.TextBox();
             this.ChkSaveOutTrace = new System.Windows.Forms.CheckBox();
@@ -79,8 +81,6 @@
             this.TabHTML = new System.Windows.Forms.TabPage();
             this.PictureTheme = new System.Windows.Forms.PictureBox();
             this.PanelHtml = new System.Windows.Forms.Panel();
-            this.LblHtmlExternalScriptsCdn = new System.Windows.Forms.Label();
-            this.LblHtmlExternalScriptsPath = new System.Windows.Forms.Label();
             this.PanelTheme = new System.Windows.Forms.Panel();
             this.RadioThemeLight = new System.Windows.Forms.RadioButton();
             this.RadioThemeDark = new System.Windows.Forms.RadioButton();
@@ -470,20 +470,43 @@
             this.ChkDetailledWvW.UseVisualStyleBackColor = true;
             this.ChkDetailledWvW.CheckedChanged += new System.EventHandler(this.ChkDetailledWvWCheckedChange);
             // 
+            // LblHtmlExternalScriptsCdn
+            // 
+            this.LblHtmlExternalScriptsCdn.AutoSize = true;
+            this.LblHtmlExternalScriptsCdn.Location = new System.Drawing.Point(9, 57);
+            this.LblHtmlExternalScriptsCdn.Name = "LblHtmlExternalScriptsCdn";
+            this.LblHtmlExternalScriptsCdn.Size = new System.Drawing.Size(29, 13);
+            this.LblHtmlExternalScriptsCdn.TabIndex = 56;
+            this.LblHtmlExternalScriptsCdn.Text = "Cdn:";
+            this.TlpSettings.SetToolTip(this.LblHtmlExternalScriptsCdn, resources.GetString("LblHtmlExternalScriptsCdn.ToolTip"));
+            // 
+            // LblHtmlExternalScriptsPath
+            // 
+            this.LblHtmlExternalScriptsPath.AutoSize = true;
+            this.LblHtmlExternalScriptsPath.Location = new System.Drawing.Point(9, 34);
+            this.LblHtmlExternalScriptsPath.Name = "LblHtmlExternalScriptsPath";
+            this.LblHtmlExternalScriptsPath.Size = new System.Drawing.Size(79, 13);
+            this.LblHtmlExternalScriptsPath.TabIndex = 55;
+            this.LblHtmlExternalScriptsPath.Text = "Absolute Path: ";
+            this.TlpSettings.SetToolTip(this.LblHtmlExternalScriptsPath, "Fill in an absolute path of a directory here to place the external scripts at a d" +
+        "ifferent location then the report file.");
+            // 
             // TxtHtmlExternalScriptsCdn
             // 
-            this.TxtHtmlExternalScriptsCdn.Location = new System.Drawing.Point(44, 54);
+            this.TxtHtmlExternalScriptsCdn.Location = new System.Drawing.Point(37, 54);
             this.TxtHtmlExternalScriptsCdn.Name = "TxtHtmlExternalScriptsCdn";
-            this.TxtHtmlExternalScriptsCdn.Size = new System.Drawing.Size(157, 20);
+            this.TxtHtmlExternalScriptsCdn.Size = new System.Drawing.Size(189, 20);
             this.TxtHtmlExternalScriptsCdn.TabIndex = 57;
+            this.TlpSettings.SetToolTip(this.TxtHtmlExternalScriptsCdn, resources.GetString("TxtHtmlExternalScriptsCdn.ToolTip"));
             this.TxtHtmlExternalScriptsCdn.TextChanged += new System.EventHandler(this.TxtHtmlExternalScriptCdnUrl_TextChanged);
             // 
             // TxtHtmlExternalScriptsPath
             // 
-            this.TxtHtmlExternalScriptsPath.Location = new System.Drawing.Point(44, 31);
+            this.TxtHtmlExternalScriptsPath.Location = new System.Drawing.Point(90, 31);
             this.TxtHtmlExternalScriptsPath.Name = "TxtHtmlExternalScriptsPath";
-            this.TxtHtmlExternalScriptsPath.Size = new System.Drawing.Size(157, 20);
+            this.TxtHtmlExternalScriptsPath.Size = new System.Drawing.Size(136, 20);
             this.TxtHtmlExternalScriptsPath.TabIndex = 54;
+            this.TlpSettings.SetToolTip(this.TxtHtmlExternalScriptsPath, "Fill a directory name here to place the external scripts in a subdirectory");
             this.TxtHtmlExternalScriptsPath.TextChanged += new System.EventHandler(this.TxtHtmlExternalScriptsPath_TextChanged);
             // 
             // ChkSaveOutTrace
@@ -688,28 +711,6 @@
             this.PanelHtml.Name = "PanelHtml";
             this.PanelHtml.Size = new System.Drawing.Size(468, 87);
             this.PanelHtml.TabIndex = 54;
-            // 
-            // LblHtmlExternalScriptsCdn
-            // 
-            this.LblHtmlExternalScriptsCdn.AutoSize = true;
-            this.LblHtmlExternalScriptsCdn.Location = new System.Drawing.Point(9, 57);
-            this.LblHtmlExternalScriptsCdn.Name = "LblHtmlExternalScriptsCdn";
-            this.LblHtmlExternalScriptsCdn.Size = new System.Drawing.Size(29, 13);
-            this.LblHtmlExternalScriptsCdn.TabIndex = 56;
-            this.LblHtmlExternalScriptsCdn.Text = "Cdn:";
-            this.TlpSettings.SetToolTip(this.LblHtmlExternalScriptsCdn, "Fill in a CDN Url to place the external scripts only once and reuse it for your r" +
-        "eports. Remember to think about CORS if you place those files on a seperate cdn " +
-        "server");
-            // 
-            // LblHtmlExternalScriptsPath
-            // 
-            this.LblHtmlExternalScriptsPath.AutoSize = true;
-            this.LblHtmlExternalScriptsPath.Location = new System.Drawing.Point(9, 34);
-            this.LblHtmlExternalScriptsPath.Name = "LblHtmlExternalScriptsPath";
-            this.LblHtmlExternalScriptsPath.Size = new System.Drawing.Size(32, 13);
-            this.LblHtmlExternalScriptsPath.TabIndex = 55;
-            this.LblHtmlExternalScriptsPath.Text = "Path:";
-            this.TlpSettings.SetToolTip(this.LblHtmlExternalScriptsPath, "Fill a directory name here to place the external scripts in a subdirectory");
             // 
             // PanelTheme
             // 

--- a/GW2EIParser/Settings/SettingsForm.Designer.cs
+++ b/GW2EIParser/Settings/SettingsForm.Designer.cs
@@ -60,6 +60,9 @@
             this.ChkMultiLogs = new System.Windows.Forms.CheckBox();
             this.ChkAnonymous = new System.Windows.Forms.CheckBox();
             this.ChkHtmlExternalScripts = new System.Windows.Forms.CheckBox();
+            this.ChkDetailledWvW = new System.Windows.Forms.CheckBox();
+            this.TxtHtmlExternalScriptsCdn = new System.Windows.Forms.TextBox();
+            this.TxtHtmlExternalScriptsPath = new System.Windows.Forms.TextBox();
             this.ChkSaveOutTrace = new System.Windows.Forms.CheckBox();
             this.ChkDamageMods = new System.Windows.Forms.CheckBox();
             this.ChkRawTimelineArrays = new System.Windows.Forms.CheckBox();
@@ -76,6 +79,8 @@
             this.TabHTML = new System.Windows.Forms.TabPage();
             this.PictureTheme = new System.Windows.Forms.PictureBox();
             this.PanelHtml = new System.Windows.Forms.Panel();
+            this.LblHtmlExternalScriptsCdn = new System.Windows.Forms.Label();
+            this.LblHtmlExternalScriptsPath = new System.Windows.Forms.Label();
             this.PanelTheme = new System.Windows.Forms.Panel();
             this.RadioThemeLight = new System.Windows.Forms.RadioButton();
             this.RadioThemeDark = new System.Windows.Forms.RadioButton();
@@ -96,7 +101,6 @@
             this.BtnClose = new System.Windows.Forms.Button();
             this.BtnDumpSettings = new System.Windows.Forms.Button();
             this.BtnLoadSettings = new System.Windows.Forms.Button();
-            this.ChkDetailledWvW = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.NumericCustomTooShort)).BeginInit();
             this.GroupWebhookSettings.SuspendLayout();
             this.TabControl.SuspendLayout();
@@ -449,9 +453,38 @@
             this.ChkHtmlExternalScripts.Text = "External Scripts";
             this.TlpSettings.SetToolTip(this.ChkHtmlExternalScripts, "Writes static css and js scripts in own files, which are shared between all logs." +
         " Log file size decreases, but the script files have to be kept along with the ht" +
-        "ml.");
+        "ml if you dont set a CDN Path");
             this.ChkHtmlExternalScripts.UseVisualStyleBackColor = true;
             this.ChkHtmlExternalScripts.CheckedChanged += new System.EventHandler(this.ChkHtmlExternalScriptsCheckedChanged);
+            // 
+            // ChkDetailledWvW
+            // 
+            this.ChkDetailledWvW.AutoSize = true;
+            this.ChkDetailledWvW.Location = new System.Drawing.Point(6, 88);
+            this.ChkDetailledWvW.Name = "ChkDetailledWvW";
+            this.ChkDetailledWvW.Size = new System.Drawing.Size(136, 17);
+            this.ChkDetailledWvW.TabIndex = 41;
+            this.ChkDetailledWvW.Text = "Detailled WvW Parsing";
+            this.TlpSettings.SetToolTip(this.ChkDetailledWvW, "Keep default value if unsure. Enabling this will make parsing significantly slowe" +
+        "r and the generated files bigger");
+            this.ChkDetailledWvW.UseVisualStyleBackColor = true;
+            this.ChkDetailledWvW.CheckedChanged += new System.EventHandler(this.ChkDetailledWvWCheckedChange);
+            // 
+            // TxtHtmlExternalScriptsCdn
+            // 
+            this.TxtHtmlExternalScriptsCdn.Location = new System.Drawing.Point(44, 54);
+            this.TxtHtmlExternalScriptsCdn.Name = "TxtHtmlExternalScriptsCdn";
+            this.TxtHtmlExternalScriptsCdn.Size = new System.Drawing.Size(157, 20);
+            this.TxtHtmlExternalScriptsCdn.TabIndex = 57;
+            this.TxtHtmlExternalScriptsCdn.TextChanged += new System.EventHandler(this.TxtHtmlExternalScriptCdnUrl_TextChanged);
+            // 
+            // TxtHtmlExternalScriptsPath
+            // 
+            this.TxtHtmlExternalScriptsPath.Location = new System.Drawing.Point(44, 31);
+            this.TxtHtmlExternalScriptsPath.Name = "TxtHtmlExternalScriptsPath";
+            this.TxtHtmlExternalScriptsPath.Size = new System.Drawing.Size(157, 20);
+            this.TxtHtmlExternalScriptsPath.TabIndex = 54;
+            this.TxtHtmlExternalScriptsPath.TextChanged += new System.EventHandler(this.TxtHtmlExternalScriptsPath_TextChanged);
             // 
             // ChkSaveOutTrace
             // 
@@ -645,12 +678,38 @@
             // 
             // PanelHtml
             // 
+            this.PanelHtml.Controls.Add(this.TxtHtmlExternalScriptsCdn);
+            this.PanelHtml.Controls.Add(this.LblHtmlExternalScriptsCdn);
+            this.PanelHtml.Controls.Add(this.LblHtmlExternalScriptsPath);
+            this.PanelHtml.Controls.Add(this.TxtHtmlExternalScriptsPath);
             this.PanelHtml.Controls.Add(this.PanelTheme);
             this.PanelHtml.Controls.Add(this.ChkHtmlExternalScripts);
             this.PanelHtml.Location = new System.Drawing.Point(0, 36);
             this.PanelHtml.Name = "PanelHtml";
             this.PanelHtml.Size = new System.Drawing.Size(468, 87);
             this.PanelHtml.TabIndex = 54;
+            // 
+            // LblHtmlExternalScriptsCdn
+            // 
+            this.LblHtmlExternalScriptsCdn.AutoSize = true;
+            this.LblHtmlExternalScriptsCdn.Location = new System.Drawing.Point(9, 57);
+            this.LblHtmlExternalScriptsCdn.Name = "LblHtmlExternalScriptsCdn";
+            this.LblHtmlExternalScriptsCdn.Size = new System.Drawing.Size(29, 13);
+            this.LblHtmlExternalScriptsCdn.TabIndex = 56;
+            this.LblHtmlExternalScriptsCdn.Text = "Cdn:";
+            this.TlpSettings.SetToolTip(this.LblHtmlExternalScriptsCdn, "Fill in a CDN Url to place the external scripts only once and reuse it for your r" +
+        "eports. Remember to think about CORS if you place those files on a seperate cdn " +
+        "server");
+            // 
+            // LblHtmlExternalScriptsPath
+            // 
+            this.LblHtmlExternalScriptsPath.AutoSize = true;
+            this.LblHtmlExternalScriptsPath.Location = new System.Drawing.Point(9, 34);
+            this.LblHtmlExternalScriptsPath.Name = "LblHtmlExternalScriptsPath";
+            this.LblHtmlExternalScriptsPath.Size = new System.Drawing.Size(32, 13);
+            this.LblHtmlExternalScriptsPath.TabIndex = 55;
+            this.LblHtmlExternalScriptsPath.Text = "Path:";
+            this.TlpSettings.SetToolTip(this.LblHtmlExternalScriptsPath, "Fill a directory name here to place the external scripts in a subdirectory");
             // 
             // PanelTheme
             // 
@@ -868,18 +927,6 @@
             this.BtnLoadSettings.UseVisualStyleBackColor = true;
             this.BtnLoadSettings.Click += new System.EventHandler(this.BtnLoadSettingsClicked);
             // 
-            // ChkDetailledWvW
-            // 
-            this.ChkDetailledWvW.AutoSize = true;
-            this.ChkDetailledWvW.Location = new System.Drawing.Point(6, 88);
-            this.ChkDetailledWvW.Name = "ChkDetailledWvW";
-            this.ChkDetailledWvW.Size = new System.Drawing.Size(156, 17);
-            this.ChkDetailledWvW.TabIndex = 41;
-            this.ChkDetailledWvW.Text = "Detailled WvW Parsing";
-            this.TlpSettings.SetToolTip(this.ChkDetailledWvW, "Keep default value if unsure. Enabling this will make parsing significantly slower and the generated files bigger");
-            this.ChkDetailledWvW.UseVisualStyleBackColor = true;
-            this.ChkDetailledWvW.CheckedChanged += new System.EventHandler(this.ChkDetailledWvWCheckedChange);
-            // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -1003,5 +1050,9 @@
         private System.Windows.Forms.Label DPSReportUserTokenLabel;
         private System.Windows.Forms.Label LblWebhookUrl;
         private System.Windows.Forms.CheckBox ChkDetailledWvW;
+        private System.Windows.Forms.Label LblHtmlExternalScriptsPath;
+        private System.Windows.Forms.TextBox TxtHtmlExternalScriptsPath;
+        private System.Windows.Forms.TextBox TxtHtmlExternalScriptsCdn;
+        private System.Windows.Forms.Label LblHtmlExternalScriptsCdn;
     }
 }

--- a/GW2EIParser/Settings/SettingsForm.Designer.cs
+++ b/GW2EIParser/Settings/SettingsForm.Designer.cs
@@ -81,6 +81,7 @@
             this.TabHTML = new System.Windows.Forms.TabPage();
             this.PictureTheme = new System.Windows.Forms.PictureBox();
             this.PanelHtml = new System.Windows.Forms.Panel();
+            this.BtnHtmlExternalScriptPathSelect = new System.Windows.Forms.Button();
             this.PanelTheme = new System.Windows.Forms.Panel();
             this.RadioThemeLight = new System.Windows.Forms.RadioButton();
             this.RadioThemeDark = new System.Windows.Forms.RadioButton();
@@ -495,7 +496,7 @@
             // 
             this.TxtHtmlExternalScriptsCdn.Location = new System.Drawing.Point(37, 54);
             this.TxtHtmlExternalScriptsCdn.Name = "TxtHtmlExternalScriptsCdn";
-            this.TxtHtmlExternalScriptsCdn.Size = new System.Drawing.Size(189, 20);
+            this.TxtHtmlExternalScriptsCdn.Size = new System.Drawing.Size(201, 20);
             this.TxtHtmlExternalScriptsCdn.TabIndex = 57;
             this.TlpSettings.SetToolTip(this.TxtHtmlExternalScriptsCdn, resources.GetString("TxtHtmlExternalScriptsCdn.ToolTip"));
             this.TxtHtmlExternalScriptsCdn.TextChanged += new System.EventHandler(this.TxtHtmlExternalScriptCdnUrl_TextChanged);
@@ -504,7 +505,7 @@
             // 
             this.TxtHtmlExternalScriptsPath.Location = new System.Drawing.Point(90, 31);
             this.TxtHtmlExternalScriptsPath.Name = "TxtHtmlExternalScriptsPath";
-            this.TxtHtmlExternalScriptsPath.Size = new System.Drawing.Size(136, 20);
+            this.TxtHtmlExternalScriptsPath.Size = new System.Drawing.Size(103, 20);
             this.TxtHtmlExternalScriptsPath.TabIndex = 54;
             this.TlpSettings.SetToolTip(this.TxtHtmlExternalScriptsPath, "Fill a directory name here to place the external scripts in a subdirectory");
             this.TxtHtmlExternalScriptsPath.TextChanged += new System.EventHandler(this.TxtHtmlExternalScriptsPath_TextChanged);
@@ -701,6 +702,7 @@
             // 
             // PanelHtml
             // 
+            this.PanelHtml.Controls.Add(this.BtnHtmlExternalScriptPathSelect);
             this.PanelHtml.Controls.Add(this.TxtHtmlExternalScriptsCdn);
             this.PanelHtml.Controls.Add(this.LblHtmlExternalScriptsCdn);
             this.PanelHtml.Controls.Add(this.LblHtmlExternalScriptsPath);
@@ -711,6 +713,16 @@
             this.PanelHtml.Name = "PanelHtml";
             this.PanelHtml.Size = new System.Drawing.Size(468, 87);
             this.PanelHtml.TabIndex = 54;
+            // 
+            // BtnHtmlExternalScriptPathSelect
+            // 
+            this.BtnHtmlExternalScriptPathSelect.Location = new System.Drawing.Point(194, 30);
+            this.BtnHtmlExternalScriptPathSelect.Name = "BtnHtmlExternalScriptPathSelect";
+            this.BtnHtmlExternalScriptPathSelect.Size = new System.Drawing.Size(45, 22);
+            this.BtnHtmlExternalScriptPathSelect.TabIndex = 58;
+            this.BtnHtmlExternalScriptPathSelect.Text = "Select";
+            this.BtnHtmlExternalScriptPathSelect.UseVisualStyleBackColor = true;
+            this.BtnHtmlExternalScriptPathSelect.Click += new System.EventHandler(this.BtnHtmlExternalScriptPathSelect_Click);
             // 
             // PanelTheme
             // 
@@ -1055,5 +1067,6 @@
         private System.Windows.Forms.TextBox TxtHtmlExternalScriptsPath;
         private System.Windows.Forms.TextBox TxtHtmlExternalScriptsCdn;
         private System.Windows.Forms.Label LblHtmlExternalScriptsCdn;
+        private System.Windows.Forms.Button BtnHtmlExternalScriptPathSelect;
     }
 }

--- a/GW2EIParser/Settings/SettingsForm.cs
+++ b/GW2EIParser/Settings/SettingsForm.cs
@@ -39,6 +39,7 @@ namespace GW2EIParser.Setting
             BtnLoadSettings.Enabled = !busy;
             GroupWebhookSettings.Enabled = !busy;
             TxtHtmlExternalScriptsPath.Enabled = !busy;
+            TxtHtmlExternalScriptsCdn.Enabled = !busy;
         }
 
         private void SetUIEnable()

--- a/GW2EIParser/Settings/SettingsForm.cs
+++ b/GW2EIParser/Settings/SettingsForm.cs
@@ -38,6 +38,7 @@ namespace GW2EIParser.Setting
             BtnResetTraitList.Enabled = !busy;
             BtnLoadSettings.Enabled = !busy;
             GroupWebhookSettings.Enabled = !busy;
+            TxtHtmlExternalScriptsPath.Enabled = !busy;
         }
 
         private void SetUIEnable()
@@ -47,6 +48,10 @@ namespace GW2EIParser.Setting
             PanelJson.Enabled = Properties.Settings.Default.SaveOutJSON;
             PanelXML.Enabled = Properties.Settings.Default.SaveOutXML;
             GroupRawSettings.Enabled = Properties.Settings.Default.SaveOutJSON || Properties.Settings.Default.SaveOutXML;
+            TxtHtmlExternalScriptsPath.Enabled = Properties.Settings.Default.HtmlExternalScripts;
+            LblHtmlExternalScriptsPath.Enabled = Properties.Settings.Default.HtmlExternalScripts;
+            TxtHtmlExternalScriptsCdn.Enabled = Properties.Settings.Default.HtmlExternalScripts;
+            LblHtmlExternalScriptsCdn.Enabled = Properties.Settings.Default.HtmlExternalScripts;
         }
 
         private void SetValues()
@@ -88,6 +93,9 @@ namespace GW2EIParser.Setting
             ChkDetailledWvW.Checked = Properties.Settings.Default.DetailledWvW;
 
             ChkHtmlExternalScripts.Checked = Properties.Settings.Default.HtmlExternalScripts;
+            TxtHtmlExternalScriptsPath.Text = Properties.Settings.Default.HtmlExternalScriptsPath;
+            TxtHtmlExternalScriptsCdn.Text = Properties.Settings.Default.HtmlExternalScriptsCdn;
+            
 
             SetUIEnable();
         }
@@ -237,6 +245,10 @@ namespace GW2EIParser.Setting
         private void ChkHtmlExternalScriptsCheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.HtmlExternalScripts = ChkHtmlExternalScripts.Checked;
+            LblHtmlExternalScriptsPath.Enabled = ChkHtmlExternalScripts.Checked;
+            TxtHtmlExternalScriptsPath.Enabled = ChkHtmlExternalScripts.Checked;
+            LblHtmlExternalScriptsCdn.Enabled = ChkHtmlExternalScripts.Checked;
+            TxtHtmlExternalScriptsCdn.Enabled = ChkHtmlExternalScripts.Checked;
         }
 
         private void RadioThemeLightCheckedChanged(object sender, EventArgs e)
@@ -378,6 +390,16 @@ namespace GW2EIParser.Setting
         private void ChkRawTimelineArraysCheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.RawTimelineArrays = ChkRawTimelineArrays.Checked;
+        }
+
+        private void TxtHtmlExternalScriptsPath_TextChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.HtmlExternalScriptsPath = TxtHtmlExternalScriptsPath.Text.Trim();
+        }
+
+        private void TxtHtmlExternalScriptCdnUrl_TextChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.HtmlExternalScriptsCdn = TxtHtmlExternalScriptsCdn.Text.Trim();
         }
     }
 }

--- a/GW2EIParser/Settings/SettingsForm.cs
+++ b/GW2EIParser/Settings/SettingsForm.cs
@@ -40,6 +40,7 @@ namespace GW2EIParser.Setting
             GroupWebhookSettings.Enabled = !busy;
             TxtHtmlExternalScriptsPath.Enabled = !busy;
             TxtHtmlExternalScriptsCdn.Enabled = !busy;
+            BtnHtmlExternalScriptPathSelect.Enabled = !busy;
         }
 
         private void SetUIEnable()
@@ -53,6 +54,7 @@ namespace GW2EIParser.Setting
             LblHtmlExternalScriptsPath.Enabled = Properties.Settings.Default.HtmlExternalScripts;
             TxtHtmlExternalScriptsCdn.Enabled = Properties.Settings.Default.HtmlExternalScripts;
             LblHtmlExternalScriptsCdn.Enabled = Properties.Settings.Default.HtmlExternalScripts;
+            BtnHtmlExternalScriptPathSelect.Enabled = Properties.Settings.Default.HtmlExternalScripts;
         }
 
         private void SetValues()
@@ -92,11 +94,9 @@ namespace GW2EIParser.Setting
             ChkMultiLogs.Checked = Properties.Settings.Default.ParseMultipleLogs;
             ChkRawTimelineArrays.Checked = Properties.Settings.Default.RawTimelineArrays;
             ChkDetailledWvW.Checked = Properties.Settings.Default.DetailledWvW;
-
             ChkHtmlExternalScripts.Checked = Properties.Settings.Default.HtmlExternalScripts;
             TxtHtmlExternalScriptsPath.Text = Properties.Settings.Default.HtmlExternalScriptsPath;
-            TxtHtmlExternalScriptsCdn.Text = Properties.Settings.Default.HtmlExternalScriptsCdn;
-            
+            TxtHtmlExternalScriptsCdn.Text = Properties.Settings.Default.HtmlExternalScriptsCdn;            
 
             SetUIEnable();
         }
@@ -221,6 +221,7 @@ namespace GW2EIParser.Setting
         {
             Properties.Settings.Default.SkipFailedTries = ChkSkipFailedTries.Checked;
         }
+
         private void ChkOutputJSONCheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.SaveOutJSON = ChkOutputJson.Checked;
@@ -250,6 +251,7 @@ namespace GW2EIParser.Setting
             TxtHtmlExternalScriptsPath.Enabled = ChkHtmlExternalScripts.Checked;
             LblHtmlExternalScriptsCdn.Enabled = ChkHtmlExternalScripts.Checked;
             TxtHtmlExternalScriptsCdn.Enabled = ChkHtmlExternalScripts.Checked;
+            BtnHtmlExternalScriptPathSelect.Enabled = ChkHtmlExternalScripts.Checked;
         }
 
         private void RadioThemeLightCheckedChanged(object sender, EventArgs e)
@@ -319,6 +321,7 @@ namespace GW2EIParser.Setting
         {
             Properties.Settings.Default.AddPoVProf = ChkAddPoVProf.Checked;
         }
+
         private void ChkCompressRawCheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.CompressRaw = ChkCompressRaw.Checked;
@@ -401,6 +404,26 @@ namespace GW2EIParser.Setting
         private void TxtHtmlExternalScriptCdnUrl_TextChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.HtmlExternalScriptsCdn = TxtHtmlExternalScriptsCdn.Text.Trim();
+        }
+
+        private void BtnHtmlExternalScriptPathSelect_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                var fbd = new FolderBrowserDialog();
+                if (!string.IsNullOrWhiteSpace(Properties.Settings.Default.HtmlExternalScriptsPath))
+                {
+                    fbd.ShowNewFolderButton = true;
+                    fbd.SelectedPath = Properties.Settings.Default.HtmlExternalScriptsPath;
+                }
+                fbd.ShowDialog();
+                if (!string.IsNullOrWhiteSpace(fbd.SelectedPath) && Directory.Exists(fbd.SelectedPath))
+                {
+                    Properties.Settings.Default.HtmlExternalScriptsPath = fbd.SelectedPath;
+                    TxtHtmlExternalScriptsPath.Text = fbd.SelectedPath;
+                }
+            }
+            catch { }
         }
     }
 }

--- a/GW2EIParser/Settings/SettingsForm.resx
+++ b/GW2EIParser/Settings/SettingsForm.resx
@@ -120,6 +120,15 @@
   <metadata name="TlpSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="TlpSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="LblHtmlExternalScriptsCdn.ToolTip" xml:space="preserve">
+    <value>Fill in a CDN Url to place the external scripts only once and reuse it for your reports. Remember to think about CORS if you place those files on a seperate cdn server. If set this url will be used for includes and absolute path will be overwritten.</value>
+  </data>
+  <data name="TxtHtmlExternalScriptsCdn.ToolTip" xml:space="preserve">
+    <value>Fill in a CDN Url to place the external scripts only once and reuse it for your reports. Remember to think about CORS if you place those files on a seperate cdn server. If set, this url will be used for includes and absolute path will be overwritten.</value>
+  </data>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>59</value>
   </metadata>

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Note it may take some time for each file to parse and they will not be ready to 
 
 -__HtmlExternalScripts__: if true, css and js files will be separated from the html.
 
--__HtmlExternalScriptsPath__: Available if HtmlExternalScripts is enabled. Will place the external script files in a subdirectory.
+-__HtmlExternalScriptsPath__: Available if HtmlExternalScripts is enabled. Fill in an absolute path to place the external script files at a different location than the report file. If you use this tool on a server and wish to populate reports directly remember to set valid path in __HtmlExternalScriptsCdn__. Otherwise users might not be able to open the external scripts within your report.
 
--__HtmlExternalScriptsCdn__: Available if HtmlExternalScripts is enabled. Will use an url for the external script files. Generate once use multiple times. Will reduce needed webspace a bit.
+-__HtmlExternalScriptsCdn__: Available if HtmlExternalScripts is enabled. Will use an url for the external script files. Generate once, use multiple times. Will reduce needed webspace a bit. If this option is set the settings of __HtmlExternalScriptsPath__ will not be used to include external sources. Think about CORS if you use a seperate server for static source files.
 
 -__LightTheme__: if true, the html will use a light theme by default. Please note that the theme can be dynamically changed on the html post generation.
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Note it may take some time for each file to parse and they will not be ready to 
 
 -__HtmlExternalScripts__: if true, css and js files will be separated from the html.
 
+-__HtmlExternalScriptsPath__: Available if HtmlExternalScripts is enabled. Will place the external script files in a subdirectory.
+
+-__HtmlExternalScriptsCdn__: Available if HtmlExternalScripts is enabled. Will use an url for the external script files. Generate once use multiple times. Will reduce needed webspace a bit.
+
 -__LightTheme__: if true, the html will use a light theme by default. Please note that the theme can be dynamically changed on the html post generation.
 
 ### CSV Settings


### PR DESCRIPTION
I added a feature based on #520 

You have now two more options on the settings tab "HTML". Both are only available if you activated "External scripts"
![image](https://user-images.githubusercontent.com/61412192/106062908-b7b1bf00-60f7-11eb-8446-5b72b35eac00.png)

1) Fill in the name of a subdirectory here to place external script & css files in a subdirectory based on the root dir of the report. Remeber to use valid chars here otherwise this option will be ignored. The html report file will use this directory to include those files.. except if you fill an url in option 2:

2) Fill in an Url. The report html file will use this url to include css and script files. They have to be saved there once.
- Remember to think about CORS if you use a seperate server for holding the external files
- You have to save the external files on the url location once. The reports will not work if you forget this. And if you patch the version of the tool you have to upload those static files once again.
