### PR TITLE
Reward classes

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -261,7 +261,6 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Reclaimed Energy", ReclaimedEnergy, Source.FightSpecific, BuffClassification.Other, BuffImages.ReclaimedEnergy),
             new Buff("Mortal Coil (Statue of Death)", MortalCoilStatueOfDeath, Source.FightSpecific, BuffStackType.Stacking, 30, BuffClassification.Other, BuffImages.MortalCoil),
             new Buff("Empowered (Statue of Death)", EmpoweredStatueOfDeath, Source.FightSpecific, BuffClassification.Offensive, BuffImages.EmpoweredEater),
-            //new Buff("Energy Threshold (Statue of Death)", 48583, Source.FightSpecific, BuffStackType.Stacking, 5, BuffNature.GraphOnlyBuff, BuffImages.SpiritForm),
             // Eyes
             new Buff("Last Grasp (Judgment)", LastGraspJudgment, Source.FightSpecific, BuffClassification.Other, BuffImages.LastGrasp),
             new Buff("Last Grasp (Fate)", LastGraspFate, Source.FightSpecific, BuffClassification.Other, BuffImages.LastGrasp),
@@ -278,7 +277,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Lethal Report", LethalReport, Source.FightSpecific, BuffClassification.Other, BuffImages.MantraOfSignets),
             new Buff("Hastened Demise", HastenedDemise, Source.FightSpecific, BuffClassification.Other, BuffImages.HastenedDemise),
             new Buff("Echo's Pick up", EchosPickup, Source.FightSpecific, BuffClassification.Other, BuffImages.Unstable),
-            new Buff("Energy Threshold (Dhuum)", EnergyThresholdDhuum, Source.FightSpecific, BuffStackType.Stacking, 5, BuffClassification.Other, BuffImages.SpiritForm),
+            new Buff("Energy Threshold", EnergyThreshold, Source.FightSpecific, BuffStackType.Stacking, 5, BuffClassification.Other, BuffImages.SpiritForm), // Dhuum & Eater of Souls
             //////////////////////////////////////////////
             // CA
             new Buff("Greatsword Power", GreatswordPower, Source.FightSpecific, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.GreatswordPower),

