### PR TITLE
Target name improvements

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
@@ -182,5 +182,21 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
             return false;
         }
+
+        internal static void SuffixNameBasedOnInitialPosition(AbstractSingleActor target, IReadOnlyList<CombatItem> combatData, IReadOnlyCollection<(string, float, float)> positionData, float maxDiff = 10)
+        {
+            CombatItem position = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target.AgentItem) && x.IsStateChange == ArcDPSEnums.StateChange.Position);
+            if (position != null)
+            {
+                (float x, float y, _) = AbstractMovementEvent.UnpackMovementData(position.DstAgent, 0);
+                foreach ((string name, float expectedX, float expectedY) in positionData)
+                {
+                    if ((Math.Abs(x - expectedX) <= maxDiff && Math.Abs(y - expectedY) <= maxDiff))
+                    {
+                        target.OverrideName(target.Character + " " + name);
+                    }
+                }
+            }
+        }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
@@ -183,20 +183,22 @@ namespace GW2EIEvtcParser.EncounterLogic
             return false;
         }
 
-        internal static void SuffixNameBasedOnInitialPosition(AbstractSingleActor target, IReadOnlyList<CombatItem> combatData, IReadOnlyCollection<(string, float, float)> positionData, float maxDiff = 10)
+        internal static string AddNameSuffixBasedOnInitialPosition(AbstractSingleActor target, IReadOnlyList<CombatItem> combatData, IReadOnlyCollection<(string, float, float)> positionData, float maxDiff = 10)
         {
             CombatItem position = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target.AgentItem) && x.IsStateChange == ArcDPSEnums.StateChange.Position);
             if (position != null)
             {
                 (float x, float y, _) = AbstractMovementEvent.UnpackMovementData(position.DstAgent, 0);
-                foreach ((string name, float expectedX, float expectedY) in positionData)
+                foreach ((string suffix, float expectedX, float expectedY) in positionData)
                 {
                     if ((Math.Abs(x - expectedX) <= maxDiff && Math.Abs(y - expectedY) <= maxDiff))
                     {
-                        target.OverrideName(target.Character + " " + name);
+                        target.OverrideName(target.Character + " " + suffix);
+                        return suffix;
                     }
                 }
             }
+            return null;
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
+using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -98,6 +99,44 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
             }
             return phases;
