### PR TITLE
Damage Modifiers API rework (and some internal behavior changes)

### DIFF
--- a/GW2EIBuilders/CSVBuilder.cs
+++ b/GW2EIBuilders/CSVBuilder.cs
@@ -257,16 +257,16 @@ namespace GW2EIBuilders
             {
                 FinalGameplayStatsAll stats = player.GetGameplayStats(_log, phase.Start, phase.End);
                 FinalGameplayStats statsBoss = player.GetGameplayStats(_legacyTarget, _log, phase.Start, phase.End);
-                Dictionary<string, List<DamageModifierStat>> damageMods = player.GetDamageModifierStats(_log, _legacyTarget);
+                IReadOnlyDictionary<string, DamageModifierStat> damageMods = player.GetDamageModifierStats(_legacyTarget, _log, phase.Start, phase.End);
                 var scholar = new DamageModifierStat(0, 0, 0, 0);
                 var moving = new DamageModifierStat(0, 0, 0, 0);
-                if (damageMods.TryGetValue("Scholar Rune", out List<DamageModifierStat> schoDict))
+                if (damageMods.TryGetValue("Scholar Rune", out DamageModifierStat schoDict))
                 {
-                    scholar = schoDict[phaseIndex];
+                    scholar = schoDict;
                 }
-                if (damageMods.TryGetValue("Moving Bonus", out List<DamageModifierStat> moveDict))
+                if (damageMods.TryGetValue("Moving Bonus", out DamageModifierStat moveDict))
                 {
-                    moving = moveDict[phaseIndex];
+                    moving = moveDict;
                 }
 
                 WriteLine(new[] { player.Group.ToString(), player.Prof, player.Character,
@@ -303,16 +303,16 @@ namespace GW2EIBuilders
             foreach (Player player in _noFakePlayers)
             {
                 FinalGameplayStatsAll stats = player.GetGameplayStats(_log, phase.Start, phase.End);
-                Dictionary<string, List<DamageModifierStat>> damageMods = player.GetDamageModifierStats(_log, null);
+                IReadOnlyDictionary<string, DamageModifierStat> damageMods = player.GetDamageModifierStats(_legacyTarget, _log, phase.Start, phase.End);
                 var scholar = new DamageModifierStat(0, 0, 0, 0);
                 var moving = new DamageModifierStat(0, 0, 0, 0);
-                if (damageMods.TryGetValue("Scholar Rune", out List<DamageModifierStat> schoDict))
+                if (damageMods.TryGetValue("Scholar Rune", out DamageModifierStat schoDict))
                 {
-                    scholar = schoDict[phaseIndex];
+                    scholar = schoDict;
                 }
-                if (damageMods.TryGetValue("Moving Bonus", out List<DamageModifierStat> moveDict))
+                if (damageMods.TryGetValue("Moving Bonus", out DamageModifierStat moveDict))
                 {
-                    moving = moveDict[phaseIndex];
+                    moving = moveDict;
                 }
 
                 WriteLine(new[] { player.Group.ToString(), player.Prof, player.Character,

--- a/GW2EIBuilders/HtmlModels/HtmlStats/DamageModData.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlStats/DamageModData.cs
@@ -9,16 +9,13 @@ namespace GW2EIBuilders.HtmlModels
         public List<object[]> Data { get; } = new List<object[]>();
         public List<List<object[]>> DataTarget { get; } = new List<List<object[]>>();
 
-        private DamageModData(Player player, ParsedEvtcLog log, List<DamageModifier> listToUse, int phaseIndex)
+        private DamageModData(Player player, ParsedEvtcLog log, List<DamageModifier> listToUse, PhaseData phase)
         {
-            Dictionary<string, List<DamageModifierStat>> dModData = player.GetDamageModifierStats(log, null);
-            IReadOnlyList<PhaseData> phases = log.FightData.GetPhases(log);
-            PhaseData phase = phases[phaseIndex];
+            IReadOnlyDictionary<string, DamageModifierStat> dModData = player.GetDamageModifierStats(null, log, phase.Start, phase.End);
             foreach (DamageModifier dMod in listToUse)
             {
-                if (dModData.TryGetValue(dMod.Name, out List<DamageModifierStat> list))
+                if (dModData.TryGetValue(dMod.Name, out DamageModifierStat data))
                 {
-                    DamageModifierStat data = list[phaseIndex];
                     Data.Add(new object[]
                     {
                         data.HitCount,
@@ -42,12 +39,11 @@ namespace GW2EIBuilders.HtmlModels
             {
                 var pTarget = new List<object[]>();
                 DataTarget.Add(pTarget);
-                dModData = player.GetDamageModifierStats(log, target);
+                dModData = player.GetDamageModifierStats(target, log, phase.Start, phase.End);
                 foreach (DamageModifier dMod in listToUse)
                 {
-                    if (dModData.TryGetValue(dMod.Name, out List<DamageModifierStat> list))
+                    if (dModData.TryGetValue(dMod.Name, out DamageModifierStat data))
                     {
-                        DamageModifierStat data = list[phaseIndex];
                         pTarget.Add(new object[]
                         {
                             data.HitCount,
@@ -69,22 +65,22 @@ namespace GW2EIBuilders.HtmlModels
                 }
             }
         }
-        public static List<DamageModData> BuildDmgModifiersData(ParsedEvtcLog log, int phaseIndex, List<DamageModifier> damageModsToUse)
+        public static List<DamageModData> BuildDmgModifiersData(ParsedEvtcLog log, PhaseData phase, List<DamageModifier> damageModsToUse)
         {
             var pData = new List<DamageModData>();
             foreach (Player player in log.PlayerList)
             {
-                pData.Add(new DamageModData(player, log, damageModsToUse, phaseIndex));
+                pData.Add(new DamageModData(player, log, damageModsToUse, phase));
             }
             return pData;
         }
 
-        public static List<DamageModData> BuildPersonalDmgModifiersData(ParsedEvtcLog log, int phaseIndex, Dictionary<string, List<DamageModifier>> damageModsToUse)
+        public static List<DamageModData> BuildPersonalDmgModifiersData(ParsedEvtcLog log, PhaseData phase, Dictionary<string, List<DamageModifier>> damageModsToUse)
         {
             var pData = new List<DamageModData>();
             foreach (Player player in log.PlayerList)
             {
-                pData.Add(new DamageModData(player, log, damageModsToUse[player.Prof], phaseIndex));
+                pData.Add(new DamageModData(player, log, damageModsToUse[player.Prof], phase));
             }
             return pData;
         }

--- a/GW2EIBuilders/HtmlModels/LogDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/LogDataDto.cs
@@ -335,9 +335,9 @@ namespace GW2EIBuilders.HtmlModels
                     DefBuffGenActiveOGroupStats = BuffData.BuildActiveBuffGenerationData(log, statistics.PresentDefbuffs, phase, BuffEnum.OffGroup),
                     DefBuffGenActiveSquadStats = BuffData.BuildActiveBuffGenerationData(log, statistics.PresentDefbuffs, phase, BuffEnum.Squad),
                     //
-                    DmgModifiersCommon = DamageModData.BuildDmgModifiersData(log, i, commonDamageModifiers),
-                    DmgModifiersItem = DamageModData.BuildDmgModifiersData(log, i, itemDamageModifiers),
-                    DmgModifiersPers = DamageModData.BuildPersonalDmgModifiersData(log, i, persDamageModDict),
+                    DmgModifiersCommon = DamageModData.BuildDmgModifiersData(log, phase, commonDamageModifiers),
+                    DmgModifiersItem = DamageModData.BuildDmgModifiersData(log, phase, itemDamageModifiers),
+                    DmgModifiersPers = DamageModData.BuildPersonalDmgModifiersData(log, phase, persDamageModDict),
                     TargetsCondiStats = new List<List<BuffData>>(),
                     TargetsCondiTotals = new List<BuffData>(),
                     TargetsBoonTotals = new List<BuffData>(),

--- a/GW2EIBuilders/JsonModels/JsonActors/JsonPlayerBuilder.cs
+++ b/GW2EIBuilders/JsonModels/JsonActors/JsonPlayerBuilder.cs
@@ -15,7 +15,7 @@ namespace GW2EIBuilders.JsonModels
     /// </summary>
     internal static class JsonPlayerBuilder
     {
-        
+
         public static JsonPlayer BuildJsonPlayer(Player player, ParsedEvtcLog log, RawFormatSettings settings, Dictionary<string, JsonLog.SkillDesc> skillDesc, Dictionary<string, JsonLog.BuffDesc> buffDesc, Dictionary<string, JsonLog.DamageModDesc> damageModDesc, Dictionary<string, HashSet<long>> personalBuffs)
         {
             var jsonPlayer = new JsonPlayer();
@@ -30,7 +30,7 @@ namespace GW2EIBuilders.JsonModels
             jsonPlayer.ActiveTimes = phases.Select(x => player.GetActiveDuration(log, x.Start, x.End)).ToList();
             jsonPlayer.HasCommanderTag = player.HasCommanderTag;
             //
-            jsonPlayer.Support = phases.Select(phase => JsonStatisticsBuilder.BuildJsonPlayerSupport(player.GetPlayerSupportStats(log, phase.Start, phase.End))).ToArray();           
+            jsonPlayer.Support = phases.Select(phase => JsonStatisticsBuilder.BuildJsonPlayerSupport(player.GetPlayerSupportStats(log, phase.Start, phase.End))).ToArray();
             var targetDamage1S = new IReadOnlyList<int>[log.FightData.Logic.Targets.Count][];
             var targetPowerDamage1S = new IReadOnlyList<int>[log.FightData.Logic.Targets.Count][];
             var targetConditionDamage1S = new IReadOnlyList<int>[log.FightData.Logic.Targets.Count][];
@@ -117,8 +117,8 @@ namespace GW2EIBuilders.JsonModels
                 jsonPlayer.DeathRecap = deathRecaps.Select(x => JsonDeathRecapBuilder.BuildJsonDeathRecap(x)).ToList();
             }
             // 
-            jsonPlayer.DamageModifiers = JsonDamageModifierDataBuilder.GetDamageModifiers(player.GetDamageModifierStats(log, null), log, damageModDesc);
-            jsonPlayer.DamageModifiersTarget = JsonDamageModifierDataBuilder.GetDamageModifiersTarget(player, log, damageModDesc);
+            jsonPlayer.DamageModifiers = JsonDamageModifierDataBuilder.GetDamageModifiers(phases.Select(x => player.GetDamageModifierStats(null, log, x.Start, x.End)).ToList(), log, damageModDesc);
+            jsonPlayer.DamageModifiersTarget = JsonDamageModifierDataBuilder.GetDamageModifiersTarget(player, log, damageModDesc, phases);
             return jsonPlayer;
         }
 

--- a/GW2EIEvtcParser/EIData/Actors/Player.cs
+++ b/GW2EIEvtcParser/EIData/Actors/Player.cs
@@ -21,6 +21,8 @@ namespace GW2EIEvtcParser.EIData
         private Dictionary<string, List<DamageModifierStat>> _damageModifiers;
         private HashSet<string> _presentDamageModifiers;
         private Dictionary<NPC, Dictionary<string, List<DamageModifierStat>>> _damageModifiersTargets;
+        private CachingCollectionWithTarget<Dictionary<string, DamageModifierStat>> _damageModifiersPerTargets;
+        private CachingCollectionWithTarget<Dictionary<string, List<DamageModifierEvent>>> _damageModifierEventsPerTargets;
         // statistics
         private CachingCollection<FinalPlayerSupport> _playerSupportStats;
         private CachingCollectionCustom<BuffEnum, Dictionary<long, FinalPlayerBuffs>[]> _buffStats;
@@ -183,6 +185,81 @@ namespace GW2EIEvtcParser.EIData
             }
             return _damageModifiers;
         }
+
+        public Dictionary<string, DamageModifierStat> GetDamageModifierStats(NPC target, ParsedEvtcLog log, long start, long end)
+        {
+            // If conjured sword, targetless or WvW, stop
+            if (!log.ParserSettings.ComputeDamageModifiers || IsDummyActor || log.FightData.Logic.Targetless)
+            {
+                return new Dictionary<string, DamageModifierStat>();
+            }
+            if (_damageModifiersPerTargets == null)
+            {
+                _damageModifiersPerTargets = new CachingCollectionWithTarget<Dictionary<string, DamageModifierStat>>(log);
+                _damageModifierEventsPerTargets = new CachingCollectionWithTarget<Dictionary<string, List<DamageModifierEvent>>>(log);
+            }
+            if (_damageModifiersPerTargets.TryGetValue(start, end, target, out Dictionary<string, DamageModifierStat> res))
+            {
+                return res;
+            }
+            if (_damageModifierEventsPerTargets.TryGetValue(log.FightData.FightStart, log.FightData.FightEnd, target, out Dictionary<string, List<DamageModifierEvent>> events))
+            {
+                res = new Dictionary<string, DamageModifierStat>();
+                foreach (KeyValuePair<string, List<DamageModifierEvent>> pair in events)
+                {
+                    DamageModifier damageMod = pair.Value.FirstOrDefault()?.DamageModifier;
+                    if (damageMod != null)
+                    {
+                        var eventsToUse = pair.Value.Where(x => x.Time >= start && x.Time <= end).ToList();
+                        int totalDamage = damageMod.GetTotalDamage(this, log, target, start, end);
+                        IReadOnlyList<AbstractHealthDamageEvent> typeHits = damageMod.GetHitDamageEvents(this, log, target, start, end);
+                        res[pair.Key] = new DamageModifierStat(eventsToUse.Count, typeHits.Count, eventsToUse.Sum(x => x.DamageGain), totalDamage);
+                    }
+                }
+                _damageModifiersPerTargets.Set(start, end, target, res);
+                return res;
+            }
+            //
+            var damageMods = new List<DamageModifier>();
+            if (log.DamageModifiers.DamageModifiersPerSource.TryGetValue(Source.Item, out IReadOnlyList<DamageModifier> list))
+            {
+                damageMods.AddRange(list);
+            }
+            if (log.DamageModifiers.DamageModifiersPerSource.TryGetValue(Source.Gear, out list))
+            {
+                damageMods.AddRange(list);
+            }
+            if (log.DamageModifiers.DamageModifiersPerSource.TryGetValue(Source.Common, out list))
+            {
+                damageMods.AddRange(list);
+            }
+            if (log.DamageModifiers.DamageModifiersPerSource.TryGetValue(Source.FightSpecific, out list))
+            {
+                damageMods.AddRange(list);
+            }
+            damageMods.AddRange(log.DamageModifiers.GetModifiersPerProf(Prof));
+            //
+            var damageModifierEvents = new List<DamageModifierEvent>();
+            foreach (DamageModifier damageMod in damageMods)
+            {
+                damageModifierEvents.AddRange(damageMod.ComputeDamageModifier(this, log));
+            }
+            damageModifierEvents.Sort((x, y) => x.Time.CompareTo(y.Time));
+            var damageModifiersEvents = damageModifierEvents.GroupBy(y => y.DamageModifier.Name).ToDictionary(y => y.Key, y => y.ToList());
+            _damageModifierEventsPerTargets.Set(log.FightData.FightStart, log.FightData.FightEnd, null, damageModifiersEvents);
+            var damageModifiersEventsByTarget = damageModifierEvents.GroupBy(x => x.Dst).ToDictionary(x => x.Key, x => x.GroupBy(y => y.DamageModifier.Name).ToDictionary(y => y.Key, y=> y.ToList()));
+            foreach (AgentItem actor in damageModifiersEventsByTarget.Keys)
+            {
+                _damageModifierEventsPerTargets.Set(log.FightData.FightStart, log.FightData.FightEnd, log.FindActor(actor), damageModifiersEventsByTarget[actor]);
+            }
+            //
+            return GetDamageModifierStats(target, log, start, end);
+        }
+
+        /*public IReadOnlyCollection<string> GetPresentDamageModifier(ParsedEvtcLog log)
+        {
+            return GetDamageModifierStats(null, log, log.FightData.FightStart, log.FightData.FightEnd).Keys;
+        }*/
 
         public IReadOnlyCollection<string> GetPresentDamageModifier(ParsedEvtcLog log)
         {

--- a/GW2EIEvtcParser/EIData/DamageModifiers/BuffDamageModifier.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/BuffDamageModifier.cs
@@ -77,5 +77,22 @@ namespace GW2EIEvtcParser.EIData
                 data[Name].Add(new DamageModifierStat(damages.Count, typeHits.Count, damages.Sum(), totalDamage));
             }
         }
+
+        internal override List<DamageModifierEvent> ComputeDamageModifier(Player p, ParsedEvtcLog log)
+        {
+            Dictionary<long, BuffsGraphModel> bgms = p.GetBuffGraphs(log);
+            if (!Tracker.Has(bgms) && GainComputer != ByAbsence)
+            {
+                return new List<DamageModifierEvent>();
+            }
+            var res = new List<DamageModifierEvent>();
+            IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, log.FightData.FightStart, log.FightData.FightStart);
+            foreach (AbstractHealthDamageEvent evt in typeHits)
+            {
+                res.Add(new DamageModifierEvent(evt, this, ComputeGain(Tracker.GetStack(bgms, evt.Time), evt, log)));
+            }
+            res.RemoveAll(x => x.DamageGain == -1.0);
+            return res;
+        }
     }
 }

--- a/GW2EIEvtcParser/EIData/DamageModifiers/BuffDamageModifier.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/BuffDamageModifier.cs
@@ -40,44 +40,6 @@ namespace GW2EIEvtcParser.EIData
             return gain > 0.0 ? gain * dl.HealthDamage : -1.0;
         }
 
-        internal override void ComputeDamageModifier(Dictionary<string, List<DamageModifierStat>> data, Dictionary<NPC, Dictionary<string, List<DamageModifierStat>>> dataTarget, Player p, ParsedEvtcLog log)
-        {
-            IReadOnlyList<PhaseData> phases = log.FightData.GetPhases(log);
-            Dictionary<long, BuffsGraphModel> bgms = p.GetBuffGraphs(log);
-            if (!Tracker.Has(bgms) && GainComputer != ByAbsence)
-            {
-                return;
-            }
-            foreach (NPC target in log.FightData.Logic.Targets)
-            {
-                if (!dataTarget.TryGetValue(target, out Dictionary<string, List<DamageModifierStat>> extra))
-                {
-                    dataTarget[target] = new Dictionary<string, List<DamageModifierStat>>();
-                }
-                Dictionary<string, List<DamageModifierStat>> dict = dataTarget[target];
-                if (!dict.TryGetValue(Name, out List<DamageModifierStat> list))
-                {
-                    var extraDataList = new List<DamageModifierStat>();
-                    foreach (PhaseData phase in phases)
-                    {
-                        int totalDamage = GetTotalDamage(p, log, target, phase.Start, phase.End);
-                        IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, target, phase.Start, phase.End);
-                        var damages = typeHits.Select(x => ComputeGain(Tracker.GetStack(bgms, x.Time), x, log)).Where(x => x != -1.0).ToList();
-                        extraDataList.Add(new DamageModifierStat(damages.Count, typeHits.Count, damages.Sum(), totalDamage));
-                    }
-                    dict[Name] = extraDataList;
-                }
-            }
-            data[Name] = new List<DamageModifierStat>();
-            foreach (PhaseData phase in phases)
-            {
-                int totalDamage = GetTotalDamage(p, log, null, phase.Start, phase.End);
-                IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, phase.Start, phase.End);
-                var damages = typeHits.Select(x => ComputeGain(Tracker.GetStack(bgms, x.Time), x, log)).Where(x => x != -1.0).ToList();
-                data[Name].Add(new DamageModifierStat(damages.Count, typeHits.Count, damages.Sum(), totalDamage));
-            }
-        }
-
         internal override List<DamageModifierEvent> ComputeDamageModifier(Player p, ParsedEvtcLog log)
         {
             Dictionary<long, BuffsGraphModel> bgms = p.GetBuffGraphs(log);
@@ -86,7 +48,7 @@ namespace GW2EIEvtcParser.EIData
                 return new List<DamageModifierEvent>();
             }
             var res = new List<DamageModifierEvent>();
-            IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, log.FightData.FightStart, log.FightData.FightStart);
+            IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, log.FightData.FightStart, log.FightData.FightEnd);
             foreach (AbstractHealthDamageEvent evt in typeHits)
             {
                 res.Add(new DamageModifierEvent(evt, this, ComputeGain(Tracker.GetStack(bgms, evt.Time), evt, log)));

--- a/GW2EIEvtcParser/EIData/DamageModifiers/DamageLogDamageModifier.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/DamageLogDamageModifier.cs
@@ -16,49 +16,11 @@ namespace GW2EIEvtcParser.EIData
         {
         }
 
-        internal override void ComputeDamageModifier(Dictionary<string, List<DamageModifierStat>> data, Dictionary<NPC, Dictionary<string, List<DamageModifierStat>>> dataTarget, Player p, ParsedEvtcLog log)
-        {
-            IReadOnlyList<PhaseData> phases = log.FightData.GetPhases(log);
-            double gain = GainComputer.ComputeGain(GainPerStack, 1);
-            if (!p.GetHitDamageEvents(null, log, phases[0].Start, phases[0].End).Any(x => DLChecker(x, log)))
-            {
-                return;
-            }
-            foreach (NPC target in log.FightData.Logic.Targets)
-            {
-                if (!dataTarget.TryGetValue(target, out Dictionary<string, List<DamageModifierStat>> extra))
-                {
-                    dataTarget[target] = new Dictionary<string, List<DamageModifierStat>>();
-                }
-                Dictionary<string, List<DamageModifierStat>> dict = dataTarget[target];
-                if (!dict.TryGetValue(Name, out List<DamageModifierStat> list))
-                {
-                    var extraDataList = new List<DamageModifierStat>();
-                    foreach (PhaseData phase in phases)
-                    {
-                        int totalDamage = GetTotalDamage(p, log, target, phase.Start, phase.End);
-                        IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, target, phase.Start, phase.End);
-                        var effect = typeHits.Where(x => DLChecker(x, log)).ToList();
-                        extraDataList.Add(new DamageModifierStat(effect.Count, typeHits.Count, gain * effect.Sum(x => x.HealthDamage), totalDamage));
-                    }
-                    dict[Name] = extraDataList;
-                }
-            }
-            data[Name] = new List<DamageModifierStat>();
-            foreach (PhaseData phase in phases)
-            {
-                int totalDamage = GetTotalDamage(p, log, null, phase.Start, phase.End);
-                IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, phase.Start, phase.End);
-                var effect = typeHits.Where(x => DLChecker(x, log)).ToList();
-                data[Name].Add(new DamageModifierStat(effect.Count, typeHits.Count, gain * effect.Sum(x => x.HealthDamage), totalDamage));
-            }
-        }
-
         internal override List<DamageModifierEvent> ComputeDamageModifier(Player p, ParsedEvtcLog log)
         {
             var res = new List<DamageModifierEvent>();
             double gain = GainComputer.ComputeGain(GainPerStack, 1);
-            IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, log.FightData.FightStart, log.FightData.FightStart);
+            IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, log.FightData.FightStart, log.FightData.FightEnd);
             foreach (AbstractHealthDamageEvent evt in typeHits)
             {
                 if (DLChecker(evt, log))

--- a/GW2EIEvtcParser/EIData/DamageModifiers/DamageLogDamageModifier.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/DamageLogDamageModifier.cs
@@ -53,5 +53,20 @@ namespace GW2EIEvtcParser.EIData
                 data[Name].Add(new DamageModifierStat(effect.Count, typeHits.Count, gain * effect.Sum(x => x.HealthDamage), totalDamage));
             }
         }
