### PR TITLE
Add Skorvald normal mode Anomalies

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -77,6 +77,10 @@ namespace GW2EIEvtcParser.EncounterLogic
                         (int)ArcDPSEnums.TrashID.FluxAnomaly2,
                         (int)ArcDPSEnums.TrashID.FluxAnomaly3,
                         (int)ArcDPSEnums.TrashID.FluxAnomaly4,
+                        (int)ArcDPSEnums.TrashID.FluxAnomalyCM1,
+                        (int)ArcDPSEnums.TrashID.FluxAnomalyCM2,
+                        (int)ArcDPSEnums.TrashID.FluxAnomalyCM3,
+                        (int)ArcDPSEnums.TrashID.FluxAnomalyCM4,
                     };
                     AddTargetsToPhaseAndFit(phase, ids, log);
                 }
@@ -104,15 +108,19 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 switch (target.ID) {
                     case (int) ArcDPSEnums.TrashID.FluxAnomaly1:
+                    case (int) ArcDPSEnums.TrashID.FluxAnomalyCM1:
                         target.OverrideName(target.Character + " " + (1 + 4 * nameCount[0]++));
                         break;
                     case (int) ArcDPSEnums.TrashID.FluxAnomaly2:
+                    case (int) ArcDPSEnums.TrashID.FluxAnomalyCM2:
                         target.OverrideName(target.Character + " " + (2 + 4 * nameCount[1]++));
                         break;
                     case (int) ArcDPSEnums.TrashID.FluxAnomaly3:
+                    case (int) ArcDPSEnums.TrashID.FluxAnomalyCM3:
                         target.OverrideName(target.Character + " " + (3 + 4 * nameCount[2]++));
                         break;
                     case (int) ArcDPSEnums.TrashID.FluxAnomaly4:
+                    case (int) ArcDPSEnums.TrashID.FluxAnomalyCM4:
                         target.OverrideName(target.Character + " " + (4 + 4 * nameCount[3]++));
                         break;
                 }
@@ -178,10 +186,14 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<int>()
             {
                 (int)ArcDPSEnums.TargetID.Skorvald,
-                (int)ArcDPSEnums.TrashID.FluxAnomaly4,
-                (int)ArcDPSEnums.TrashID.FluxAnomaly3,
-                (int)ArcDPSEnums.TrashID.FluxAnomaly2,
                 (int)ArcDPSEnums.TrashID.FluxAnomaly1,
+                (int)ArcDPSEnums.TrashID.FluxAnomaly2,
+                (int)ArcDPSEnums.TrashID.FluxAnomaly3,
+                (int)ArcDPSEnums.TrashID.FluxAnomaly4,
+                (int)ArcDPSEnums.TrashID.FluxAnomalyCM1,
+                (int)ArcDPSEnums.TrashID.FluxAnomalyCM2,
+                (int)ArcDPSEnums.TrashID.FluxAnomalyCM3,
+                (int)ArcDPSEnums.TrashID.FluxAnomalyCM4,
             };
         }
 
@@ -414,10 +426,10 @@ namespace GW2EIEvtcParser.EncounterLogic
                         AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation + angle, translation, cascadeCount);
                     }
                     break;
-                case (int)ArcDPSEnums.TrashID.FluxAnomaly1:
-                case (int)ArcDPSEnums.TrashID.FluxAnomaly2:
-                case (int)ArcDPSEnums.TrashID.FluxAnomaly3:
-                case (int)ArcDPSEnums.TrashID.FluxAnomaly4:
+                case (int)ArcDPSEnums.TrashID.FluxAnomalyCM1:
+                case (int)ArcDPSEnums.TrashID.FluxAnomalyCM2:
+                case (int)ArcDPSEnums.TrashID.FluxAnomalyCM3:
+                case (int)ArcDPSEnums.TrashID.FluxAnomalyCM4:
                     // Solar Stomp
                     var solarStomp = casts.Where(x => x.SkillId == SolarStomp).ToList();
                     foreach (AbstractCastEvent c in solarStomp)

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -807,10 +807,14 @@ namespace GW2EIEvtcParser
             NightmareHallucination2 = 17033, // (small adds, last phase)
             NightmareAltar = 35791,
             // Skorvald
-            FluxAnomaly4 = 17673,
-            FluxAnomaly3 = 17851,
-            FluxAnomaly2 = 17770,
-            FluxAnomaly1 = 17599,
+            FluxAnomaly1 = 17578,
+            FluxAnomaly2 = 17929,
+            FluxAnomaly3 = 17695,
+            FluxAnomaly4 = 17651,
+            FluxAnomalyCM1 = 17599,
+            FluxAnomalyCM2 = 17770,
+            FluxAnomalyCM3 = 17851,
+            FluxAnomalyCM4 = 17673,
             SolarBloom = 17732,
             // Artsariiv
             TemporalAnomaly = 17870,

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -830,6 +830,10 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.FluxAnomaly2, TrashFluxAnomaly },
             { ArcDPSEnums.TrashID.FluxAnomaly3, TrashFluxAnomaly },
             { ArcDPSEnums.TrashID.FluxAnomaly4, TrashFluxAnomaly },
+            { ArcDPSEnums.TrashID.FluxAnomalyCM1, TrashFluxAnomaly },
+            { ArcDPSEnums.TrashID.FluxAnomalyCM2, TrashFluxAnomaly },
+            { ArcDPSEnums.TrashID.FluxAnomalyCM3, TrashFluxAnomaly },
+            { ArcDPSEnums.TrashID.FluxAnomalyCM4, TrashFluxAnomaly },
         };
 
         /// <summary>


### PR DESCRIPTION
Adds ids for Flux Anomalies in normal mode Skorvald. This allows normal mode Skorvald to also display split phases.