### PR TITLE
Fix Dhuum phase detection bug

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -162,7 +162,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             // Sometimes the pre event is not in the evtc
             IReadOnlyList<AbstractCastEvent> castLogs = dhuum.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
             IReadOnlyList<AbstractCastEvent> dhuumCast = dhuum.GetCastEvents(log, log.FightData.FightStart, 20000);
-            if (dhuumCast.Any(x => !(x is InstantCastEvent) && x.SkillId != WeaponStow))
+            if (dhuumCast.Any(x => !(x is InstantCastEvent) && x.SkillId != WeaponDraw && x.SkillId != WeaponStow))
             {
                 // full fight does not contain the pre event
                 ComputeFightPhases(phases, castLogs, fightDuration, 0);

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -854,6 +854,7 @@
         public const long PowerfulPotionOfSlayingScarletsArmies = 23228;
         public const long Enraged2_Unknown = 23235;
         public const long SwiftMoaFeather = 23239;
+        public const long WeaponDraw = 23284;
         public const long WeaponStow = 23285;
         public const long Reflection2 = 24014;
         public const long SigilOfWater = 24241;


### PR DESCRIPTION
This broken log was posted on the Wingman Discord: https://gw2wingman.nevermindcreations.de/log/KO0o-20230502-204904_dhuum.
Turns out the phase detection failed since in the log Dhuum casts Weapon Draw 2ms into the encounter.