### PR TITLE
Completed mesmer clones and added consumable summons

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
@@ -1503,6 +1503,10 @@
         internal const string HealthfulRejuvenation = "https://wiki.guildwars2.com/images/1/1c/Healthful_Rejuvenation.png";
         internal const string DamageBonus5 = "https://wiki.guildwars2.com/images/6/66/Damage_Bonus_%28five_percent%29.png";
         internal const string SwiftMoaFeather = "https://wiki.guildwars2.com/images/f/f0/Swift_Moa_Feather.png";
+        internal const string OgrePetWhistle = "https://wiki.guildwars2.com/images/d/de/Ogre_Pet_Whistle.png";
+        internal const string FireElementalPowder = "https://wiki.guildwars2.com/images/9/9c/Pile_of_Cinnamon_and_Sugar.png";
+        internal const string SunspearParagonSupport = "https://wiki.guildwars2.com/images/1/17/Sunspear_Paragon_Support.png";
+        internal const string RavenSpiritShadow = "https://wiki.guildwars2.com/images/d/de/Raven_Spirit_Shadow.png";
         // Others
         internal const string NourishmentBirthdayBlaster = "https://wiki.guildwars2.com/images/e/ec/Nourishment_%28Birthday_Blaster%29.png";
         internal const string SiegeAmmoAvailable = "https://wiki.guildwars2.com/images/e/e3/Siege_Ammo_Available.png";

--- a/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
@@ -1496,6 +1496,7 @@
         internal const string GlyphOfElementalPowerWater = "https://wiki.guildwars2.com/images/b/bf/Glyph_of_Elemental_Power_%28water%29.png";
         internal const string GlyphOfElementalPowerAir = "https://wiki.guildwars2.com/images/c/cb/Glyph_of_Elemental_Power_%28air%29.png";
         internal const string GlyphOfElementalPowerEarth = "https://wiki.guildwars2.com/images/0/0a/Glyph_of_Elemental_Power_%28earth%29.png";
+        internal const string FreezingGust = "https://wiki.guildwars2.com/images/4/48/Freezing_Gust.png";
         // Consumables
         internal const string ReinforcedArmor = "https://wiki.guildwars2.com/images/8/83/Reinforced_Armor.png";
         internal const string SpeedBonus15 = "https://wiki.guildwars2.com/images/d/d7/Speed_Bonus_%28fifteen_percent%29.png";

--- a/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
@@ -117,6 +117,11 @@ namespace GW2EIEvtcParser.EIData
             // Consumable Portal
             new Buff("Portal Weaving (Xera/Watchwork)", PortalWeavingXeraWatchwork, Source.Common, BuffClassification.Other, BuffImages.PortalEnter),
             new Buff("Portal Uses (Xera/Watchwork)", PortalUsesXeraWatchwork, Source.Common, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.PortalEnter),
+            // Consumable Summons
+            new Buff("Ogre Pet Whistle", OgrePetWhistleEffect, Source.Common, BuffClassification.Other, BuffImages.OgrePetWhistle),
+            new Buff("Fire Elemental Powder", FireElementalPowderEffect, Source.Common, BuffClassification.Other, BuffImages.FireElementalPowder),
+            new Buff("Sunspear Paragon Support", SunspearParagonSupportEffect, Source.Common, BuffClassification.Other, BuffImages.SunspearParagonSupport),
+            new Buff("Raven Spirit Shadow", RavenSpiritShadowEffect, Source.Common, BuffClassification.Other, BuffImages.RavenSpiritShadow),
         };
 
         internal static readonly List<Buff> Gear = new List<Buff>

--- a/GW2EIEvtcParser/EIData/Buffs/WvWBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/WvWBuffs.cs
@@ -65,6 +65,7 @@ namespace GW2EIEvtcParser.EIData.Buffs
             new Buff("Commander's Presence", CommandersPresence, Source.Common, BuffClassification.Support, BuffImages.MightyBlow),
             new Buff("Inferno Hound", InfernoHound, Source.Common, BuffClassification.Other, BuffImages.HoundsOfBalthazar),
             new Buff("Smoke Form", SmokeForm, Source.Common, BuffClassification.Other, BuffImages.InkShot),
