### PR TITLE
add combat replay for Harvest Temple Void Pools

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -845,16 +845,16 @@ namespace GW2EIEvtcParser.EncounterLogic
                         // sort pool effects by time so that we can grow each effect
                         poolEffects.Sort((a, b) => a.Time.CompareTo(b.Time));
                         knownEffectsIDs.Add(voidPool.ContentID);
-                        var radius = 100;
-                        const int radiusIncrement = 35;
+                        var radius = 100.0;
+                        var radiusIncrement = log.FightData.IsCM ? 35.0 : 35.0 / 2;
                         for (int i = 0; i < poolEffects.Count-1; i++)
                         {
                             EffectEvent curEffect = poolEffects[i];
                             EffectEvent nextEffect = poolEffects[i + 1];
                             int start = (int)curEffect.Time;
                             int end = (int)nextEffect.Time;
-                            replay.Decorations.Add(new CircleDecoration(true, 0, radius, (start, end), "rgba(59, 0, 16, 0.2)", new PositionConnector(curEffect.Position)));
-                            replay.Decorations.Add(new CircleDecoration(false, 0, radius, (start, end), "rgba(255, 0, 0, 0.5)", new PositionConnector(curEffect.Position)));
+                            replay.Decorations.Add(new CircleDecoration(true, 0, (int)radius, (start, end), "rgba(59, 0, 16, 0.2)", new PositionConnector(curEffect.Position)));
+                            replay.Decorations.Add(new CircleDecoration(false, 0, (int)radius, (start, end), "rgba(255, 0, 0, 0.5)", new PositionConnector(curEffect.Position)));
                             radius += radiusIncrement;
                         }
                         // last pool effect ends slightly differently depending on phase
@@ -901,8 +901,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                                 }
                                 break;
                         }
-                        replay.Decorations.Add(new CircleDecoration(true, 0, radius, (lastStart, lastEnd), "rgba(59, 0, 16, 0.2)", new PositionConnector(lastEffect.Position)));
-                        replay.Decorations.Add(new CircleDecoration(false, 0, radius, (lastStart, lastEnd), "rgba(255, 0, 0, 0.5)", new PositionConnector(lastEffect.Position)));
+                        replay.Decorations.Add(new CircleDecoration(true, 0, (int)radius, (lastStart, lastEnd), "rgba(59, 0, 16, 0.2)", new PositionConnector(lastEffect.Position)));
+                        replay.Decorations.Add(new CircleDecoration(false, 0, (int)radius, (lastStart, lastEnd), "rgba(255, 0, 0, 0.5)", new PositionConnector(lastEffect.Position)));
                     }
                     break;
                 case (int)ArcDPSEnums.TrashID.VoidWarforged1:

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -838,12 +838,16 @@ namespace GW2EIEvtcParser.EncounterLogic
                     }
                     break;
                 case (int)ArcDPSEnums.TrashID.VoidAmalgamate:
-                    EffectGUIDEvent voidPool = log.CombatData.GetEffectGUIDEvent(EffectGUIDs.HarvestTempleVoidPoolCM);
+                    EffectGUIDEvent voidPool = log.CombatData.GetEffectGUIDEvent(EffectGUIDs.HarvestTempleVoidPool);
                     if (voidPool != null)
                     {
-                        var poolEffects = log.CombatData.GetEffectEventsByEffectID(voidPool.ContentID).Where(x => x.Src.Agent == target.AgentItem.Agent).ToList();
+                        var poolEffects = log.CombatData.GetEffectEventsByEffectID(voidPool.ContentID).Where(x => x.Src == target.AgentItem).ToList();
                         // sort pool effects by time so that we can grow each effect
                         poolEffects.Sort((a, b) => a.Time.CompareTo(b.Time));
+                        if (!poolEffects.Any())
+                        {
+                            break;
+                        }
                         knownEffectsIDs.Add(voidPool.ContentID);
                         var radius = 100.0;
                         var radiusIncrement = log.FightData.IsCM ? 35.0 : 35.0 / 2;

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -119,5 +119,6 @@ namespace GW2EIEvtcParser
         public const string HarvestTempleGreen = "72EE47DE4F63D3438E193578011FBCBF";
         public const string HarvestTempleFailedGreen = "F4F80E9AF2B6AF49AFE46D8CF797B604";
         public const string HarvestTempleOrbExplosion = "B329CFB6B354C148A537E114DC14CED6";
+        public const string HarvestTempleVoidPoolCM = "912F68E45158C14E9A30D6011B7B0C7F";
     }
 }

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -119,6 +119,6 @@ namespace GW2EIEvtcParser
         public const string HarvestTempleGreen = "72EE47DE4F63D3438E193578011FBCBF";
         public const string HarvestTempleFailedGreen = "F4F80E9AF2B6AF49AFE46D8CF797B604";
         public const string HarvestTempleOrbExplosion = "B329CFB6B354C148A537E114DC14CED6";
-        public const string HarvestTempleVoidPoolCM = "912F68E45158C14E9A30D6011B7B0C7F";
+        public const string HarvestTempleVoidPool = "912F68E45158C14E9A30D6011B7B0C7F";
     }
 }


### PR DESCRIPTION
Add support for Void Pools (expanding AoE from orbs) in Harvest Temple.

Example of a CM log:

https://user-images.githubusercontent.com/818368/222917776-2b90ce15-7a6b-4173-a5f1-3ba4c26a0656.mp4

`FindActiveOrNextPhase` doesn't quite work as intended for Soo-Won (SW1, Puri, SW2 all return SooWon).