### PR TITLE
Escort mechanics

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
@@ -22,7 +22,13 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             MechanicList.AddRange(new List<Mechanic>
             {
-
+                new PlayerDstSkillMechanic(DetonateMineEscort, "Detonate", new MechanicPlotlySetting(Symbols.CircleCross, Colors.Red), "Mine.H", "Hit by Mine Detonation", "Mine Detonation Hit", 150, (de, log) => de.CreditedFrom.IsSpecies(ArcDPSEnums.TrashID.Mine)),
+                new PlayerDstSkillMechanic(GlennaBombHit, "Bomb Explosion", new MechanicPlotlySetting(Symbols.Hexagon, Colors.LightGrey), "Bomb.H", "Hit by Glenna's Bomb", "Glenna's Bomb Hit", 0),
+                new PlayerDstHitMechanic(FireMortarEscortHit, "Fire Mortar", new MechanicPlotlySetting(Symbols.Hourglass, Colors.DarkPurple), "Shrd.H", "Hit by Mortar Fire (Bloodstone Turrets)", "Mortar Fire Hit", 0),
+                new PlayerDstBuffApplyMechanic(RadiantAttunementPhantasm, "Radiant Attunement", new MechanicPlotlySetting(Symbols.Diamond, Colors.White), "Rad.A", "Radiant Attunement Application", "Radiant Attunement Application", 150),
+                new PlayerDstBuffApplyMechanic(CrimsonAttunementPhantasm, "Crimson Attunement", new MechanicPlotlySetting(Symbols.Diamond, Colors.Red), "Crim.A", "Crimson Attunement Application", "Crimson Attunement Application", 150),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.DiamondOpen, Colors.LightBlue), "Inv.A", "Invulnerability Applied", "Invulnerability Applied", 150),
+                new EnemyCastStartMechanic(TeleportDisplacementField, "Teleport Displacement Field", new MechanicPlotlySetting(Symbols.Square, Colors.LightPurple), "Tel.C", "Teleport Cast", "Teleport Cast", 150),
             }
             );
             ChestID = ArcDPSEnums.ChestID.SiegeChest;

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -222,6 +222,7 @@ namespace GW2EIEvtcParser.ParsedData
             {SaintsShieldDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
             {ImperialImpactDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
             {GlyphOfUnityCA, "https://wiki.guildwars2.com/images/4/4c/Glyph_of_Unity_%28Celestial_Avatar%29.png" },
+            { HaresSpeedSkill, "https://wiki.guildwars2.com/images/0/05/Hare%27s_Speed.png" },
             // Weaver attunements
             {DualFireAttunement, "https://wiki.guildwars2.com/images/b/b4/Fire_Attunement.png" },
             {FireWaterAttunement, "https://i.imgur.com/ar8Hn8G.png" },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -178,6 +178,7 @@
         public const long RocketTurretDamage = 6108;
         public const long OverchargedShot = 6154;
         public const long SupplyCrateUW = 6183;
+        public const long HaresSpeedSkill = 6221;
         public const long Knockdown = 6892;
         public const long LeapOfFaith = 9080;
         public const long ShieldOfWrathSkill = 9082;
@@ -1334,7 +1335,9 @@
         public const long SpatialDistortion = 34918;
         public const long GravityWellXera = 34921;
         public const long StatueFixated2 = 34925;
+        public const long DetonateMineEscort = 34926;
         public const long CreepingPursuit = 34927;
+        public const long TurretShotEscort = 34945;
         public const long ConstructAura = 34946;
         public const long Outnumbered = 34947;
         public const long SoothingWaters = 34955;
@@ -1370,9 +1373,11 @@
         public const long CerebralSlash = 35087;
         public const long CrimsonAttunementOrb = 35091;
         public const long Compromised = 35096;
+        public const long GlennaBombHit = 35100;
         public const long XerasFury = 35103;
         public const long StillWaters = 35106;
         public const long RadiantAttunementOrb = 35109;
+        public const long TeleportDisplacementField = 35116;
         public const long MagicBlast = 35119;
         public const long TemporalShredOrb = 35128;
         public const long ReviveSickness = 35133;
@@ -1384,6 +1389,7 @@
         public const long EscortSurveilled = 35157;
         public const long ShiftingChaos = 35162;
         public const long BloodstoneProtection = 35168;
+        public const long FireMortarEscortHit = 35171;
         public const long SpinningCut = 35452;
         public const long PullCharge = 35761;
         public const long WhirlingDevastation = 35940;


### PR DESCRIPTION
- Player hit by Mine detonation
- Player hit by Glenna's Bomb (on the gates)
- Player hit by Bloodstone shards shot by the turrets
- Player gained Crimson Attunement
- Player gained Radiant Attunement
- McLeod gained Invulnerability (useful to check if you've got a phase skip)
- Added icon override for Hare's Speed skill (the swiftness skill while holding the rabbit)