### PR TITLE
General updates

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
@@ -287,6 +287,8 @@
         internal const string Claim = "https://wiki.guildwars2.com/images/e/ef/Claim.png";
         // Samarog
         internal const string SoulSwarm = "https://wiki.guildwars2.com/images/0/0e/Soul_Swarm_%28effect%29.png";
+        internal const string FixateRigom = "https://wiki.guildwars2.com/images/f/f9/Fixate_%28Rigom%29.png";
+        internal const string FixateGuldhem = "https://wiki.guildwars2.com/images/8/83/Fixate_%28Guldhem%29.png";
         internal const string Burrowed = "https://wiki.guildwars2.com/images/e/e3/Burrowed.png";
         // Deimos
         internal const string UnnaturalSignet = "https://wiki.guildwars2.com/images/2/20/Unnatural_Signet.png";
@@ -354,6 +356,7 @@
         internal const string KineticAbundance = "https://wiki.guildwars2.com/images/6/64/Kinetic_Abundance.png";
         internal const string EnfeebledForce = "https://wiki.guildwars2.com/images/b/b6/Enfeebled_Force.png";
         internal const string MagicBlastIntensity = "https://wiki.guildwars2.com/images/a/a9/Magic_Blast_Intensity.png";
+        internal const string PartiallyProtected = "https://wiki.guildwars2.com/images/d/d0/Partially_Protected.png";
         // Fractal
         internal const string GambitExhausted = "https://wiki.guildwars2.com/images/4/41/Gambit_Exhausted.png";
         internal const string RedirectAnomaly = "https://wiki.guildwars2.com/images/9/94/Redirect_Anomaly.png";
@@ -397,6 +400,7 @@
         internal const string FrozenBarrier = "https://wiki.guildwars2.com/images/c/c8/Frozen_Barrier.png";
         internal const string GiftOfTrueSight = "https://wiki.guildwars2.com/images/7/75/Gift_of_True_Sight.png";
         internal const string Hallucinations = "https://wiki.guildwars2.com/images/c/ce/Hallucinations.png";
+        internal const string Disoriented = "https://wiki.guildwars2.com/images/7/7c/Disoriented.png";
         // Open World
         internal const string JadeTechOffensive = "https://wiki.guildwars2.com/images/d/d2/Jade_Tech_Offensive_Overcharge.png";
         internal const string JadeTechDefensive = "https://wiki.guildwars2.com/images/4/4e/Jade_Tech_Defensive_Overcharge.png";

--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -217,23 +217,23 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Hero's Departure", HerosDeparture, Source.FightSpecific, BuffClassification.Other, BuffImages.Determined),
             new Buff("Hero's Return", HerosReturn, Source.FightSpecific, BuffClassification.Other, BuffImages.Determined),
             //////////////////////////////////////////////
-            // Cairn        
+            // Cairn
             new Buff("Shared Agony", SharedAgony, Source.FightSpecific, BuffClassification.Debuff, BuffImages.SharedAgony),
             new Buff("Enraged (Cairn)", EnragedCairn, Source.FightSpecific, BuffClassification.Other, BuffImages.Enraged),
             new Buff("Enraged (Cairn 2)", EnragedCairn2, Source.FightSpecific, BuffClassification.Other, BuffImages.Enraged),
             new Buff("Unseen Burden", UnseenBurden, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Debuff, BuffImages.UnseenBurden),
             new Buff("Countdown", Countdown, Source.FightSpecific, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.Countdown),
             new Buff("Gaze Avoidance", GazeAvoidance, Source.FightSpecific, BuffClassification.Other, BuffImages.GazeAvoidance),
-            // MO             
+            // Mursaat Overseer
             new Buff("Empowered", Empowered, Source.FightSpecific, BuffStackType.Stacking, 4, BuffClassification.Other, BuffImages.Empowered),
             new Buff("Mursaat Overseer's Shield", MursaatOverseersShield, Source.FightSpecific, BuffClassification.Other, BuffImages.Dispel),
