### PR TITLE
Track Mechanical Genius uptime on Mechanists

### DIFF
--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/MechanistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/MechanistHelper.cs
@@ -39,6 +39,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Shift Signet",ShiftSignetEffect, Source.Mechanist, BuffClassification.Other, "https://wiki.guildwars2.com/images/d/d1/Shift_Signet.png"),
             new Buff("Superconducting Signet",SuperconductingSignet, Source.Mechanist, BuffClassification.Other, "https://wiki.guildwars2.com/images/5/51/Superconducting_Signet.png"),
             new Buff("Overclock Signet",OverclockSignet, Source.Mechanist, BuffClassification.Other, "https://wiki.guildwars2.com/images/c/c7/Overclock_Signet.png"),
+            new Buff("Mechanical Genius",MechanicalGenius, Source.Mechanist, BuffClassification.Other, "https://wiki.guildwars2.com/images/b/b0/Mechanical_Genius.png"),
             //
             //new Buff("Rectifier Signet (J-Drive)",-1, Source.Mechanist, BuffNature.GraphOnlyBuff, "https://wiki.guildwars2.com/images/c/c4/Rectifier_Signet.png"),
             new Buff("Barrier Signet (J-Drive)",BarrierSignetJDrive, Source.Mechanist, BuffClassification.Other, "https://wiki.guildwars2.com/images/b/b8/Barrier_Signet.png"),

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1799,6 +1799,7 @@ namespace GW2EIEvtcParser
         public const long FixatedOldLionsCourt = 68562;
         public const long DormantCourage = 68585;
         public const long DormantJustice = 68607;
+        public const long MechanicalGenius = 68612;
         public const long DormantResolve = 68640;
     }
 


### PR DESCRIPTION
Buff applied is https://wiki.guildwars2.com/index.php?title=Mechanical_Genius_(effect) with ID `68612`. Buff ID does not appear to vary depending on the trait selected for the type of stats that's distributed (https://wiki.guildwars2.com/wiki/Mech_Frame:_Conductive_Alloys https://wiki.guildwars2.com/wiki/Mech_Frame:_Channeling_Conduits https://wiki.guildwars2.com/wiki/Mech_Frame:_Variable_Mass_Distributor).

![image](https://user-images.githubusercontent.com/818368/211196392-54c947f5-9496-4812-8cd7-39771cfdcbd4.png)
