### PR TITLE
Add HT green and orb failure effects to combat replay

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -637,6 +637,21 @@ namespace GW2EIEvtcParser.EncounterLogic
                         }
                     }
                     //
+                    EffectGUIDEvent orbExploded = log.CombatData.GetEffectGUIDEvent(EffectGUIDs.HarvestTempleOrbExplosion);
+                    if (orbExploded != null)
+                    {
+                        IReadOnlyList<EffectEvent> orbEffects = log.CombatData.GetEffectEventsByEffectID(orbExploded.ContentID);
+                        knownEffectsIDs.Add(orbExploded.ContentID);
+                        foreach (EffectEvent orbEffect in orbEffects)
+                        {
+                            int duration = 3000;
+                            int start = (int)orbEffect.Time;
+                            int end = start + duration;
+                            replay.Decorations.Add(new CircleDecoration(true, end, 2500, (start, end), "rgba(250, 250, 250, 0.05)", new PositionConnector(orbEffect.Position)));
+                            replay.Decorations.Add(new CircleDecoration(true, 0, 2500, (start, end), "rgba(250, 250, 250, 0.05)", new PositionConnector(orbEffect.Position)));
+                        }
+                    }
+                    //
                     BreakbarStateEvent breakbar = log.CombatData.GetBreakbarStateEvents(target.AgentItem).FirstOrDefault(x => x.State == ArcDPSEnums.BreakbarState.Active);
                     if (breakbar != null)
                     {

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -104,5 +104,6 @@ namespace GW2EIEvtcParser
         public const string HarvestTempleRedPuddleSelect = "61C1CD7E89346843B04FCE613EC487AA";
         public const string HarvestTempleGreen = "72EE47DE4F63D3438E193578011FBCBF";
         public const string HarvestTempleGreenExplosion = "F4F80E9AF2B6AF49AFE46D8CF797B604";
+        public const string HarvestTempleOrbExplosion = "B329CFB6B354C148A537E114DC14CED6";
     }
 }


### PR DESCRIPTION
Sample log for testing:

* Normal mode run with bug strat on orb, triggering orb explosion on edge: [20230212-221938.zevtc.zip](https://github.com/baaron4/GW2-Elite-Insights-Parser/files/10788082/20230212-221938.zevtc.zip)

Orb explosion fills over time to simulate the shockwave
![image](https://user-images.githubusercontent.com/818368/220206899-2eba4969-c99b-4279-adfa-9bf325572fd3.png)