-            new Buff("Protect (SAK)", ProtectSAK, Source.FightSpecific, BuffClassification.Other, BuffImages.Protect),
-            new Buff("Dispel (SAK)", DispelSAK, Source.FightSpecific, BuffClassification.Other, BuffImages.Dispel),
-            new Buff("Claim (SAK)", ClaimSAK, Source.FightSpecific, BuffClassification.Other, BuffImages.Claim),
-            // Samarog            
+            new Buff("Protect", ProtectEffect, Source.FightSpecific, BuffClassification.Other, BuffImages.Protect),
+            new Buff("Dispel", DispelEffect, Source.FightSpecific, BuffClassification.Other, BuffImages.Dispel),
+            new Buff("Claim", ClaimEffect, Source.FightSpecific, BuffClassification.Other, BuffImages.Claim),
+            // Samarog
             new Buff("Fixated (Samarog)", FixatedSamarog, Source.FightSpecific, BuffClassification.Other, BuffImages.Fixated),
-            new Buff("Fixated (Guldhem)", FixatedGuldhem, Source.FightSpecific, BuffClassification.Other, BuffImages.Fixated),
-            new Buff("Fixated (Rigom)", FixatedRigom, Source.FightSpecific, BuffClassification.Other, BuffImages.Fixated),
+            new Buff("Fixated (Guldhem)", FixatedGuldhem, Source.FightSpecific, BuffClassification.Other, BuffImages.FixateGuldhem),
+            new Buff("Fixated (Rigom)", FixatedRigom, Source.FightSpecific, BuffClassification.Other, BuffImages.FixateRigom),
             new Buff("Inevitable Betrayal (Big)", InevitableBetrayalBig, Source.FightSpecific, BuffClassification.Other, BuffImages.FeedingFrenzy),
             new Buff("Inevitable Betrayal (Small)", InevitableBetrayalSmall, Source.FightSpecific, BuffClassification.Other, BuffImages.FeedingFrenzy),
             new Buff("Soul Swarm", SoulSwarm, Source.FightSpecific, BuffClassification.Other, BuffImages.SoulSwarm),
@@ -357,6 +357,8 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Incorporeal", Incorporeal, Source.FightSpecific, BuffClassification.Other, BuffImages.MagicAura),
             new Buff("Flare-Up", FlareUp, Source.FightSpecific, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.MagicAura),
             new Buff("Unbridled Chaos", UnbridledChaos, Source.FightSpecific, BuffStackType.Stacking, 3, BuffClassification.Other, BuffImages.ExposedEyes),
+            new Buff("Rebellious Power", RebelliousPower, Source.FightSpecific, BuffStackType.Stacking, 40, BuffClassification.Other, BuffImages.InfusedShield),
+            new Buff("Charged Soul", ChargedSoul, Source.FightSpecific, BuffStackType.Stacking, 20, BuffClassification.Other, BuffImages.PartiallyProtected),
             new Buff("Achievement Eligibility: Power Surge", AchievementEligibilityPowerSurge, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             //////////////////////////////////////////////
             // Fractals 
@@ -492,7 +494,8 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Shared Destruction (Li CM)", SharedDestructionLiCM, Source.FightSpecific, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, BuffImages.MonsterSkill),
             new Buff("Debilitated", Debilitated, Source.FightSpecific, BuffStackType.Stacking, 3, BuffClassification.Debuff, BuffImages.Debilitated),
             new Buff("Infirmity", Infirmity, Source.FightSpecific, BuffStackType.Stacking, 4, BuffClassification.Debuff, BuffImages.DebilitatingVoid),
-            //Harvest Temple
+            new Buff("Disoriented", DisorientedEffect, Source.FightSpecific, BuffClassification.Other, BuffImages.Disoriented),
+            // Harvest Temple
             new Buff("Influence of the Void", InfluenceOfTheVoidEffect, Source.FightSpecific, BuffStackType.Stacking, 20, BuffClassification.Other, BuffImages.ThrowCursedArtifact),
             new Buff("Targeted (Dragon Void)", TargetedDragonVoid, Source.FightSpecific, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.Fixated),
             new Buff("Void Repulsion 1", VoidRepulsion1, Source.FightSpecific, BuffClassification.Other, BuffImages.FrozenBarrier),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
@@ -65,7 +65,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Skale Venom", SkaleVenomEffect, Source.Thief, BuffStackType.StackingConditionalLoss, 4, BuffClassification.Offensive, BuffImages.SkaleVenom),
             new Buff("Spider Venom", SpiderVenomEffect, Source.Thief, BuffStackType.StackingConditionalLoss, 6, BuffClassification.Offensive, BuffImages.SpiderVenom),
             new Buff("Soul Stone Venom", SoulStoneVenomEffect, Source.Thief, BuffStackType.Stacking, 25, BuffClassification.Offensive, BuffImages.SoulStoneVenom),
-            new Buff("Basilisk Venom", BasiliskVenom, Source.Thief, BuffStackType.StackingConditionalLoss, 2, BuffClassification.Support, BuffImages.BasiliskVenom),
+            new Buff("Basilisk Venom", BasiliskVenomEffect, Source.Thief, BuffStackType.StackingConditionalLoss, 2, BuffClassification.Support, BuffImages.BasiliskVenom),
             new Buff("Petrified 1", Petrified1, Source.Thief, BuffClassification.Other, BuffImages.Stun),
             new Buff("Petrified 2", Petrified2, Source.Thief, BuffClassification.Other, BuffImages.Stun),
             new Buff("Infiltration", Infiltration, Source.Thief, BuffClassification.Other, BuffImages.Shadowstep),

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
@@ -23,9 +23,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             //new Mechanic(DispelSAK, "Dispel", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.MursaatOverseer, new MechanicPlotlySetting(Symbols.Circle,Colors.Yellow), "Dispel",0), //Buff remove only
             //new Mechanic(ProtectSAK, "Protect", Mechanic.MechType.PlayerBoon, ParseEnum.BossIDS.MursaatOverseer, new MechanicPlotlySetting(Symbols.Circle,Colors.Teal), "Protect",0), //Buff remove only
             new PlayerDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.CircleOpen,Colors.Teal), "Protect","Protected by the Protect Shield","Protect Shield",0).UsingChecker((ba, log) => ba.AppliedDuration == 1000),
