### PR TITLE
Encounter start logic update.

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
@@ -135,8 +135,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                 {
                     throw new MissingKeyActorsException("Arkk not found");
                 }
-                CombatItem firstBuffApply = combatData.FirstOrDefault(x => x.IsBuffApply() && x.SrcMatchesAgent(arkk) && x.SkillID == ArkkStartEffect && x.Time <= logStartNPCUpdate.Time + ParserHelper.ServerDelayConstant);
-                CombatItem enterCombat = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.EnterCombat && x.SrcMatchesAgent(arkk) && x.Time <= logStartNPCUpdate.Time + ParserHelper.ServerDelayConstant);
+                long upperLimit = GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, arkk);
+                CombatItem firstBuffApply = combatData.FirstOrDefault(x => x.IsBuffApply() && x.SrcMatchesAgent(arkk) && x.SkillID == ArkkStartEffect && x.Time <= upperLimit + TimeThresholdConstant);
+                CombatItem enterCombat = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.EnterCombat && x.SrcMatchesAgent(arkk) && x.Time <= upperLimit + TimeThresholdConstant);
                 return firstBuffApply != null ? Math.Min(firstBuffApply.Time, enterCombat != null ? enterCombat.Time : long.MaxValue): GetGenericFightOffset(fightData);
             }
             return GetGenericFightOffset(fightData);

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -137,9 +137,10 @@ namespace GW2EIEvtcParser.EncounterLogic
                 {
                     throw new MissingKeyActorsException("Skorvald not found");
                 }
+                long upperLimit = GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, skorvald);
                 // Skorvald may spawns with 0% hp
                 CombatItem firstNonZeroHPUpdate = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.HealthUpdate && x.SrcMatchesAgent(skorvald) && x.DstAgent > 0);
-                CombatItem enterCombat = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.EnterCombat && x.SrcMatchesAgent(skorvald) && x.Time <= logStartNPCUpdate.Time + ParserHelper.ServerDelayConstant);
+                CombatItem enterCombat = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.EnterCombat && x.SrcMatchesAgent(skorvald) && x.Time <= upperLimit + ParserHelper.ServerDelayConstant);
                 return firstNonZeroHPUpdate != null ? Math.Min(firstNonZeroHPUpdate.Time, enterCombat != null ? enterCombat.Time : long.MaxValue) : GetGenericFightOffset(fightData);
             }
             return GetGenericFightOffset(fightData);

--- a/GW2EIEvtcParser/EncounterLogic/Golem.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Golem.cs
@@ -183,7 +183,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             CombatItem logStartNPCUpdate = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.LogStartNPCUpdate);
             if (logStartNPCUpdate != null)
             {
-                return logStartNPCUpdate.Time;
+                return GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, GenericTriggerID);
             }
             return GetGenericFightOffset(fightData);
         }

--- a/GW2EIEvtcParser/EncounterLogic/OpenWorld/SooWon.cs
+++ b/GW2EIEvtcParser/EncounterLogic/OpenWorld/SooWon.cs
@@ -48,7 +48,7 @@ namespace GW2EIEvtcParser.EncounterLogic.OpenWorld
             CombatItem logStartNPCUpdate = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.LogStartNPCUpdate);
             if (logStartNPCUpdate != null)
             {
-                return logStartNPCUpdate.Time;
+                return GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, agentData.GetGadgetsByID(ArcDPSEnums.TargetID.SooWonOW).FirstOrDefault());
             }
             return startToUse;
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfDeath.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfDeath.cs
@@ -75,7 +75,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 } 
                 else
                 {
-                    startToUse = logStartNPCUpdate.Time;
+                    startToUse = GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, eaterOfSouls);
                 }
             }
             return startToUse;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfIce.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfIce.cs
@@ -56,7 +56,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 } 
                 else
                 {
-                    startToUse = logStartNPCUpdate.Time;
+                    startToUse = GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, brokenKing);
                 }
             }
             return startToUse;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/ConjuredAmalgamate.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/ConjuredAmalgamate.cs
@@ -65,7 +65,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         if (logStartNPCUpdate != null)
                         {
                             // we couldn't have hit CA before the initial smash
-                            return firstArmSmash.Time > logStartNPCUpdate.Time ? logStartNPCUpdate.Time : firstArmSmash.Time;
+                            return firstArmSmash.Time > GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, agentData.GetGadgetsByID(_cn ? ArcDPSEnums.TargetID.ConjuredAmalgamate_CHINA : ArcDPSEnums.TargetID.ConjuredAmalgamate).FirstOrDefault()) ? logStartNPCUpdate.Time : firstArmSmash.Time;
                         } 
                         else
                         {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
@@ -224,7 +224,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     CombatItem firstDamageEvent = combatData.FirstOrDefault(x => x.DstMatchesAgent(target) && x.IsDamage() && x.Value > 0);
                     if (firstDamageEvent != null)
                     {
-                        return logStartNPCUpdate.Time;
+                        return GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, target);
                     }
                     else
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/SuperKodanBrothers.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/SuperKodanBrothers.cs
@@ -57,7 +57,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     throw new MissingKeyActorsException("Main target not found");
                 }
                 CombatItem firstCast = combatData.FirstOrDefault(x => x.SrcMatchesAgent(mainTarget) && x.IsActivation != ArcDPSEnums.Activation.None && x.Time <= logStartNPCUpdate.Time && x.SkillID != SkillIDs.WeaponStow && x.SkillID != SkillIDs.WeaponDraw);
-                if (startToUse == mainTarget.FirstAware && firstCast != null && combatData.Any(x => x.SrcMatchesAgent(mainTarget) && x.Time > logStartNPCUpdate.Time + ParserHelper.TimeThresholdConstant))
+                if (firstCast != null && combatData.Any(x => x.SrcMatchesAgent(mainTarget) && x.Time > logStartNPCUpdate.Time + ParserHelper.TimeThresholdConstant))
                 {
                     startToUse = firstCast.Time;
                 }

--- a/GW2EIEvtcParser/EncounterLogic/UnknownFightLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/UnknownFightLogic.cs
@@ -31,14 +31,15 @@ namespace GW2EIEvtcParser.EncounterLogic
             CombatItem logStartNPCUpdate = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.LogStartNPCUpdate);
             if (logStartNPCUpdate != null)
             {
-                return logStartNPCUpdate.Time;
+                AgentItem target = agentData.GetNPCsByID(GenericTriggerID).FirstOrDefault() ?? agentData.GetGadgetsByID(GenericTriggerID).FirstOrDefault();
+                return GetPostLogStartNPCUpdateDamageEventTime(fightData, agentData, combatData, logStartNPCUpdate.Time, target);
             }
             return GetGenericFightOffset(fightData);
         }
 
         internal override void ComputeFightTargets(AgentData agentData, List<CombatItem> combatItems, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)
         {
-            int id = GetTargetsIDs().First();
+            int id = GenericTriggerID;
             AgentItem agentItem = agentData.GetNPCsByID(id).FirstOrDefault();
             // Trigger ID is not NPC
             if (agentItem == null)


### PR DESCRIPTION
LogStartNPCUpdate is not tied to damage events since november-december 2022 as such there are edge cases where encounter start is off.
Updated the base logic to find the first damage event post LogStartNPCUpdate to keep existing logics working.