+            new Buff("Chilling Fog", ChillingFogEffect, Source.Common, BuffClassification.Debuff, BuffImages.FreezingGust),
             // Edge of the Mists
             new Buff("Marked (Mists Arena)", MarkedMistsArena, Source.Common, BuffClassification.Debuff, BuffImages.FireTrebuchet),
             new Buff("Marked (Red Sentry Turret)", MarkedSentryTurretRed, Source.Common, BuffClassification.Debuff, BuffImages.FireTrebuchet),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -211,26 +211,29 @@ namespace GW2EIEvtcParser.EIData
 
         private static readonly HashSet<long> _cloneIDs = new HashSet<long>()
         {
-            (int)MinionID.CloneSpear,
-            (int)MinionID.CloneUnknown1,
-            (int)MinionID.CloneUnknown2,
-            (int)MinionID.CloneUnknown3,
+            (int)MinionID.CloneSword,
+            (int)MinionID.CloneScepter,
+            (int)MinionID.CloneAxe,
             (int)MinionID.CloneGreatsword,
             (int)MinionID.CloneStaff,
+            (int)MinionID.CloneTrident,
+            (int)MinionID.CloneSpear,
             (int)MinionID.CloneDownstate,
-            (int)MinionID.CloneSwordPistol,
+            (int)MinionID.CloneUnknown,
             (int)MinionID.CloneSwordTorch,
-            (int)MinionID.CloneScepterTorch,
             (int)MinionID.CloneSwordFocus,
-            (int)MinionID.CloneSwordTorchPhantasm,
-            (int)MinionID.CloneSwordFocusPhantasm,
             (int)MinionID.CloneSwordSword,
             (int)MinionID.CloneSwordShield,
+            (int)MinionID.CloneSwordPistol,
+            (int)MinionID.CloneIllusionaryLeap,
+            (int)MinionID.CloneIllusionaryLeapFocus,
+            (int)MinionID.CloneIllusionaryLeapShield,
+            (int)MinionID.CloneIllusionaryLeapSword,
+            (int)MinionID.CloneIllusionaryLeapPistol,
+            (int)MinionID.CloneIllusionaryLeapTorch,
+            (int)MinionID.CloneScepterTorch,
             (int)MinionID.CloneScepterShield,
-            (int)MinionID.CloneSwordPistolPhantasm,
             (int)MinionID.CloneScepterPistol,
-            (int)MinionID.CloneSwordShieldPhantasm,
-            (int)MinionID.CloneSwordSwordPhantasm,
             (int)MinionID.CloneScepterFocus,
             (int)MinionID.CloneScepterSword,
             (int)MinionID.CloneAxeTorch,
@@ -252,21 +255,27 @@ namespace GW2EIEvtcParser.EIData
                 case (int)MinionID.CloneStaff:
                     minion.OverrideName("Staff " + minion.Name);
                     break;
+                case (int)MinionID.CloneTrident:
+                    minion.OverrideName("Trident " + minion.Name);
+                    break;
                 case (int)MinionID.CloneDownstate:
                     minion.OverrideName("Downstate " + minion.Name);
                     break;
+                case (int)MinionID.CloneSword:
                 case (int)MinionID.CloneSwordPistol:
                 case (int)MinionID.CloneSwordTorch:
                 case (int)MinionID.CloneSwordFocus:
-                case (int)MinionID.CloneSwordTorchPhantasm:
-                case (int)MinionID.CloneSwordFocusPhantasm:
                 case (int)MinionID.CloneSwordSword:
                 case (int)MinionID.CloneSwordShield:
-                case (int)MinionID.CloneSwordPistolPhantasm:
-                case (int)MinionID.CloneSwordShieldPhantasm:
-                case (int)MinionID.CloneSwordSwordPhantasm:
+                case (int)MinionID.CloneIllusionaryLeap:
+                case (int)MinionID.CloneIllusionaryLeapFocus:
+                case (int)MinionID.CloneIllusionaryLeapShield:
+                case (int)MinionID.CloneIllusionaryLeapSword:
+                case (int)MinionID.CloneIllusionaryLeapPistol:
+                case (int)MinionID.CloneIllusionaryLeapTorch:
                     minion.OverrideName("Sword " + minion.Name);
                     break;
+                case (int)MinionID.CloneScepter:
                 case (int)MinionID.CloneScepterTorch:
                 case (int)MinionID.CloneScepterShield:
                 case (int)MinionID.CloneScepterPistol:
@@ -274,6 +283,7 @@ namespace GW2EIEvtcParser.EIData
                 case (int)MinionID.CloneScepterSword:
                     minion.OverrideName("Scepter " + minion.Name);
                     break;
+                case (int)MinionID.CloneAxe:
                 case (int)MinionID.CloneAxeTorch:
                 case (int)MinionID.CloneAxePistol:
                 case (int)MinionID.CloneAxeSword:
@@ -310,6 +320,8 @@ namespace GW2EIEvtcParser.EIData
             (int)MinionID.IllusionaryDisenchanter,
             (int)MinionID.IllusionaryRogue,
             (int)MinionID.IllusionaryDefender,
+            (int)MinionID.IllusionaryMariner,
+            (int)MinionID.IllusionaryWhaler,
         };
 
         internal static bool IsKnownMinionID(long id)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -302,6 +302,7 @@ namespace GW2EIEvtcParser.EIData
         {
             // Racial Summons
             (int)ArcDPSEnums.MinionID.HoundOfBalthazar,
+            (int)ArcDPSEnums.MinionID.SnowWurm,
             (int)ArcDPSEnums.MinionID.DruidSpirit,
             (int)ArcDPSEnums.MinionID.SylvanHound,
             (int)ArcDPSEnums.MinionID.IronLegionSoldier,
@@ -310,6 +311,8 @@ namespace GW2EIEvtcParser.EIData
             (int)ArcDPSEnums.MinionID.BloodLegionMarksman,
             (int)ArcDPSEnums.MinionID.AshLegionSoldier,
             (int)ArcDPSEnums.MinionID.AshLegionMarksman,
+            (int)ArcDPSEnums.MinionID.STAD007,
+            (int)ArcDPSEnums.MinionID.STA7012,
             // GW2 Digital Deluxe
             (int)ArcDPSEnums.MinionID.MistfireWolf,
             // Rune Summons

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -295,12 +295,34 @@ namespace GW2EIEvtcParser.EIData
             return _canSummonClones.Contains(spec);
         }
 
