### PR TITLE
Fixed gitv detection and immobilize image

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
@@ -32,7 +32,7 @@
         internal const string Chilled = "https://wiki.guildwars2.com/images/a/a6/Chilled.png";
         internal const string Crippled = "https://wiki.guildwars2.com/images/f/fb/Crippled.png";
         internal const string Fear = "https://wiki.guildwars2.com/images/e/e6/Fear.png";
-        internal const string Immobile = "https://wiki.guildwars2.com/images/3/32/Immobile.png\"";
+        internal const string Immobile = "https://wiki.guildwars2.com/images/3/32/Immobile.png";
         internal const string Slow = "https://wiki.guildwars2.com/images/f/f5/Slow.png";
         internal const string Weakness = "https://wiki.guildwars2.com/images/f/f9/Weakness.png";
         internal const string Taunt = "https://wiki.guildwars2.com/images/c/cc/Taunt.png";

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
@@ -151,28 +151,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             base.SetInstanceBuffs(log);
 
-            if (log.FightData.Success && log.FightData.IsCM)
+            if (log.FightData.Success && log.FightData.IsCM && CustomCheckGazeIntoTheVoidEligibility(log))
             {
-                IReadOnlyList<AbstractBuffEvent> gitv = log.CombatData.GetBuffData(AchievementEligibilityGazeIntoTheVoid);
-                bool hasGitvBeenAdded = false;
-                if (gitv.Any())
-                {
-                    foreach (Player p in log.PlayerList)
-                    {
-                        if (p.HasBuff(log, AchievementEligibilityGazeIntoTheVoid, log.FightData.FightEnd - ServerDelayConstant))
-                        {
-                            InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityGazeIntoTheVoid], 1));
-                            hasGitvBeenAdded = true;
-                            break;
-                        }
-                    }
-                }
-                if (!hasGitvBeenAdded && CustomCheckGazeIntoTheVoidEligibility(log))
-                {
-                    InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityGazeIntoTheVoid], 1));
-                }
+                InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityGazeIntoTheVoid], 1));
             }
-            
         }
 
         private static bool CustomCheckGazeIntoTheVoidEligibility(ParsedEvtcLog log)


### PR DESCRIPTION
Minor fix, removed the buff detection and restricted it to stacks count check only, it was causing logs with < 6 stacks and a achievement eligibility to parse as "gaze into the void". Also fixed a typo for the immobilize image.