+
+        internal override List<DamageModifierEvent> ComputeDamageModifier(Player p, ParsedEvtcLog log)
+        {
+            var res = new List<DamageModifierEvent>();
+            double gain = GainComputer.ComputeGain(GainPerStack, 1);
+            IReadOnlyList<AbstractHealthDamageEvent> typeHits = GetHitDamageEvents(p, log, null, log.FightData.FightStart, log.FightData.FightStart);
+            foreach (AbstractHealthDamageEvent evt in typeHits)
+            {
+                if (DLChecker(evt, log))
+                {
+                    res.Add(new DamageModifierEvent(evt, this, gain * evt.HealthDamage));
+                }
+            }
+            return res;
+        }
     }
 }

--- a/GW2EIEvtcParser/EIData/DamageModifiers/DamageModifier.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/DamageModifier.cs
@@ -154,6 +154,8 @@ namespace GW2EIEvtcParser.EIData
 
         internal abstract void ComputeDamageModifier(Dictionary<string, List<DamageModifierStat>> data, Dictionary<NPC, Dictionary<string, List<DamageModifierStat>>> dataTarget, Player p, ParsedEvtcLog log);
 
+        internal abstract List<DamageModifierEvent> ComputeDamageModifier(Player p, ParsedEvtcLog log);
+
         internal static readonly List<DamageModifier> ItemDamageModifiers = new List<DamageModifier>
         {
             new DamageLogDamageModifier("Moving Bonus","Seaweed Salad (and the likes) – 5% while moving", DamageSource.NoPets, 5.0, DamageType.Power, DamageType.Power, Source.Item,"https://wiki.guildwars2.com/images/1/1c/Bowl_of_Seaweed_Salad.png", (x, log) => x.IsMoving, ByPresence, DamageModifierMode.All),

--- a/GW2EIEvtcParser/EIData/DamageModifiers/DamageModifier.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/DamageModifier.cs
@@ -152,8 +152,6 @@ namespace GW2EIEvtcParser.EIData
             }
         }
 