-            new PlayerDstBuffApplyMechanic(ProtectSAK, "Protect (SAK)", new MechanicPlotlySetting(Symbols.Circle,Colors.Blue), "Protect (SAK)","Took protect","Protect (SAK)",0),
-            new PlayerDstBuffApplyMechanic(DispelSAK, "Dispel (SAK)", new MechanicPlotlySetting(Symbols.Circle,Colors.Purple), "Dispel (SAK)","Took dispel","Dispel (SAK)",0),
-            new PlayerDstBuffApplyMechanic(ClaimSAK, "Claim (SAK)", new MechanicPlotlySetting(Symbols.Circle,Colors.Yellow), "Claim (SAK)","Took claim","Claim (SAK)",0),
+            new PlayerDstBuffApplyMechanic(ProtectEffect, "Protect (SAK)", new MechanicPlotlySetting(Symbols.Circle,Colors.Blue), "Protect (SAK)","Took protect","Protect (SAK)",0),
+            new PlayerDstBuffApplyMechanic(DispelEffect, "Dispel (SAK)", new MechanicPlotlySetting(Symbols.Circle,Colors.Purple), "Dispel (SAK)","Took dispel","Dispel (SAK)",0),
+            new PlayerDstBuffApplyMechanic(ClaimEffect, "Claim (SAK)", new MechanicPlotlySetting(Symbols.Circle,Colors.Yellow), "Claim (SAK)","Took claim","Claim (SAK)",0),
             new EnemyDstBuffApplyMechanic(MursaatOverseersShield, "Mursaat Overseer's Shield", new MechanicPlotlySetting(Symbols.CircleOpen,Colors.Yellow), "Shield","Jade Soldier Shield", "Soldier Shield",0),
             new EnemyDstBuffRemoveMechanic(MursaatOverseersShield, "Mursaat Overseer's Shield", new MechanicPlotlySetting(Symbols.SquareOpen,Colors.Yellow), "Dispel","Dispelled Jade Soldier Shield", "Dispel",0),
             //new Mechanic(EnemyTile, "Enemy Tile", ParseEnum.BossIDS.MursaatOverseer, new MechanicPlotlySetting(Symbols.SquareOpen,Colors.Yellow), "Floor","Enemy Tile damage", "Tile dmg",0) //Fixed damage (3500), not trackable

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
@@ -35,10 +35,13 @@ namespace GW2EIEvtcParser.EncounterLogic
                 new PlayerDstHitMechanic(CausticChaosProjectile, "Caustic Chaos", new MechanicPlotlySetting(Symbols.TriangleRight,Colors.Red), "A.Prj.H", "Hit by Aimed Projectile", "Aimed Projectile", 0),
                 new EnemySrcHitMechanic(ShowerOfChaos, "Shower of Chaos", new MechanicPlotlySetting(Symbols.Circle,Colors.Black), "Orb.D", "Pylon Orb not caught", "Shower of Chaos", 1000),
                 new EnemySrcHitMechanic(EclipsedBacklash, "Eclipsed Backlash", new MechanicPlotlySetting(Symbols.Circle,Colors.Orange), "Entropic.Expl", "Entropic Distortion exploded", "Eclipsed Backlash", 1000),
