### PR TITLE
Add on kill food procs

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/Buff.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/Buff.cs
@@ -932,8 +932,8 @@ namespace GW2EIEvtcParser.EIData
         internal static readonly List<Buff> FoodProcs = new List<Buff>
         {
             // Effect procs for On Kill Food
-            new Buff("Nourishment (Bonus Power)", 10110, Source.Item, BuffClassification.Consumable, "https://wiki.guildwars2.com/images/d/d6/Champion_of_the_Crown.png"),
-            new Buff("Malice (Bonus Condition Damage)", 10104, Source.Item, BuffClassification.Consumable, "https://wiki.guildwars2.com/images/d/d6/Champion_of_the_Crown.png"),
+            new Buff("Nourishment (Bonus Power)", 10110, Source.Item, BuffClassification.Gear, "https://wiki.guildwars2.com/images/d/d6/Champion_of_the_Crown.png"),
+            new Buff("Malice (Bonus Condition Damage)", 10104, Source.Item, BuffClassification.Gear, "https://wiki.guildwars2.com/images/d/d6/Champion_of_the_Crown.png"),
         };
     }
 }

--- a/GW2EIEvtcParser/EIData/Buffs/Buff.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/Buff.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using GW2EIEvtcParser.EIData.BuffSimulators;
@@ -929,5 +929,11 @@ namespace GW2EIEvtcParser.EIData
                 new Buff("Strawberry Cilantro Cheesecake", Unknown, Source.Item, BuffClassification.Consumable, "https://wiki.guildwars2.com/images/8/8d/Strawberry_Cilantro_Cheesecake.png"),
         };
 
+        internal static readonly List<Buff> FoodProcs = new List<Buff>
+        {
+            // Effect procs for On Kill Food
+            new Buff("Nourishment (Bonus Power)", 10110, Source.Item, BuffClassification.Consumable, "https://wiki.guildwars2.com/images/d/d6/Champion_of_the_Crown.png"),
+            new Buff("Malice (Bonus Condition Damage)", 10104, Source.Item, BuffClassification.Consumable, "https://wiki.guildwars2.com/images/d/d6/Champion_of_the_Crown.png"),
+        };
     }
 }

--- a/GW2EIEvtcParser/EIData/Buffs/BuffsContainer.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffsContainer.cs
@@ -29,6 +29,7 @@ namespace GW2EIEvtcParser.EIData
                 Gear,
                 NormalFoods,
                 AscendedFood,
+                FoodProcs,
                 Utilities,
                 Potions,
                 Writs,


### PR DESCRIPTION
This adds the effect proc buffs for On Kill Food [Dragon's Breath Bun](https://wiki.guildwars2.com/wiki/Dragon%27s_Breath_Bun) and [Saffron Stuffed Mushroom](https://wiki.guildwars2.com/wiki/Saffron_Stuffed_Mushroom).