-        private static HashSet<long> CommonMinions = new HashSet<long>()
+        /// <summary>
+        /// Minions that aren't profession-specific bound.
+        /// </summary>
+        private static readonly HashSet<long> CommonMinions = new HashSet<long>()
         {
+            // Racial Summons
+            (int)ArcDPSEnums.MinionID.HoundOfBalthazar,
+            (int)ArcDPSEnums.MinionID.DruidSpirit,
+            (int)ArcDPSEnums.MinionID.SylvanHound,
+            (int)ArcDPSEnums.MinionID.IronLegionSoldier,
+            (int)ArcDPSEnums.MinionID.IronLegionMarksman,
+            (int)ArcDPSEnums.MinionID.BloodLegionSoldier,
+            (int)ArcDPSEnums.MinionID.BloodLegionMarksman,
+            (int)ArcDPSEnums.MinionID.AshLegionSoldier,
+            (int)ArcDPSEnums.MinionID.AshLegionMarksman,
+            // GW2 Digital Deluxe
+            (int)ArcDPSEnums.MinionID.MistfireWolf,
+            // Rune Summons
             (int)ArcDPSEnums.MinionID.RuneJaggedHorror,
             (int)ArcDPSEnums.MinionID.RuneRockDog,
             (int)ArcDPSEnums.MinionID.RuneMarkIGolem,
             (int)ArcDPSEnums.MinionID.RuneTropicalBird,
+            // Consumables with summons
+            (int)ArcDPSEnums.MinionID.Ember,
+            (int)ArcDPSEnums.MinionID.HawkeyeGriffon,
+            (int)ArcDPSEnums.MinionID.SousChef,
+            (int)ArcDPSEnums.MinionID.SunspearParagonSupport,
+            (int)ArcDPSEnums.MinionID.RavenSpiritShadow,
         };
 
         internal static bool IsKnownMinionID(long id)

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -289,9 +289,9 @@ namespace GW2EIEvtcParser.ParsedData
                         { LightningStrikeSigil, GW2Builds.StartOfLife }, 
                         { FlameBlastSigil, GW2Builds.StartOfLife },
                         { FireAttunementSkill, GW2Builds.December2018Balance }, 