+                new PlayerCastStartMechanic(PlayerLiftUpQadimThePeerless, "Lift Up", new MechanicPlotlySetting(Symbols.TriangleUp, Colors.Orange), "Up", "Player lifted up", "Player lifted up", 0),
+                new PlayerCastEndMechanic(FluxDisruptorActivateCast, "Flux Disruptor: Activate", new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.Blue), "Flux.Act", "Flux Disruptor Activated", "Flux Disruptor Activated", 0),
+                new PlayerCastEndMechanic(FluxDisruptorDeactivateCast, "Flux Disruptor: Deactivate", new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.LightBlue), "Flux.Dea", "Flux Disruptor Deactivated", "Flux Disruptor Deactivated", 0),
                 new PlayerDstBuffApplyMechanic(FixatedQadimThePeerless, "Fixated", new MechanicPlotlySetting(Symbols.Star,Colors.Magenta), "Fixated", "Fixated", "Fixated", 0),
                 new PlayerDstBuffApplyMechanic(CriticalMass, "Critical Mass", new MechanicPlotlySetting(Symbols.CircleOpen,Colors.Red), "Orb caught", "Collected a Pylon Orb", "Critical Mass", 0),
-                new PlayerDstHitMechanic(CausticChaosExplosion, "Caustic Chaos", new MechanicPlotlySetting(Symbols.TriangleRightOpen,Colors.Red), "A.Prj.E", "Hit by Aimed Projectile Explosion", "Aimed Projectile Explosion", 0),
                 new PlayerDstBuffApplyMechanic(SappingSurge, "Sapping Surge", new MechanicPlotlySetting(Symbols.YDownOpen,Colors.Red), "B.Tether", "25% damage reduction", "Bad Tether", 0),
+                new PlayerDstHitMechanic(CausticChaosExplosion, "Caustic Chaos", new MechanicPlotlySetting(Symbols.TriangleRightOpen,Colors.Red), "A.Prj.E", "Hit by Aimed Projectile Explosion", "Aimed Projectile Explosion", 0),
             });
             Extension = "prlqadim";
             Icon = EncounterIconPeerlessQadim;

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -76,6 +76,9 @@ namespace GW2EIEvtcParser.ParsedData
             {RegenerativeBreakbar, "Regenerative Breakbar" },
             // P.Qadim
             {RuinousNovaCharge, "Ruinous Nova Charge" },
+            { FluxDisruptorActivateCast, "Flux Disruptor: Activate" },
+            { FluxDisruptorDeactivateCast, "Flux Disruptor: Deactivate" },
+            { PlayerLiftUpQadimThePeerless, "Player Lift Up Mechanic" },
             //{56036, "Magma Bomb" },
             {ForceOfRetaliationCast, "Force of Retaliation Cast" },
             {PeerlessQadimTPCenter, "Teleport Center" },
@@ -123,6 +126,7 @@ namespace GW2EIEvtcParser.ParsedData
             //
             {SoulStoneVenomSkill, "Soul Stone Venom" },
             {SoulStoneVenomStrike, "Soul Stone Venom (Hit)" },
+            { BasiliskVenomStunBreakbarDamage, "Basilisk Venom (Stun)" },
             {MantraOfSolace, "Mantra of Solace" },
             {DesertEmpowerment, "Desert Empowerment" },
             {SigilOfWater, "Sigil of Water" },
@@ -329,6 +333,12 @@ namespace GW2EIEvtcParser.ParsedData
             // - Conjured Amalgamated
             { ConjuredSlashSAK, "https://wiki.guildwars2.com/images/5/59/Conjured_Slash.png" },
             { ConjuredProtectionSAK, "https://wiki.guildwars2.com/images/0/02/Conjured_Protection.png" },