+        }
+        
+        static readonly List<(string, float, float)> EchoLocations = new List<(string, float, float)> {
+            ("N", 1870.630f, -2205.379f),
+            ("E", 2500.260f, -3288.280f),
+            ("S", 1572.040f, -3992.580f),
+            ("W", 907.199f, -2976.850f),
+            ("NW", 1036.980f, -2237.050f),
+            ("NE", 2556.450f, -2628.590f),
+            ("SE", 2293.149f, -3912.510f),
+            ("SW", 891.370f, -3722.450f),
+        };
+
+        internal override void EIEvtcParse(ulong gw2Build, FightData fightData, AgentData agentData, List<CombatItem> combatData, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)
+        {
+            base.EIEvtcParse(gw2Build, fightData, agentData, combatData, extensions);
+            foreach (AbstractSingleActor target in Targets)
+            {
+                if (target.IsSpecies(ArcDPSEnums.TargetID.Siax))
+                {
+                    target.OverrideName("Siax the Corrupted");
+                }
+                else if (target.IsSpecies(ArcDPSEnums.TrashID.EchoOfTheUnclean))
+                {
+                    CombatItem position = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target.AgentItem) && x.IsStateChange == ArcDPSEnums.StateChange.Position);
+                    if (position != null)
+                    {
+                        (float x, float y, _) = AbstractMovementEvent.UnpackMovementData(position.DstAgent, 0);
+                        foreach ((string nameAddition, float expectedX, float expectedY) in EchoLocations)
+                        {
+                            if ((Math.Abs(x - expectedX) < 10 && Math.Abs(y - expectedY) < 10))
+                            {
+                                target.OverrideName(target.Character + " " + nameAddition);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -123,7 +123,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
                 else if (target.IsSpecies(ArcDPSEnums.TrashID.EchoOfTheUnclean))
                 {
-                    SuffixNameBasedOnInitialPosition(target, combatData, EchoLocations);
+                    AddNameSuffixBasedOnInitialPosition(target, combatData, EchoLocations);
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -123,18 +123,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
                 else if (target.IsSpecies(ArcDPSEnums.TrashID.EchoOfTheUnclean))
                 {
-                    CombatItem position = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target.AgentItem) && x.IsStateChange == ArcDPSEnums.StateChange.Position);
-                    if (position != null)
-                    {
-                        (float x, float y, _) = AbstractMovementEvent.UnpackMovementData(position.DstAgent, 0);
-                        foreach ((string nameAddition, float expectedX, float expectedY) in EchoLocations)
-                        {
-                            if ((Math.Abs(x - expectedX) < 10 && Math.Abs(y - expectedY) < 10))
-                            {
-                                target.OverrideName(target.Character + " " + nameAddition);
-                            }
-                        }
-                    }
+                    SuffixNameBasedOnInitialPosition(target, combatData, EchoLocations);
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -90,22 +90,12 @@ namespace GW2EIEvtcParser.EncounterLogic
                 PhaseData phase = phases[i];
                 if (i % 2 == 0)
                 {
-                    int split = i / 2;
-                    phase.Name = "Split " + split;
+                    phase.Name = "Split " + (i) / 2;
                     var ids = new List<int>
                     {
                        (int)ArcDPSEnums.TrashID.CloneArtsariiv,
                     };
                     AddTargetsToPhaseAndFit(phase, ids, log);
-
-                    // deduplicate clone names
-                    foreach (NPC target in phase.Targets)
-                    {
-                        if (target.IsSpecies(ArcDPSEnums.TrashID.CloneArtsariiv))
-                        {
-                            target.OverrideName(target.Character + " " + split);
-                        }
-                    }
                 }
                 else
                 {
@@ -159,11 +149,21 @@ namespace GW2EIEvtcParser.EncounterLogic
                     trashMob.OverrideName("Big " + trashMob.Character);
                 }
             }
+
+            Dictionary<string, int> nameCount = new Dictionary<string, int> {
+                    { "M", 1 }, { "NE", 1 }, { "NW", 1 }, { "SW", 1 }, { "SE", 1 }, // both split clones start at 1
+                    { "N", 2 }, { "E", 2 }, { "S", 2 }, { "W", 2 }, // second split clones start at 2
+            };
             foreach (NPC target in _targets)
             {
                 if (target.IsSpecies(ArcDPSEnums.TrashID.CloneArtsariiv))
                 {
-                    SuffixNameBasedOnInitialPosition(target, combatData, CloneLocations);
+                    string suffix = AddNameSuffixBasedOnInitialPosition(target, combatData, CloneLocations);
+                    if (suffix != null && nameCount.ContainsKey(suffix))
+                    {
+                        // deduplicate name
+                        target.OverrideName(target.Character + " " + (nameCount[suffix]++));
+                    }
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -106,6 +106,18 @@ namespace GW2EIEvtcParser.EncounterLogic
             return phases;
         }
 
+        static readonly List<(string, float, float)> CloneLocations = new List<(string, float, float)> {
+            ("M", 10357.898f, 1466.580f),
+            ("NE", 11431.998f, 2529.760f),
+            ("NW", 9286.878f, 2512.429f),
+            ("SW", 9284.729f, 392.916f),
+            ("SE", 11422.698f, 401.501f),
+            ("N", 10369.498f, 2529.010f),
+            ("E", 11_432.598f, 1460.400f),
+            ("S", 10_388.698f, 390.419f),
+            ("W", 9295.668f, 1450.060f),
+        };
+
         internal override void EIEvtcParse(ulong gw2Build, FightData fightData, AgentData agentData, List<CombatItem> combatData, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)
         {
             var artsariivs = new List<AgentItem>(agentData.GetNPCsByID(ArcDPSEnums.TargetID.Artsariiv));
@@ -122,7 +134,6 @@ namespace GW2EIEvtcParser.EncounterLogic
                 agentData.Refresh();
             }
             base.EIEvtcParse(gw2Build, fightData, agentData, combatData, extensions);
-            int count = 0;
             foreach (NPC trashMob in _trashMobs)
             {
                 if (trashMob.IsSpecies(ArcDPSEnums.TrashID.SmallArtsariiv))
@@ -142,7 +153,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 if (target.IsSpecies(ArcDPSEnums.TrashID.CloneArtsariiv))
                 {
-                    target.OverrideName("Clone " + target.Character + " " + (++count));
+                    SuffixNameBasedOnInitialPosition(target, combatData, CloneLocations);
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -90,12 +90,22 @@ namespace GW2EIEvtcParser.EncounterLogic
                 PhaseData phase = phases[i];
                 if (i % 2 == 0)
                 {
-                    phase.Name = "Split " + (i) / 2;
+                    int split = i / 2;
+                    phase.Name = "Split " + split;
                     var ids = new List<int>
                     {
                        (int)ArcDPSEnums.TrashID.CloneArtsariiv,
                     };
                     AddTargetsToPhaseAndFit(phase, ids, log);
+
+                    // deduplicate clone names
+                    foreach (NPC target in phase.Targets)
+                    {
+                        if (target.IsSpecies(ArcDPSEnums.TrashID.CloneArtsariiv))
+                        {
+                            target.OverrideName(target.Character + " " + split);
+                        }
+                    }
                 }
                 else
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -98,15 +98,21 @@ namespace GW2EIEvtcParser.EncounterLogic
                 throw new MissingKeyActorsException("Skorvald not found");
             }
             skorvald.OverrideName("Skorvald");
-            int count = 0;
             foreach (NPC target in _targets)
             {
-                if (target.IsSpecies(ArcDPSEnums.TrashID.FluxAnomaly1) ||
-                    target.IsSpecies(ArcDPSEnums.TrashID.FluxAnomaly2) ||
-                    target.IsSpecies(ArcDPSEnums.TrashID.FluxAnomaly3) ||
-                    target.IsSpecies(ArcDPSEnums.TrashID.FluxAnomaly4))
-                {
-                    target.OverrideName(target.Character + " " + (++count));
+                switch (target.ID) {
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly1:
+                        target.OverrideName(target.Character + " 1");
+                        break;
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly2:
+                        target.OverrideName(target.Character + " 2");
+                        break;
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly3:
+                        target.OverrideName(target.Character + " 3");
+                        break;
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly4:
+                        target.OverrideName(target.Character + " 4");
+                        break;
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -79,26 +79,6 @@ namespace GW2EIEvtcParser.EncounterLogic
                         (int)ArcDPSEnums.TrashID.FluxAnomaly4,
                     };
                     AddTargetsToPhaseAndFit(phase, ids, log);
-
-                    // add anomaly numbers
-                    int offset = 4 * (i / 2 - 1);
-                    foreach (NPC target in phase.Targets)
-                    {
-                        switch (target.ID) {
-                            case (int) ArcDPSEnums.TrashID.FluxAnomaly1:
-                                target.OverrideName(target.Character + " " + (1 + offset));
-                                break;
-                            case (int) ArcDPSEnums.TrashID.FluxAnomaly2:
-                                target.OverrideName(target.Character + " " + (2 + offset));
-                                break;
-                            case (int) ArcDPSEnums.TrashID.FluxAnomaly3:
-                                target.OverrideName(target.Character + " " + (3 + offset));
-                                break;
-                            case (int) ArcDPSEnums.TrashID.FluxAnomaly4:
-                                target.OverrideName(target.Character + " " + (4 + offset));
-                                break;
-                        } 
-                    }
                 }
                 else
                 {
@@ -118,6 +98,25 @@ namespace GW2EIEvtcParser.EncounterLogic
                 throw new MissingKeyActorsException("Skorvald not found");
             }
             skorvald.OverrideName("Skorvald");
+            
+            int[] nameCount = new [] { 0, 0, 0, 0 };
+            foreach (NPC target in _targets)
+            {
+                switch (target.ID) {
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly1:
+                        target.OverrideName(target.Character + " " + (1 + 4 * nameCount[0]++));
+                        break;
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly2:
+                        target.OverrideName(target.Character + " " + (2 + 4 * nameCount[1]++));
+                        break;
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly3:
+                        target.OverrideName(target.Character + " " + (3 + 4 * nameCount[2]++));
+                        break;
+                    case (int) ArcDPSEnums.TrashID.FluxAnomaly4:
+                        target.OverrideName(target.Character + " " + (4 + 4 * nameCount[3]++));
+                        break;
+                }
+            }
         }
 
         internal override long GetFightOffset(FightData fightData, AgentData agentData, List<CombatItem> combatData)

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -73,12 +73,32 @@ namespace GW2EIEvtcParser.EncounterLogic
                     phase.Name = "Split " + (i) / 2;
                     var ids = new List<int>
                     {
-                        (int)ArcDPSEnums.TrashID.FluxAnomaly4,
-                        (int)ArcDPSEnums.TrashID.FluxAnomaly3,
-                        (int)ArcDPSEnums.TrashID.FluxAnomaly2,
                         (int)ArcDPSEnums.TrashID.FluxAnomaly1,
+                        (int)ArcDPSEnums.TrashID.FluxAnomaly2,
+                        (int)ArcDPSEnums.TrashID.FluxAnomaly3,
+                        (int)ArcDPSEnums.TrashID.FluxAnomaly4,
                     };
                     AddTargetsToPhaseAndFit(phase, ids, log);
+
+                    // add anomaly numbers
+                    int offset = 4 * (i / 2 - 1);
+                    foreach (NPC target in phase.Targets)
+                    {
+                        switch (target.ID) {
+                            case (int) ArcDPSEnums.TrashID.FluxAnomaly1:
+                                target.OverrideName(target.Character + " " + (1 + offset));
+                                break;
+                            case (int) ArcDPSEnums.TrashID.FluxAnomaly2:
+                                target.OverrideName(target.Character + " " + (2 + offset));
+                                break;
+                            case (int) ArcDPSEnums.TrashID.FluxAnomaly3:
+                                target.OverrideName(target.Character + " " + (3 + offset));
+                                break;
+                            case (int) ArcDPSEnums.TrashID.FluxAnomaly4:
+                                target.OverrideName(target.Character + " " + (4 + offset));
+                                break;
+                        } 
+                    }
                 }
                 else
                 {
@@ -98,23 +118,6 @@ namespace GW2EIEvtcParser.EncounterLogic
                 throw new MissingKeyActorsException("Skorvald not found");
             }
             skorvald.OverrideName("Skorvald");
-            foreach (NPC target in _targets)
-            {
-                switch (target.ID) {
-                    case (int) ArcDPSEnums.TrashID.FluxAnomaly1:
-                        target.OverrideName(target.Character + " 1");
-                        break;
-                    case (int) ArcDPSEnums.TrashID.FluxAnomaly2:
-                        target.OverrideName(target.Character + " 2");
-                        break;
-                    case (int) ArcDPSEnums.TrashID.FluxAnomaly3:
-                        target.OverrideName(target.Character + " 3");
-                        break;
-                    case (int) ArcDPSEnums.TrashID.FluxAnomaly4:
-                        target.OverrideName(target.Character + " 4");
-                        break;
-                }
-            }
         }
 
         internal override long GetFightOffset(FightData fightData, AgentData agentData, List<CombatItem> combatData)


### PR DESCRIPTION
Improvements to target names, making sure their numbers makes sense or using location suffixes (N for north, E for east etc.).

- Siax: Adjusts the target name to be "Siax the Corrupted" rather than "Nightmare Oratuss"
- Siax: Adds location suffix to "Echo of the Unclean" split targets
- Skorvald: Adjusts the Anomaly numbers to be in the order you (usually) kill them
- Artsariiv: Adds location suffix to Clone split targets