### PR TITLE
Siax encounter improvements

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
+using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -98,6 +99,44 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
             }
             return phases;
+        }
+        
+        static readonly List<(string, float, float)> EchoLocations = new List<(string, float, float)> {
+            ("N", 1870.630f, -2205.379f),
+            ("E", 2500.260f, -3288.280f),
+            ("S", 1572.040f, -3992.580f),
+            ("W", 907.199f, -2976.850f),
+            ("NW", 1036.980f, -2237.050f),
+            ("NE", 2556.450f, -2628.590f),
+            ("SE", 2293.149f, -3912.510f),
+            ("SW", 891.370f, -3722.450f),
+        };
+
+        internal override void EIEvtcParse(ulong gw2Build, FightData fightData, AgentData agentData, List<CombatItem> combatData, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)
+        {
+            base.EIEvtcParse(gw2Build, fightData, agentData, combatData, extensions);
+            foreach (AbstractSingleActor target in Targets)
+            {
+                if (target.IsSpecies(ArcDPSEnums.TargetID.Siax))
+                {
+                    target.OverrideName("Siax the Corrupted");
+                }
+                else if (target.IsSpecies(ArcDPSEnums.TrashID.EchoOfTheUnclean))
+                {
+                    CombatItem position = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target.AgentItem) && x.IsStateChange == ArcDPSEnums.StateChange.Position);
+                    if (position != null)
+                    {
+                        (float x, float y, _) = AbstractMovementEvent.UnpackMovementData(position.DstAgent, 0);
+                        foreach ((string nameAddition, float expectedX, float expectedY) in EchoLocations)
+                        {
+                            if ((Math.Abs(x - expectedX) < 10 && Math.Abs(y - expectedY) < 10))
+                            {
+                                target.OverrideName(target.Character + " " + nameAddition);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)


### PR DESCRIPTION
Improvements to the Siax encounter. Currently this:
- Adjusts the target name to be "Siax the Corrupted" rather than "Nightmare Oratuss"
- Adds an abbreviation for the location (N for north, E for east etc.) to "Echo of the Unclean" target names

I am not sure whether the name change for the boss itself could lead to any problems?