-                        { Mug, GW2Builds.StartOfLife }, // Mug
-                        { PulmonaryImpactSkill, 54485 }, // Pulmonary Impact
-                        { 52370, GW2Builds.StartOfLife },
+                        { Mug, GW2Builds.StartOfLife },
+                        { PulmonaryImpactSkill, GW2Builds.HoTRelease },
+                        { ConjuredSlashPlayer, GW2Builds.StartOfLife },
                         { LightningJolt, GW2Builds.StartOfLife },
                         { Sunspot, GW2Builds.December2018Balance },
                         { EarthenBlast, GW2Builds.December2018Balance },

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -1044,6 +1044,7 @@ namespace GW2EIEvtcParser
         {
             // Racial Summons
             HoundOfBalthazar = 6394,
+            SnowWurm = 6445,
             DruidSpirit = 6475,
             SylvanHound = 6476,
             IronLegionSoldier = 6509,
@@ -1052,6 +1053,8 @@ namespace GW2EIEvtcParser
             BloodLegionMarksman = 10107,
             AshLegionSoldier = 10108,
             AshLegionMarksman = 10109,
+            STAD007 = 10145,
+            STA7012 = 10146,
             // GW2 Digital Deluxe
             MistfireWolf = 9801,
             // Rune Summons

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -11,6 +11,7 @@ namespace GW2EIEvtcParser
         {
             internal const ulong StartOfLife = ulong.MinValue;
             //
+            internal const ulong HoTRelease = 54485;
             internal const ulong February2017Balance = 72781;
             internal const ulong December2017Balance = 84832;
             internal const ulong February2018Balance = 86181;
@@ -1058,7 +1059,13 @@ namespace GW2EIEvtcParser
             RuneRockDog = 8836,
             RuneMarkIGolem = 8837,
             RuneTropicalBird = 8838,
-            //
+            // Consumables with summons
+            Ember = 1454,
+            HawkeyeGriffon = 5614,
+            SousChef = 10076,
+            SunspearParagonSupport = 19643,
+            RavenSpiritShadow = 22309,
+            // Mesmer Phantasmas
             IllusionarySwordsman = 6487,
             IllusionaryBerserker = 6535,
             IllusionaryDisenchanter = 6621,
@@ -1068,36 +1075,45 @@ namespace GW2EIEvtcParser
             IllusionaryDuelist = 5758,
             IllusionaryWarlock = 6449,
             IllusionaryWarden = 7981,
+            IllusionaryMariner = 9052,
+            IllusionaryWhaler = 9057,
             IllusionaryAvenger = 15188,
-            //
-            CloneSpear = 6479,
-            CloneUnknown1 = 8106,
-            CloneUnknown2 = 8107,
-            CloneUnknown3 = 8108,
+            // Mesmer Clones
+            // - Single Weapon
+            CloneSword = 8108,
+            CloneScepter = 8109,
+            CloneAxe = 18894,
             CloneGreatsword = 8110,
             CloneStaff = 8111,
             CloneTrident = 9058,
+            CloneSpear = 6479,
             CloneDownstate = 10542,
-            CloneSwordPistol = 15003,
-            CloneSwordTorch = 15032,
+            CloneUnknown = 8107, // Possibly -> https://wiki.guildwars2.com/wiki/Clone_(Snowball_Mayhem)
+            // - Sword + Offhand
+            CloneSwordTorch = 15090,
+            CloneSwordFocus = 15114,
+            CloneSwordSword = 15233,
+            CloneSwordShield = 15199,
+            CloneSwordPistol = 15181,
+            // - Sword 3 + Offhand
+            CloneIllusionaryLeap = 8106,
+            CloneIllusionaryLeapFocus = 15084,
+            CloneIllusionaryLeapShield = 15131,
+            CloneIllusionaryLeapSword = 15117,
+            CloneIllusionaryLeapPistol = 15003,
+            CloneIllusionaryLeapTorch = 15032,
+            // - Scepter + Offhand
             CloneScepterTorch = 15044,
-            CloneSwordFocus = 15084,
-            CloneSwordTorchPhantasm = 15090,
-            CloneSwordFocusPhantasm = 15114,
-            CloneSwordSword = 15117,
-            CloneSwordShield = 15131,
             CloneScepterShield = 15156,
-            CloneSwordPistolPhantasm = 15181,
             CloneScepterPistol = 15196,
-            CloneSwordShieldPhantasm = 15199,
-            CloneSwordSwordPhantasm = 15233,
             CloneScepterFocus = 15240,
             CloneScepterSword = 15249,
+            // - Axe + Offhand
             CloneAxeTorch = 18922,
             CloneAxePistol = 18939,
             CloneAxeSword = 19134,
             CloneAxeFocus = 19257,
-            //
+            // Necromancer Minions
             BloodFiend = 1104,
             BoneFiend = 1458,
             FleshGolem = 1792,
@@ -1106,13 +1122,14 @@ namespace GW2EIEvtcParser
             BoneMinion = 1192,
             UnstableHorror = 18802,
             ShamblingHorror = 15314,
-            //
+            // Ranger Spirits
             StoneSpirit = 6370,
             SunSpirit = 6330,
             FrostSpirit = 6369,
             StormSpirit = 6371,
             WaterSpirit = 12778,
             SpiritOfNatureRenewal = 6649,
+            // Ranger Pets
             JuvenileJungleStalker = 3827,
             JuvenileKrytanDrakehound = 4425,
             JuvenileBrownBear = 4426,
@@ -1172,12 +1189,12 @@ namespace GW2EIEvtcParser
             JuvenileWhiteTiger = 24298,
             JuvenileSiegeTurtle = 24796,
             JuvenilePhoenix = 25131,
-            //
+            // Guardian Weapon Summons
             BowOfTruth = 6383,
             HammerOfWisdom = 5791,
             ShieldOfTheAvenger = 6382,
             SwordOfJustice = 6381,
-            //
+            // Thief
             Thief1 = 7580,
             Thief2 = 7581,
             Thief3 = 10090,
@@ -1230,7 +1247,7 @@ namespace GW2EIEvtcParser
             Specter8 = 25231,
             Specter9 = 25232,
             Specter10 = 25234,
-            //
+            // Elementalist Summons
             LesserAirElemental = 8711,
             LesserEarthElemental = 8712,
             LesserFireElemental = 8713,
@@ -1239,7 +1256,7 @@ namespace GW2EIEvtcParser
             EarthElemental = 6523,
             FireElemental = 6524,
             IceElemental = 6525,
-            //
+            // Scrapper Gyros
             SneakGyro = 15012,
             ShredderGyro = 15046,
             BulwarkGyro = 15134,
@@ -1247,14 +1264,14 @@ namespace GW2EIEvtcParser
             MedicGyro = 15208,
             BlastGyro = 15330,
             FunctionGyro = 15336,
-            //
+            // Revenant Summons
             ViskIcerazor = 18524,
             KusDarkrazor = 18594,
             JasRazorclaw = 18791,
             EraBreakrazor = 18806,
             OfelaSoulcleave = 19002,
             VentariTablet = ArcDPSEnums.VentariTablet,
-            //
+            // Mechanist
             JadeMech = 23549,
             //
             Unknown,

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -328,9 +328,12 @@ namespace GW2EIEvtcParser.ParserHelpers
 
         // Minion NPC Icons
         private const string MinionHoundOfBalthazar = "https://i.imgur.com/icmaNZS.png";
+        private const string MinionCallWurm = "https://i.imgur.com/vxj3C37.png";
         private const string MinionDruidSpirit = "https://i.imgur.com/Gi7okAw.png";
         private const string MinionSylvanHound = "https://i.imgur.com/rtcKv9N.png";
         private const string MinionWarband = "https://i.imgur.com/Y6n0bsV.png";
+        private const string MinionDSeries = "https://i.imgur.com/qYnWE47.png";
+        private const string Minion7Series = "https://i.imgur.com/CGHOzZI.png";
         private const string MinionMistfireWolf = "https://i.imgur.com/9hNzLjI.png";
         private const string MinionRuneJaggedHorror = "https://i.imgur.com/opMTn10.png";
         private const string MinionRuneRockDog = "https://i.imgur.com/EdNp7kY.png";
@@ -914,6 +917,7 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal static IReadOnlyDictionary<ArcDPSEnums.MinionID, string> MinionNPCIcons { get; private set; } = new Dictionary<ArcDPSEnums.MinionID, string>()
         {
             { ArcDPSEnums.MinionID.HoundOfBalthazar, MinionHoundOfBalthazar },
+            { ArcDPSEnums.MinionID.SnowWurm, MinionCallWurm },
             { ArcDPSEnums.MinionID.DruidSpirit, MinionDruidSpirit },
             { ArcDPSEnums.MinionID.SylvanHound, MinionSylvanHound },
             { ArcDPSEnums.MinionID.IronLegionSoldier, MinionWarband },
@@ -922,6 +926,8 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.MinionID.BloodLegionMarksman, MinionWarband },
             { ArcDPSEnums.MinionID.AshLegionSoldier, MinionWarband },
             { ArcDPSEnums.MinionID.AshLegionMarksman, MinionWarband },
+            { ArcDPSEnums.MinionID.STAD007, MinionDSeries },
+            { ArcDPSEnums.MinionID.STA7012, Minion7Series },
             { ArcDPSEnums.MinionID.MistfireWolf, MinionMistfireWolf },
             { ArcDPSEnums.MinionID.RuneJaggedHorror, MinionRuneJaggedHorror },
             { ArcDPSEnums.MinionID.RuneRockDog, MinionRuneRockDog },

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -347,6 +347,8 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string MinionIllusionaryWarden = "https://i.imgur.com/dId5lC2.png";
         private const string MinionIllusionaryWarlock = "https://i.imgur.com/ZRCcbBM.png";
         private const string MinionIllusionaryAvenger = "https://i.imgur.com/SmEAtBo.png";
+        private const string MinionIllusionaryWhaler = "https://i.imgur.com/scQEWWG.png";
+        private const string MinionIllusionaryMariner = "https://i.imgur.com/uWYbVhz.png";
         private const string MinionJadeMech = "https://i.imgur.com/54evTaq.png";
         private const string MinionEraBreakrazor = "https://i.imgur.com/2X3G3Fl.png";
         private const string MinionKusDarkrazor = "https://i.imgur.com/rJq4Ngh.png";
@@ -445,6 +447,11 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string MinionBlastGyro = "https://i.imgur.com/F7ZMxGg.png";
         private const string MinionMedicGyro = "https://i.imgur.com/zIURFje.png";
         private const string MinionFunctionGyro = "https://i.imgur.com/STMhpzk.png";
+        private const string MinionEmber = "https://i.imgur.com/Co4i7sh.png";
+        private const string MinionHawkeyeGriffon = "https://i.imgur.com/MdmIv6y.png";
+        private const string MinionSousChef = "https://i.imgur.com/v0cED9x.png";
+        private const string MinionSunspreadParagon = "https://i.imgur.com/0a5Ghmv.png";
+        private const string MinionRavenSpiritShadow = "https://i.imgur.com/ziqCoFD.png";
 
         /// <summary>
         /// Dictionary matching a <see cref="Spec"/> to their high resolution profession icon.
@@ -920,32 +927,40 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.MinionID.RuneRockDog, MinionRuneRockDog },
             { ArcDPSEnums.MinionID.RuneMarkIGolem, MinionRuneMarkIGolem },
             { ArcDPSEnums.MinionID.RuneTropicalBird, MinionTropicalBird },
+            { ArcDPSEnums.MinionID.Ember, MinionEmber },
+            { ArcDPSEnums.MinionID.HawkeyeGriffon, MinionHawkeyeGriffon },
+            { ArcDPSEnums.MinionID.SousChef, MinionSousChef },
+            { ArcDPSEnums.MinionID.SunspearParagonSupport, MinionSunspreadParagon },
+            { ArcDPSEnums.MinionID.RavenSpiritShadow, MinionRavenSpiritShadow },
             { ArcDPSEnums.MinionID.CloneSpear, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneUnknown1, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneUnknown2, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneUnknown3, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneGreatsword, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneStaff, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneDownstate, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneTrident, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneSword, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneSwordPistol, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneSwordTorch, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneScepterTorch, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneSwordFocus, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneSwordTorchPhantasm, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneSwordFocusPhantasm, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneSwordSword, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneSwordShield, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneIllusionaryLeap, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneIllusionaryLeapFocus, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneIllusionaryLeapShield, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneIllusionaryLeapSword, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneIllusionaryLeapPistol, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneIllusionaryLeapTorch, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneScepter, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneScepterTorch, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneScepterShield, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneSwordPistolPhantasm, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneScepterPistol, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneSwordShieldPhantasm, MinionMesmerClone },
-            { ArcDPSEnums.MinionID.CloneSwordSwordPhantasm, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneScepterFocus, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneScepterSword, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneAxe, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneAxeTorch, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneAxePistol, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneAxeSword, MinionMesmerClone },
             { ArcDPSEnums.MinionID.CloneAxeFocus, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneDownstate, MinionMesmerClone },
+            { ArcDPSEnums.MinionID.CloneUnknown, MinionMesmerClone },
             { ArcDPSEnums.MinionID.IllusionarySwordsman, MinionIllusionarySwordsman },
             { ArcDPSEnums.MinionID.IllusionaryBerserker, MinionIllusionaryBerserker },
             { ArcDPSEnums.MinionID.IllusionaryDisenchanter, MinionIllusionaryDisenchanter },
@@ -956,6 +971,8 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.MinionID.IllusionaryWarden, MinionIllusionaryWarden },
             { ArcDPSEnums.MinionID.IllusionaryWarlock, MinionIllusionaryWarlock },
             { ArcDPSEnums.MinionID.IllusionaryAvenger, MinionIllusionaryAvenger },