+            // - Sabir
+            { FlashDischargeSAK, "https://wiki.guildwars2.com/images/5/59/Flash_Discharge.png" },
+            // - Qadim the Peerless
+            { FluxDisruptorActivateCast, "https://wiki.guildwars2.com/images/d/d5/Flux_Disruptor-_Activate.png" },
+            { FluxDisruptorDeactivateCast, "https://wiki.guildwars2.com/images/3/34/Flux_Disruptor-_Deactivate.png" },
+            { UnleashSAK, "https://wiki.guildwars2.com/images/9/99/Touch_of_the_Sun.png" },
             // Skills
             { ProtectorsStrikeCounterHit, "https://wiki.guildwars2.com/images/e/e0/Protector%27s_Strike.png" },
             { OverbearingSmashLeap, "https://wiki.guildwars2.com/images/9/9a/Overbearing_Smash.png" },
@@ -337,6 +347,7 @@ namespace GW2EIEvtcParser.ParsedData
             { SwordOfJusticeDamage, "https://wiki.guildwars2.com/images/8/81/Sword_of_Justice.png" },
             { RefractionCutterBlade, "https://wiki.guildwars2.com/images/1/10/Refraction_Cutter.png" },
             { EntangleDamage, "https://wiki.guildwars2.com/images/6/67/Entangle.png" },
+            { BasiliskVenomStunBreakbarDamage, "https://wiki.guildwars2.com/images/3/3a/Basilisk_Venom.png" },
             // - Shades
             { ManifestSandShadeShadeHit, "https://wiki.guildwars2.com/images/a/a4/Manifest_Sand_Shade.png" },
             { NefariousFavorShadeHit, "https://wiki.guildwars2.com/images/8/83/Nefarious_Favor.png" },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -184,6 +184,7 @@
         public const long SupplyCrateUW = 6183;
         public const long HaresSpeedSkill = 6221;
         public const long Knockdown = 6892;
+        public const long DisorientedEffect = 8804;
         public const long LeapOfFaith = 9080;
         public const long ShieldOfWrathSkill = 9082;
         public const long Advance = 9084;
@@ -718,7 +719,8 @@
         public const long IceDrakeVenomEffect = 13095;
         public const long IceDrakeVenomSkill = 13096;
         public const long ShadowReturn = 13106;
-        public const long BasiliskVenom = 13133;
+        public const long BasiliskVenomSkill = 13132;
+        public const long BasiliskVenomEffect = 13133;
         public const long DaggerStorm = 13134;
         public const long Infiltration = 13135;
         public const long PersistingFlames = 13342;
@@ -881,6 +883,7 @@
         public const long MistlockInstabilityPlayingFavorites = 22299;
         public const long MistlockInstabilityBloodlust = 22300;
         public const long MistlockInstabilityStamina = 22301;
+        public const long BasiliskVenomStunBreakbarDamage = 22492;
         public const long ShatteredAegis = 22499;
         public const long OgrePetWhistleEffect = 22571;
         public const long ArcaneWave = 22572;
@@ -1548,7 +1551,7 @@
         public const long JadeSoldierAura = 37677;
         public const long FixatedRigom = 37693;
         public const long FluxBombEffect = 37695;
-        public const long DispelSAK = 37697;
+        public const long DispelEffect = 37697;
         public const long GazeAvoidance = 37714;
         public const long RapidDecay = 37716;
         public const long Devour = 37718;
@@ -1556,11 +1559,11 @@
         public const long TearInstability = 37733;
         public const long SharedAgony50 = 37768;
         public const long SharedAgony2 = 37775;
-        public const long ClaimSAK = 37779;
+        public const long ClaimEffect = 37779;
         public const long Impact = 37784;
         public const long JadeSoldierExplosion = 37788;
         public const long TramplingRush = 37797;
-        public const long ProtectSAK = 37813;
+        public const long ProtectEffect = 37813;
         public const long EnragedCairn2 = 37824;
         public const long SpearImpact = 37816;
         public const long OffBalance = 37846;
@@ -1570,7 +1573,7 @@
         public const long DemonicAura = 37872;
         public const long SoulSwarm = 37892;
         public const long EffigyPulse = 37901;
-        public const long Dispel = 37904;
+        public const long DispelSAK = 37904;
         public const long GravityWave = 37910;
         public const long CelestialDash = 37924;
         public const long Annihilate1 = 37929;
