### PR TITLE
Add soo-won claw attack to combat replay

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -934,6 +934,21 @@ namespace GW2EIEvtcParser.EncounterLogic
                         replay.Decorations.Add(new CircleDecoration(false, 0, (int)radius, (lastStart, lastEnd), "rgba(255, 0, 0, 0.5)", new PositionConnector(lastEffect.Position)));
                     }
                     break;
+                case (int)ArcDPSEnums.TargetID.TheDragonVoidSooWon:
+                    EffectGUIDEvent sooWonClaw = log.CombatData.GetEffectGUIDEvent(EffectGUIDs.HarvestTempleSooWonClaw);
+                    if (sooWonClaw != null)
+                    {
+                        IReadOnlyList<EffectEvent> sooWonClawEffects = log.CombatData.GetEffectEventsByEffectID(sooWonClaw.ContentID);
+                        knownEffectsIDs.Add(sooWonClaw.ContentID);
+                        foreach (EffectEvent effect in sooWonClawEffects)
+                        {
+                            int start = (int)effect.Time;
+                            int end = start + 2300;
+                            replay.Decorations.Add(new PieDecoration(true, 0, 1060, 99.6f, 145, (start, end), "rgba(200, 0, 0, 0.4)", new PositionConnector(effect.Position)));
+                            replay.Decorations.Add(new PieDecoration(true, end, 1060, 99.6f, 145, (start, end), "rgba(200, 0, 0, 0.4)", new PositionConnector(effect.Position)));
+                        }
+                    }
+                    break;
                 case (int)ArcDPSEnums.TrashID.VoidWarforged1:
                 case (int)ArcDPSEnums.TrashID.VoidWarforged2:
                     //CombatReplay.DebugEffects(target, log, replay, knownEffectsIDs, target.FirstAware, target.LastAware, true);

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -132,5 +132,6 @@ namespace GW2EIEvtcParser
         public const string HarvestTempleFailedGreen = "F4F80E9AF2B6AF49AFE46D8CF797B604";
         public const string HarvestTempleOrbExplosion = "B329CFB6B354C148A537E114DC14CED6";
         public const string HarvestTempleVoidPool = "912F68E45158C14E9A30D6011B7B0C7F";
+        public const string HarvestTempleSooWonClaw = "CB877C57D1423240BACDF8D6B52A440F";
     }
 }


### PR DESCRIPTION
Telegraph timing taken from skilldef:

```
skilldef 63588:0 [&BmT4AAA=] at 22637096b9c (loc:1, vis:1): 63588
--vars0
----mode: 0
----type: 0
----513:        2300   (Telegraph Time)
----506:     20.0000   (Melee Slam Damage Multiplier)
```

Sizes and orientation taken from https://github.com/QuitarHero/Heros-Marker-Pack.

Example:

https://user-images.githubusercontent.com/818368/224539221-36dc8686-be3e-4140-a4ef-00265cd56f6c.mp4

Death by claw to verify timing:

https://user-images.githubusercontent.com/818368/224539225-2e032883-4fd4-4b31-8760-a089dd7af624.mp4