--- a/GW2EIEvtcParser/EncounterLogic/Raids/RaidLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/RaidLogic.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EncounterLogic.EncounterCategory;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -21,23 +22,13 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override void CheckSuccess(CombatData combatData, AgentData agentData, FightData fightData, IReadOnlyCollection<AgentItem> playerAgents)
         {
             var raidRewardsTypes = new HashSet<int>();
-            ulong build = combatData.GetBuildEvent().Build;
-            if (build < 97235)
+            if (combatData.GetBuildEvent().Build < GW2Builds.June2019RaidRewards)
             {
-                raidRewardsTypes = new HashSet<int>
-                {
-                    // Old types, on each kill
-                    55821,
-                    60685
-                };
+                raidRewardsTypes = new HashSet<int> { (int)BouncyChests.OldRaidChest1, (int)BouncyChests.OldRaidChest2 };
             }
             else
             {
-                raidRewardsTypes = new HashSet<int>
-                {
-                    // New types, once per week
-                    22797
-                };
+                raidRewardsTypes = new HashSet<int> { (int)BouncyChests.CurrentRaidChest };
             }
             IReadOnlyList<RewardEvent> rewards = combatData.GetRewardEvents();
             RewardEvent reward = rewards.FirstOrDefault(x => raidRewardsTypes.Contains(x.RewardType));

--- a/GW2EIEvtcParser/EncounterLogic/Raids/RaidLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/RaidLogic.cs
@@ -24,11 +24,11 @@ namespace GW2EIEvtcParser.EncounterLogic
             var raidRewardsTypes = new HashSet<int>();
             if (combatData.GetBuildEvent().Build < GW2Builds.June2019RaidRewards)
             {
-                raidRewardsTypes = new HashSet<int> { (int)BouncyChests.OldRaidChest1, (int)BouncyChests.OldRaidChest2 };
+                raidRewardsTypes = new HashSet<int> { RewardTypes.OldRaidReward1, RewardTypes.OldRaidReward2 };
             }
             else
             {
-                raidRewardsTypes = new HashSet<int> { (int)BouncyChests.CurrentRaidChest };
+                raidRewardsTypes = new HashSet<int> { RewardTypes.CurrentRaidReward };
             }
             IReadOnlyList<RewardEvent> rewards = combatData.GetRewardEvents();
             RewardEvent reward = rewards.FirstOrDefault(x => raidRewardsTypes.Contains(x.RewardType));

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/EndOfDragonsStrike.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/EndOfDragonsStrike.cs
@@ -1,7 +1,7 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EncounterLogic.EncounterCategory;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -20,7 +20,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override void CheckSuccess(CombatData combatData, AgentData agentData, FightData fightData, IReadOnlyCollection<AgentItem> playerAgents)
         {
             IReadOnlyList<RewardEvent> rewards = combatData.GetRewardEvents();
-            RewardEvent reward = rewards.FirstOrDefault(x => x.RewardType == 29453);
+            RewardEvent reward = rewards.FirstOrDefault(x => x.RewardType == RewardTypes.EoDStrikeReward);
             if (reward != null)
             {
                 fightData.SetSuccess(true, reward.Time);

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Grothmar/IcebroodConstruct.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Grothmar/IcebroodConstruct.cs
@@ -61,7 +61,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 return phases;
             }
             // Invul check
-            phases.AddRange(GetPhasesByInvul(log, 757, mainTarget, false, true));
+            phases.AddRange(GetPhasesByInvul(log, Invulnerability757, mainTarget, false, true));
             for (int i = 1; i < phases.Count; i++)
             {
                 PhaseData phase = phases[i];

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/IcebroodSagaStrike.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/IcebroodSagaStrike.cs
@@ -1,7 +1,7 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EncounterLogic.EncounterCategory;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -19,9 +19,16 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override void CheckSuccess(CombatData combatData, AgentData agentData, FightData fightData, IReadOnlyCollection<AgentItem> playerAgents)
         {
             var strikeRewardIDs = new HashSet<ulong>
-                {
-                    993
-                };
+            {
+                BouncyChests.ShiverpeaksPassChests,
+                BouncyChests.KodansOldAndCurrentChest,
+                BouncyChests.KodansCurrentChest1,
+                BouncyChests.KodansCurrentRepeatableChest,
+                BouncyChests.KodansCurrentChest2,
+                BouncyChests.FraenirRepeatableChest,
+                BouncyChests.WhisperRepeatableChest,
+                BouncyChests.BoneskinnerRepeatableChest,
+            };
             IReadOnlyList<RewardEvent> rewards = combatData.GetRewardEvents();
             RewardEvent reward = rewards.FirstOrDefault(x => strikeRewardIDs.Contains(x.RewardID));
             if (reward != null)

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/IcebroodSagaStrike.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/IcebroodSagaStrike.cs
@@ -20,14 +20,14 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             var strikeRewardIDs = new HashSet<ulong>
             {
-                BouncyChests.ShiverpeaksPassChests,
-                BouncyChests.KodansOldAndCurrentChest,
-                BouncyChests.KodansCurrentChest1,
-                BouncyChests.KodansCurrentRepeatableChest,
-                BouncyChests.KodansCurrentChest2,
-                BouncyChests.FraenirRepeatableChest,
-                BouncyChests.WhisperRepeatableChest,
-                BouncyChests.BoneskinnerRepeatableChest,
+                RewardIDs.ShiverpeaksPassChests,
+                RewardIDs.KodansOldAndCurrentChest,
+                RewardIDs.KodansCurrentChest1,
+                RewardIDs.KodansCurrentRepeatableChest,
+                RewardIDs.KodansCurrentChest2,
+                RewardIDs.FraenirRepeatableChest,
+                RewardIDs.WhisperRepeatableChest,
+                RewardIDs.BoneskinnerRepeatableChest,
             };
             IReadOnlyList<RewardEvent> rewards = combatData.GetRewardEvents();
             RewardEvent reward = rewards.FirstOrDefault(x => strikeRewardIDs.Contains(x.RewardID));

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -22,6 +22,7 @@ namespace GW2EIEvtcParser
             internal const ulong December2018Balance = 94051;
             internal const ulong March2019Balance = 95535;
             internal const ulong April2019Balance = 96406;
+            internal const ulong June2019RaidRewards = 97235;
             internal const ulong July2019Balance = 97950;
             internal const ulong July2019Balance2 = 98248;
             internal const ulong October2019Balance = 99526;
@@ -72,6 +73,23 @@ namespace GW2EIEvtcParser
             public const int SecondWaterSet = 1;
             public const int TransformSet = 3;
             public const int KitSet = 2;
+        }
+
+        internal static class BouncyChests
+        {
+            // Chest Type
+            internal const ulong OldRaidChest1 = 55821; // On each kill
+            internal const ulong OldRaidChest2 = 60685; // On each kill
+            internal const ulong CurrentRaidChest = 22797; // Once per week
+            // Chest IDs
+            internal const ulong ShiverpeaksPassChests = 993; // Three chests, once a day
+            internal const ulong KodansOldAndCurrentChest = 1035; // Old repeatable chest, now only once a day
+            internal const ulong KodansCurrentChest1 = 1028; // Current, once a day
+            internal const ulong KodansCurrentChest2 = 1032; // Current, once a day
+            internal const ulong KodansCurrentRepeatableChest = 1091; // Current, repeatable
+            internal const ulong FraenirRepeatableChest = 1007;
+            internal const ulong WhisperRepeatableChest = 1052;
+            internal const ulong BoneskinnerRepeatableChest = 1031;
         }
 
         // Activation
@@ -982,6 +1000,19 @@ namespace GW2EIEvtcParser
 
         public enum MinionID : int
         {
+            // Racial Summons
+            HoundOfBalthazar = 6394,
+            DruidSpirit = 6475,
+            SylvanHound = 6476,
+            IronLegionSoldier = 6509,
+            IronLegionMarksman = 6510,
+            BloodLegionSoldier = 10106,
+            BloodLegionMarksman = 10107,
+            AshLegionSoldier = 10108,
+            AshLegionMarksman = 10109,
+            // GW2 Digital Deluxe
+            MistfireWolf = 9801,
+            // Rune Summons
             RuneJaggedHorror = 21314,
             RuneRockDog = 8836,
             RuneMarkIGolem = 8837,

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -75,21 +75,30 @@ namespace GW2EIEvtcParser
             public const int KitSet = 2;
         }
 
-        internal static class BouncyChests
+        /// <summary>
+        /// Class containing <see cref="int"/> reward types.
+        /// </summary>
+        internal static class RewardTypes
         {
-            // Chest Type
-            internal const ulong OldRaidChest1 = 55821; // On each kill
-            internal const ulong OldRaidChest2 = 60685; // On each kill
-            internal const ulong CurrentRaidChest = 22797; // Once per week
-            // Chest IDs
+            internal const int OldRaidReward1 = 55821; // On each kill
+            internal const int OldRaidReward2 = 60685; // On each kill
+            internal const int CurrentRaidReward = 22797; // Once per week
+            internal const int EoDStrikeReward = 29453;
+        }
+
+        /// <summary>
+        /// Class containing <see cref="ulong"/> reward IDs.
+        /// </summary>
+        internal static class RewardIDs
+        {
             internal const ulong ShiverpeaksPassChests = 993; // Three chests, once a day
             internal const ulong KodansOldAndCurrentChest = 1035; // Old repeatable chest, now only once a day
             internal const ulong KodansCurrentChest1 = 1028; // Current, once a day
             internal const ulong KodansCurrentChest2 = 1032; // Current, once a day
             internal const ulong KodansCurrentRepeatableChest = 1091; // Current, repeatable
             internal const ulong FraenirRepeatableChest = 1007;
-            internal const ulong WhisperRepeatableChest = 1052;
             internal const ulong BoneskinnerRepeatableChest = 1031;
+            internal const ulong WhisperRepeatableChest = 1052;
         }
 
         // Activation

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -299,10 +299,15 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashVoidAmalgamate = "https://i.imgur.com/BuKbosz.png";
 
         // Minion NPC Icons
+        private const string MinionHoundOfBalthazar = "https://i.imgur.com/icmaNZS.png";
+        private const string MinionDruidSpirit = "https://i.imgur.com/Gi7okAw.png";
+        private const string MinionSylvanHound = "https://i.imgur.com/rtcKv9N.png";
+        private const string MinionWarband = "https://i.imgur.com/Y6n0bsV.png";
+        private const string MinionMistfireWolf = "https://i.imgur.com/9hNzLjI.png";
         private const string MinionRuneJaggedHorror = "https://i.imgur.com/opMTn10.png";
-        private const string MinionRuneRockDog = "https://i.imgur.com/666bLKr.png";
+        private const string MinionRuneRockDog = "https://i.imgur.com/EdNp7kY.png";
         private const string MinionRuneMarkIGolem = "https://i.imgur.com/0ePg7eN.png";
-        private const string MinionTropicalBird = "https://i.imgur.com/wxMDqpm.png";
+        private const string MinionTropicalBird = "https://i.imgur.com/iu11ECb.png";
         private const string MinionMesmerClone = "https://i.imgur.com/5Hknsa6.png";
         private const string MinionIllusionarySwordsman = "https://i.imgur.com/ReUwrAL.png";
         private const string MinionIllusionaryBerserker = "https://i.imgur.com/VNcYhXZ.png";
@@ -325,7 +330,7 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string MinionSunSpirit = "https://i.imgur.com/HtCusPF.png";
         private const string MinionStoneSpirit = "https://i.imgur.com/4r6Ytj5.png";
         private const string MinionStormSpirit = "https://i.imgur.com/jXmencD.png";
-        private const string MinionWaterSpirit = "https://i.imgur.com/zPCwf3H.png";
+        private const string MinionWaterSpirit = "https://i.imgur.com/dMcLvwL.png";
         private const string MinionSpiritOfNatureRenewal = "https://i.imgur.com/sGMfD5j.png";
         private const string MinionJuvenileAlpineWolf = "https://i.imgur.com/6NJ4PJx.png";
         private const string MinionJuvenileArctodus = "https://i.imgur.com/of68C0V.png";
@@ -337,8 +342,8 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string MinionJuvenileBoar = "https://i.imgur.com/l9ZDJoG.png";
         private const string MinionJuvenileBristleback = "https://i.imgur.com/rLFL4JL.png";
         private const string MinionJuvenileBrownBear = "https://i.imgur.com/tTR3z9V.png";
-        private const string MinionJuvenileCarrionDevourer = "https://wiki.guildwars2.com/images/9/9e/Juvenile_Carrion_Devourer.png";
-        private const string MinionJuvenileCaveSpider = "https://wiki.guildwars2.com/images/e/eb/Juvenile_Cave_Spider.png";
+        private const string MinionJuvenileCarrionDevourer = "https://i.imgur.com/sQX9L4E.png";
+        private const string MinionJuvenileCaveSpider = "https://i.imgur.com/ulQt5J5.png";
         private const string MinionJuvenileCheetah = "https://i.imgur.com/IosaqHc.png";
         private const string MinionJuvenileEagle = "https://i.imgur.com/WuOl5qh.png";
         private const string MinionJuvenileEletricWywern = "https://i.imgur.com/RsSNDV3.png";
@@ -346,45 +351,45 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string MinionJuvenileFernHound = "https://i.imgur.com/j1c43bj.png";
         private const string MinionJuvenileFireWywern = "https://i.imgur.com/WjODNiP.png";
         private const string MinionJuvenileForestSpider = "https://i.imgur.com/Xu5kRnv.png";
-        private const string MinionJuvenileHawk = "https://wiki.guildwars2.com/images/0/0f/Juvenile_Hawk.png ";
+        private const string MinionJuvenileHawk = "https://i.imgur.com/K65bShd.png";
         private const string MinionJuvenileIceDrake = "https://i.imgur.com/SlbkLrD.png";
         private const string MinionJuvenileJacaranda = "https://i.imgur.com/IrmdDqo.png";
-        private const string MinionJuvenileJaguar = "https://wiki.guildwars2.com/images/9/91/Juvenile_Jaguar.png";
+        private const string MinionJuvenileJaguar = "https://i.imgur.com/0HVaGAX.png";
         private const string MinionJuvenileJungleSpider = "https://i.imgur.com/4zNZcn8.png";
         private const string MinionJuvenileJungleStalker = "https://i.imgur.com/jM51zQ0.png";
         private const string MinionJuvenileKrytanDrakehound = "https://i.imgur.com/KZZ0YPw.png";
         private const string MinionJuvenileLashtailDevourer = "https://i.imgur.com/CnRTFH8.png";
         private const string MinionJuvenileLynx = "https://i.imgur.com/fCjd2Qz.png";
         private const string MinionJuvenileMarshDrake = "https://i.imgur.com/5EuKe2F.png";
-        private const string MinionJuvenileMurellow = "https://wiki.guildwars2.com/images/2/21/Juvenile_Murellow.png";
+        private const string MinionJuvenileMurellow = "https://i.imgur.com/V6bElb0.png";
         private const string MinionJuvenileOwl = "https://i.imgur.com/dh3thfS.png";
-        private const string MinionJuvenilePhoenix = "https://wiki.guildwars2.com/images/7/79/Juvenile_Phoenix.png";
+        private const string MinionJuvenilePhoenix = "https://i.imgur.com/S9SJleP.png";
         private const string MinionJuvenilePig = "https://i.imgur.com/kjj0810.png";
         private const string MinionJuvenilePinkMoa = "https://i.imgur.com/AdzQreO.png";
-        private const string MinionJuvenilePolarBear = "https://wiki.guildwars2.com/images/9/96/Juvenile_Polar_Bear.png";
+        private const string MinionJuvenilePolarBear = "https://i.imgur.com/Qg4KM8u.png";
         private const string MinionJuvenileBlueRainbowJellyfish = "https://i.imgur.com/kS5xGdi.png";
-        private const string MinionJuvenileRaven = "https://wiki.guildwars2.com/images/6/6a/Juvenile_Raven.png";
+        private const string MinionJuvenileRaven = "https://i.imgur.com/RhVO1yf.png";
         private const string MinionJuvenileRedJellyfish = "https://i.imgur.com/BlQij3o.png";
         private const string MinionJuvenileRedMoa = "https://i.imgur.com/N97LXIO.png";
-        private const string MinionJuvenileReefDrake = "https://wiki.guildwars2.com/images/5/5b/Juvenile_Reef_Drake.png";
+        private const string MinionJuvenileReefDrake = "https://i.imgur.com/K5SLEX4.png";
         private const string MinionJuvenileRiverDrake = "https://i.imgur.com/K56jP8H.png";
         private const string MinionJuvenileRockGazelle = "https://i.imgur.com/XV1ySBt.png";
         private const string MinionJuvenileSalamanderDraker = "https://i.imgur.com/2EK2OBE.png";
         private const string MinionJuvenileSandLion = "https://i.imgur.com/XDkpvp9.png";
         private const string MinionJuvenileShark = "https://i.imgur.com/vZ9jIE9.png";
-        private const string MinionJuvenileSiamoth = "https://wiki.guildwars2.com/images/d/d3/Juvenile_Siamoth.png";
-        private const string MinionJuvenileSiegeTurtle = "https://wiki.guildwars2.com/images/6/6c/Juvenile_Siege_Turtle.png";
+        private const string MinionJuvenileSiamoth = "https://i.imgur.com/hD7PWzm.png";
+        private const string MinionJuvenileSiegeTurtle = "https://i.imgur.com/PdM4BnY.png";
         private const string MinionJuvenileSmokescale = "https://i.imgur.com/30k6BmC.png";
-        private const string MinionJuvenileSnowLeopard = "https://wiki.guildwars2.com/images/4/42/Juvenile_Snow_Leopard.png";
+        private const string MinionJuvenileSnowLeopard = "https://i.imgur.com/yid0beF.png";
         private const string MinionJuvenileTiger = "https://i.imgur.com/vALPpMJ.png";
-        private const string MinionJuvenileWallow = "https://wiki.guildwars2.com/images/6/63/Juvenile_Wallow.png";
+        private const string MinionJuvenileWallow = "https://i.imgur.com/a4XZott.png";
         private const string MinionJuvenileWarthog = "https://i.imgur.com/MPPsWBH.png";
         private const string MinionJuvenileWhiptailDevourer = "https://i.imgur.com/hqWNZkD.png";
-        private const string MinionJuvenileWhiteMoa = "https://wiki.guildwars2.com/images/d/d4/Juvenile_White_Moa.png";
-        private const string MinionJuvenileWhiteRaven = "https://wiki.guildwars2.com/images/3/39/Juvenile_White_Raven.png";
+        private const string MinionJuvenileWhiteMoa = "https://i.imgur.com/dhaBAxZ.png";
+        private const string MinionJuvenileWhiteRaven = "https://i.imgur.com/AGbidqS.png";
         private const string MinionJuvenileWhiteTiger = "https://i.imgur.com/B6wtfhQ.png";
         private const string MinionJuvenileWolf = "https://i.imgur.com/GQLiFky.png";
-        private const string MinionJuvenileHyena = "https://wiki.guildwars2.com/images/e/ef/Juvenile_Hyena.png";
+        private const string MinionJuvenileHyena = "https://i.imgur.com/IorUGEQ.png";
         private const string MinionBloodFiend = "https://i.imgur.com/PrOpULe.png";
         private const string MinionBoneFiend = "https://i.imgur.com/BEntBIt.png";
         private const string MinionFleshGolem = "https://i.imgur.com/JkYUNug.png";
@@ -810,6 +815,16 @@ namespace GW2EIEvtcParser.ParserHelpers
         /// </summary>
         internal static IReadOnlyDictionary<ArcDPSEnums.MinionID, string> MinionNPCIcons { get; private set; } = new Dictionary<ArcDPSEnums.MinionID, string>()
         {
+            { ArcDPSEnums.MinionID.HoundOfBalthazar, MinionHoundOfBalthazar },
+            { ArcDPSEnums.MinionID.DruidSpirit, MinionDruidSpirit },
+            { ArcDPSEnums.MinionID.SylvanHound, MinionSylvanHound },
+            { ArcDPSEnums.MinionID.IronLegionSoldier, MinionWarband },
+            { ArcDPSEnums.MinionID.IronLegionMarksman, MinionWarband },
+            { ArcDPSEnums.MinionID.BloodLegionSoldier, MinionWarband },
+            { ArcDPSEnums.MinionID.BloodLegionMarksman, MinionWarband },
+            { ArcDPSEnums.MinionID.AshLegionSoldier, MinionWarband },
+            { ArcDPSEnums.MinionID.AshLegionMarksman, MinionWarband },
+            { ArcDPSEnums.MinionID.MistfireWolf, MinionMistfireWolf },
             { ArcDPSEnums.MinionID.RuneJaggedHorror, MinionRuneJaggedHorror },
             { ArcDPSEnums.MinionID.RuneRockDog, MinionRuneRockDog },
             { ArcDPSEnums.MinionID.RuneMarkIGolem, MinionRuneMarkIGolem },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1878,7 +1878,7 @@
         public const long HastenedDemise = 48773;
         public const long LightCarrier = 48779;
         public const long HungeringAura = 48794;
-        public const long EnergyThresholdDhuum = 48848;
+        public const long EnergyThreshold = 48848;
         public const long ExposeDefenses = 48894;
         public const long SoulStoneVenomSkill = 49052;
         public const long CompoundingPower = 49058;


### PR DESCRIPTION
- Created classes RewardTypes and RewardIDs
- Moved old and current raid rewards and eod reward to RewardTypes
- Moved a reward ID for ibs strike to RewardIDs and added IDs for the other strikes

Bonus:
- Streamlined Energy Threshold since it's the same id for Dhuum and Eater
- Added the build number of the raid rewards change to GW2Builds enum
- Added IDs for racial summons and the deluxe edition of the core game