@@ -1581,6 +1584,7 @@
         public const long CosmicAura = 37989;
         public const long SamarogShockwave = 37996;
         public const long BrutalizeKill = 38013;
+        public const long ProtectSAK = 38022;
         public const long DemonicShockWaveLeft = 38046;
         public const long SharedAgony = 38049;
         public const long EnergySurge = 38060;
@@ -1605,6 +1609,7 @@
         public const long UnnaturalSignet = 38224;
         public const long FanaticalResilience = 38226;
         public const long ImpalingStab = 38231;
+        public const long ClaimSAK = 38234;
         public const long InevitableBetrayalSmall = 38247;
         public const long BrutalAura = 38258;
         public const long InevitableBetrayalFailSmall = 38260;
@@ -2227,6 +2232,7 @@
         public const long FeelNoPainSavageInstinct = 55030;
         public const long UnyieldingDevotion = 55044;
         public const long GlyphOfTheStars = 55048;
+        public const long ChargedSoul = 56011;
         public const long EtherStrikes1 = 56012;
         public const long ForceOfHavoc2 = 56017;
         public const long EnergizedAffliction = 56020;
@@ -2248,11 +2254,14 @@
         public const long ForceOfRetaliation = 56134;
         public const long StalagmitesDetonation = 56141;
         public const long ChaosCalled = 56145;
+        public const long FluxDisruptorActivateSkill = 56152;
+        public const long FluxDisruptorActivateCast = 56168;
         public const long AchievementEligibilityPowerSurge = 56171;
         public const long RepulsionField = 56172;
         public const long ResidualImpactMagmaField = 56180;
         public const long ChaosCorrosion = 56182;
         public const long UnbridledChaos2 = 56199;
+        public const long UnleashSAK = 56201;
         public const long DireDrafts = 56202;
         public const long PillarPandemonium = 56204;
         public const long EyeOfTheStorm = 56216;
@@ -2261,13 +2270,16 @@
         public const long Invulnerability56227 = 56227;
         public const long CleansedConductor = 56237;
         public const long Incorporeal = 56250;
+        public const long FlashDischargeSAK = 56251;
         public const long ExponentialRepercussionQadimShield = 56254;
         public const long ClutchedByChaos = 56257;
+        public const long FluxDisruptorDeactivateSkill = 56262;
         public const long FlareUp = 56264;
         public const long RuinousNovaCharge = 56296;
         public const long EclipsedBacklash = 56316;
         public const long BigMagmaDrop = 56329;
         public const long CausticChaosProjectile = 56332;
+        public const long FluxDisruptorDeactivateCast = 56333;
         public const long RegenerativeBreakbar = 56349;
         public const long SeismicSuffering = 56351;
         public const long BacklashingBeam = 56360;
@@ -2275,11 +2287,13 @@
         public const long PeerlessQadimTPCenter = 56375;
         public const long ResidualImpactSmallMagmaField = 56378;
         public const long TripleRotatingEarthRays = 56381;
+        public const long PlayerLiftUpQadimThePeerless = 56383;
         public const long PerilousPulse = 56390;
         public const long ElectricalRepulsion = 56391;
         public const long BoltBreak = 56394;
         public const long ForceOfRetaliationCast = 56405;
         public const long CriticalMass = 56424;
+        public const long RebelliousPower = 56434;
         public const long ErodingCurse = 56440;
         public const long ForceOfHavoc = 56441;
         public const long EatPylon = 56446;


### PR DESCRIPTION
- Fixed the buff icons for Rigom and Guldhem Fixate
- Fixed the naming scheme of Mursaat Overseer special action key buffs and added the special action keys skill ids for completition
- Added two new buffs to Qadim the Peerless CM which appear when a player gets lifted up in the air ( #740 )
- Added a mechanic to Qadim the Peerless CM which counts how many times a player has been lifted up ( #740 )
- Added two mechanics to Qadim the Peerless which count the special action key activation and deactivation cast times
- Added a buff to Kaineng Overlook strike
- Corrected the naming of the Basilisk Venom buff and added a renaming with icon override for its stun effect
- Added names to the Qadim the Peerless special action keys cast time, which have a different skill ID than the skill itself
- Added icon override for Sabir's and all three Qadim the Peerless' special action keys