-        internal abstract void ComputeDamageModifier(Dictionary<string, List<DamageModifierStat>> data, Dictionary<NPC, Dictionary<string, List<DamageModifierStat>>> dataTarget, Player p, ParsedEvtcLog log);
-
         internal abstract List<DamageModifierEvent> ComputeDamageModifier(Player p, ParsedEvtcLog log);
 
         internal static readonly List<DamageModifier> ItemDamageModifiers = new List<DamageModifier>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -26,7 +26,24 @@ namespace GW2EIEvtcParser.EIData
 
         internal static readonly List<DamageModifier> DamageMods = new List<DamageModifier>
         {
-            new BuffDamageModifier(33902, "Sic 'Em!", "40%", DamageSource.NoPets, 40.0, DamageType.Power, DamageType.All, Source.Ranger, ByPresence, "https://wiki.guildwars2.com/images/9/9d/%22Sic_%27Em%21%22.png", DamageModifierMode.PvE),
+            new BuffDamageModifier(33902, "Sic 'Em!", "40%", DamageSource.NoPets, 40.0, DamageType.Power, DamageType.All, Source.Ranger, ByPresence, "https://wiki.guildwars2.com/images/9/9d/%22Sic_%27Em%21%22.png", DamageModifierMode.PvE, (x, log) => {
+                AgentItem src = x.From;
+                AbstractBuffEvent effectApply = log.CombatData.GetBuffData(33902).Where(y => y is BuffApplyEvent && y.To == src).LastOrDefault(y => y.Time <= x.Time);
+                if (effectApply != null)
+                {
+                    return x.To == effectApply.By;
+                }
+                return false;
+            }),
+            new BuffDamageModifier(56923, "Sic 'Em!", "25%", DamageSource.NoPets, 25.0, DamageType.Power, DamageType.All, Source.Ranger, ByPresence, "https://wiki.guildwars2.com/images/9/9d/%22Sic_%27Em%21%22.png", DamageModifierMode.sPvPWvW, (x, log) => {
+                AgentItem src = x.From;
+                AbstractBuffEvent effectApply = log.CombatData.GetBuffData(33902).Where(y => y is BuffApplyEvent && y.To == src).LastOrDefault(y => y.Time <= x.Time);
+                if (effectApply != null)
+                {
+                    return x.To == effectApply.By;
+                }
+                return false;
+            }),
             new DamageLogDamageModifier("Hunter's Tactics", "10% while flanking", DamageSource.NoPets, 10.0, DamageType.Power, DamageType.All, Source.Ranger,"https://wiki.guildwars2.com/images/b/bb/Hunter%27s_Tactics.png", (x, log) => x.IsFlanking , ByPresence, 102321, ulong.MaxValue, DamageModifierMode.All),
             new BuffDamageModifier(30673, "Light on your Feet", "10% (4s) after dodging", DamageSource.NoPets, 10.0, DamageType.Power, DamageType.All, Source.Ranger, ByPresence, "https://wiki.guildwars2.com/images/2/22/Light_on_your_Feet.png", DamageModifierMode.All),
             new BuffDamageModifier(NumberOfBoonsID, "Bountiful Hunter", "1% per boon", DamageSource.All, 1.0, DamageType.Power, DamageType.All, Source.Ranger, ByStack, "https://wiki.guildwars2.com/images/2/25/Bountiful_Hunter.png", DamageModifierMode.All),

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/DamageModifierEvents/DamageModifierEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/DamageModifierEvents/DamageModifierEvent.cs
@@ -1,0 +1,20 @@
+﻿using GW2EIEvtcParser.EIData;
+
+namespace GW2EIEvtcParser.ParsedData
+{
+    internal class DamageModifierEvent : AbstractTimeCombatEvent
+    {
+        public readonly DamageModifier DamageModifier;
+        private readonly AbstractHealthDamageEvent _evt;
+        public AgentItem Src => _evt.From;
+        public AgentItem Dst => _evt.To;
+        public double DamageGain { get; }
+
+        internal DamageModifierEvent(AbstractHealthDamageEvent evt, DamageModifier damageModifier, double damageGain) : base(evt.Time)
+        {
+            _evt = evt;
+            DamageGain = damageGain;
+            DamageModifier = damageModifier;
+        }
+    }
+}

--- a/GW2EIParser/ProgramHelper.cs
+++ b/GW2EIParser/ProgramHelper.cs
@@ -317,7 +317,7 @@ namespace GW2EIParser
                     }
                 });
                 //
-                Parallel.ForEach(log.PlayerList, player => player.GetDamageModifierStats(log, null));
+                //Parallel.ForEach(log.PlayerList, player => player.GetDamageModifierStats(log, null));
                 Parallel.ForEach(log.PlayerList, actor =>
                 {
                     foreach (PhaseData phase in phases)


### PR DESCRIPTION
- Streamlined damage modifiers compute APIs to be in line with the rest of actor APIs aka with a signature of (target, log, start, end)
- Computing of the stats is now done more efficiently, damage modifiers event are created for the whole fight first as such we don't need to call damage log checkers, gain computers and buff checkers for each phases and on each damage events again.
- Damage modifiers that require checking buffs on dst now works on everything and not just on tracked targets. This has the unfortunate effect of making the computation not thread safe.