+            { ArcDPSEnums.MinionID.IllusionaryWhaler, MinionIllusionaryWhaler },
+            { ArcDPSEnums.MinionID.IllusionaryMariner, MinionIllusionaryMariner },
             { ArcDPSEnums.MinionID.JadeMech, MinionJadeMech },
             { ArcDPSEnums.MinionID.EraBreakrazor, MinionEraBreakrazor },
             { ArcDPSEnums.MinionID.KusDarkrazor, MinionKusDarkrazor },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1194,6 +1194,7 @@
         public const long CheesyCassavaRoll = 33909;
         public const long GuildObjectiveAuraVI = 32928;
         public const long PieceOfUnderseaWurmSushi = 33936;
+        public const long ChillingFogEffect = 33978;
         public const long HardenedSiegeGear = 33983;
         public const long BowlOfTapiocaPudding = 34014;
         public const long MarkedSentryGreen = 34015;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -830,8 +830,10 @@
         public const long MistlockInstabilityBloodlust = 22300;
         public const long MistlockInstabilityStamina = 22301;
         public const long ShatteredAegis = 22499;
+        public const long OgrePetWhistleEffect = 22571;
         public const long ArcaneWave = 22572;
         public const long RocketTurretCast2 = 22574;
+        public const long FireElementalPowderEffect = 22752;
         public const long ProtectedCaravan = 23088;
         public const long KodasArmor = 23158;
         public const long MarkedSentryTurretRed = 23167;
@@ -1877,6 +1879,7 @@
         public const long PiercingShadow = 47518;
         public const long NumbingBreach = 47531;
         public const long ConeSlash = 47561;
+        public const long SunspearParagonSupportEffect = 47564;
         public const long ShieldOfIce = 47595;
         public const long EnvironmentallyFriendly = 47625;
         public const long LastGraspJudgment = 47635;
@@ -2327,6 +2330,7 @@
         public const long RavenLeap1 = 58323;
         public const long Groundshaker = 58325;
         public const long PowerOfValorTier3 = 58332;
+        public const long RavenSpiritShadowEffect = 58349;
         public const long IceArmSwingFraenir = 58356;
         public const long ArrosOfTheFallen = 58371;
         public const long Frozen = 58376;


### PR DESCRIPTION
- Added 5 summons by consumable items
- Added summons to common minions hash set
- Added missing mesmer clones and renamed some incorrect ones
- Added 2 phantasmas that were missing
- Added a GW2Builds build number to the enums
- Added icons for the new summons
- Added buffs related to the consumable summons
- Added 3 racial summons