### PR TITLE
Fix Mushroom King's Blessing detection

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Golem.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Golem.cs
@@ -88,7 +88,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new BuffGainCastFinder(MushroomKingsBlessing, 34523).UsingICD(500), // Mushroom King's Blessing`
+                new BuffGainCastFinder(MushroomKingsBlessing, MushroomKingsBlessingBuff).UsingICD(500),
             };
         }
         internal override void EIEvtcParse(ulong gw2Build, FightData fightData, AgentData agentData, List<CombatItem> combatData, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)

--- a/GW2EIEvtcParser/EncounterLogic/Golem.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Golem.cs
@@ -88,7 +88,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new BuffGainCastFinder(MushroomKingsBlessing, 46970).UsingICD(500), // Mushroom King's Blessing`
+                new BuffGainCastFinder(MushroomKingsBlessing, 34523).UsingICD(500), // Mushroom King's Blessing`
             };
         }
         internal override void EIEvtcParse(ulong gw2Build, FightData fightData, AgentData agentData, List<CombatItem> combatData, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -127,7 +127,8 @@ namespace GW2EIEvtcParser.ParsedData
             {PotentHasteOrOverwhelmingCelerity, "Potent Haste or Overwhelming Celerity" },
             {PortentOfFreedomOrUnhinderedDelivery, "Portent of Freedom or Unhindered Delivery" },
 
-            {GlennaCap, "Capture" }
+            {GlennaCap, "Capture" },
+            {MushroomKingsBlessing, "Mushroom King's Blessing"},
         };
 
         private static readonly Dictionary<long, string> _overrideIcons = new Dictionary<long, string>()
@@ -272,6 +273,7 @@ namespace GW2EIEvtcParser.ParsedData
             {PotentHasteOrOverwhelmingCelerity, "https://i.imgur.com/vBBKfGz.png" },
             {PortentOfFreedomOrUnhinderedDelivery, "https://i.imgur.com/b6RUVTr.png" },
 
+            {MushroomKingsBlessing, "https://wiki.guildwars2.com/images/8/86/Cap_Hop.png"},
         };
 
         private static readonly Dictionary<long, ulong> _nonCritable = new Dictionary<long, ulong>

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -827,7 +827,6 @@
         public const long Enraged2_Unknown = 23235;
         public const long SwiftMoaFeather = 23239;
         public const long WeaponStow = 23285;
-        public const long MushroomKingsBlessing = 23488;
         public const long Reflection2 = 24014;
         public const long SigilOfWater = 24241;
         public const long Critical = 24278;
@@ -1238,6 +1237,7 @@
         public const long NarcolepsySkill = 34515;
         public const long Halitosis = 34516;
         public const long BloodShield = 34518;
+        public const long MushroomKingsBlessingBuff = 34523;
         public const long HeatWave = 34526;
         public const long ToxicCloud2 = 34537;
         public const long Thunder = 34543;
@@ -1901,6 +1901,7 @@
         public const long UnstableArtifact = 49123;
         public const long EchosPickup = 49125;
         public const long BowlOfPoultrySatay = 49296;
+        public const long MushroomKingsBlessing = 46970;
         public const long PlateOfBeefRendang = 49686;
         public const long Enraged1_100 = 50070;
         public const long AvocadoSmoothie = 50091;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1801,6 +1801,7 @@
         public const long CorsairSharpeningStone = 46925;
         public const long FracturedSpirit = 46950;
         public const long SuperiorSigilOfTheStars = 46953;
+        public const long MushroomKingsBlessing = 46970;
         public const long AchievementEligibilityNecroDancer = 46994;
         public const long Glaciate = 47022;
         public const long Flare = 47074;
@@ -1901,7 +1902,6 @@
         public const long UnstableArtifact = 49123;
         public const long EchosPickup = 49125;
         public const long BowlOfPoultrySatay = 49296;
-        public const long MushroomKingsBlessing = 46970;
         public const long PlateOfBeefRendang = 49686;
         public const long Enraged1_100 = 50070;
         public const long AvocadoSmoothie = 50091;


### PR DESCRIPTION
This updates the invisible buff id used to determinte casts of [Mushroom King's Blessing](https://wiki.guildwars2.com/wiki/Mushroom_King%27s_Blessing) in the Special Forces Training Area. Out of the 4 invisible buffs applied it uses the one that seems to be responsible for granting the skill recharge reduction.

It also adds name & icon overrides for the skill.

Edit: ~~for clarification, the current id is not working as its different from all 4 buffs applied.~~ Because skill id and buff id were mixed up.