### PR TITLE
Add icon override for the Snowball skill used in the Freezie Strike Mission

### DIFF
--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -204,6 +204,7 @@ namespace GW2EIEvtcParser.ParsedData
             {26997, "https://wiki.guildwars2.com/images/d/d9/Natural_Harmony.png" },
             {27101, "https://wiki.guildwars2.com/images/e/e7/Project_Tranquility.png" },
             {35417, "https://wiki.guildwars2.com/images/b/b6/Ventari%27s_Will.png" },
+            {53471, "https://wiki.guildwars2.com/images/d/d0/Fire_Snowball.png" },
             {DeathDropDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
             {SaintsShieldDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
             {ImperialImpactDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/42659/209541233-84d3c333-7771-4c52-9ff5-db87abb4657b.png)

**After:**

![image](https://user-images.githubusercontent.com/42659/209541283-065df341-746c-4e12-a5b8-9fe0bcdc53f6.png)
