### PR TITLE
Boneskinner combat replay

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
@@ -114,7 +114,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             return phases;
         }
 
-        private static void AddTormentingBlassDecoration(CombatReplay replay, AbstractSingleActor target, int start, int attackEnd, Point3D point, int quarterAoE, int quarterHit)
+        private static void AddTormentingBlastDecoration(CombatReplay replay, AbstractSingleActor target, int start, int attackEnd, Point3D point, int quarterAoE, int quarterHit)
         {
             int startQuarter = start + quarterAoE;
             int endQuarter = start + quarterHit;
@@ -306,8 +306,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                             var frontalPoint = new Point3D(facingDirection.X, facingDirection.Y);
                             var leftPoint = new Point3D(facingDirection.Y * -1, facingDirection.X);
 
-                            AddTormentingBlassDecoration(replay, target, start, attackEnd, frontalPoint, firstQuarterAoe, firstQuarterHit); // Frontal
-                            AddTormentingBlassDecoration(replay, target, start, attackEnd, leftPoint, secondQuarterAoe, secondQuarterHit); // Left of frontal
+                            AddTormentingBlastDecoration(replay, target, start, attackEnd, frontalPoint, firstQuarterAoe, firstQuarterHit); // Frontal
+                            AddTormentingBlastDecoration(replay, target, start, attackEnd, leftPoint, secondQuarterAoe, secondQuarterHit); // Left of frontal
                         }
                     }
 

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
@@ -127,7 +127,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 ArcDPSEnums.TrashID.GuiltDemon,
                 ArcDPSEnums.TrashID.AiDoubtDemon,
                 ArcDPSEnums.TrashID.PlayerDoubtDemon,
-                ArcDPSEnums.TrashID.EnrageWaterSprite,
+                ArcDPSEnums.TrashID.EnragedWaterSprite,
                 // Transition sorrow demons
                 ArcDPSEnums.TrashID.TransitionSorrowDemon1,
                 ArcDPSEnums.TrashID.TransitionSorrowDemon2,

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
@@ -169,11 +169,11 @@ namespace GW2EIEvtcParser.EncounterLogic
                         replay.Decorations.Add(new CircleDecoration(true, 0, radius, (pullTime, finalTime), "rgba(250, 120, 0, 0.1)", new AgentConnector(target)));
                     }
                     // Cascade
-                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator1, 200, 40);
-                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator2, 400, 80);
-                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator3, 600, 120);
-                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator4, 800, 160);
-                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator5, 1000, 200);
+                    AddCascadeDecoration(log, replay, EffectGUIDs.CascadeAoEIndicator1, 200, 40);
+                    AddCascadeDecoration(log, replay, EffectGUIDs.CascadeAoEIndicator2, 400, 80);
+                    AddCascadeDecoration(log, replay, EffectGUIDs.CascadeAoEIndicator3, 600, 120);
+                    AddCascadeDecoration(log, replay, EffectGUIDs.CascadeAoEIndicator4, 800, 160);
+                    AddCascadeDecoration(log, replay, EffectGUIDs.CascadeAoEIndicator5, 1000, 200);
                     break;
                 case (int)ArcDPSEnums.TrashID.AberrantWisp:
                     break;
@@ -210,7 +210,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
         }
 
-        private static void AddCascadeDecoration(NPC target, ParsedEvtcLog log, CombatReplay replay, string guid, int width, int height)
+        private static void AddCascadeDecoration(ParsedEvtcLog log, CombatReplay replay, string guid, int width, int height)
         {
             if (log.CombatData.TryGetEffectEventsByGUID(guid, out IReadOnlyList<EffectEvent> rectangularIndicators))
             {
@@ -220,7 +220,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     int start = (int)indicator.Time;
                     int end = (int)indicator.Time + duration;
 
-                    ParametricPoint3D point = target.GetCombatReplayPolledRotations(log).Where(x => x.Time > start && x.Time < end).FirstOrDefault();
+                    ParametricPoint3D point = replay.PolledRotations.Where(x => x.Time > start && x.Time < end).FirstOrDefault();
                     if (point != null)
                     {
                         double radian = Math.Atan2(point.X, point.Y);

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Extensions;
@@ -95,6 +96,138 @@ namespace GW2EIEvtcParser.EncounterLogic
                     {
                         InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityHoldOntoTheLight], 1));
                         break;
+                    }
+                }
+            }
+        }
+
+        internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
+        {
+            IReadOnlyList<AbstractCastEvent> casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
+
+            switch (target.ID)
+            {
+                case (int)ArcDPSEnums.TargetID.Boneskinner:
+                    // Death Wind
+                    var deathWind = casts.Where(x => x.SkillId == DeathWind).ToList();
+                    foreach (AbstractCastEvent c in deathWind)
+                    {
+                        int castTime = 3330;
+                        int hitTime = 1179;
+                        int radius = 1500;
+                        int endHitTime = (int)c.Time + hitTime;
+                        int endCastTime = (int)c.Time + castTime;
+
+                        ParametricPoint3D lastDirection = replay.PolledRotations.LastOrDefault(x => x.Time > c.Time + 100 && x.Time < c.Time + 100 + castTime);
+                        if (lastDirection != null)
+                        {
+                            var direction = new Point3D(lastDirection.X, lastDirection.Y);
+                            // Growing Decoration
+                            replay.Decorations.Add(new PieDecoration(true, endHitTime, radius, direction, 30, ((int)c.Time, endHitTime), "rgba(250, 120, 0, 0.2)", new AgentConnector(target)));
+                            replay.Decorations.Add(new PieDecoration(true, 0, radius, direction, 30, ((int)c.Time, endHitTime), "rgba(250, 120, 0, 0.2)", new AgentConnector(target)));
+                            // Lingering AoE to match in game display
+                            replay.Decorations.Add(new PieDecoration(true, 0, radius, direction, 30, (endHitTime, endCastTime), "rgba(250, 60, 0, 0.1)", new AgentConnector(target)));
+                        }
+                    }
+                    // Crushing Cruelty
+                    var crushingCruelty = casts.Where(x => x.SkillId == CrushingCruelty).ToList();
+                    foreach (AbstractCastEvent c in crushingCruelty)
+                    {
+                        int hitTime = 2833;
+                        int radius = 1500;
+                        int endTime = (int)c.Time + hitTime;
+
+                        // Position of the jump back
+                        var jumpPosition = new Point3D((float)613.054, (float)-85.3458, (float)-7075.265);
+
+                        replay.Decorations.Add(new CircleDecoration(true, endTime, radius, ((int)c.Time, endTime), "rgba(250, 120, 0, 0.1)", new PositionConnector(jumpPosition)));
+                        replay.Decorations.Add(new CircleDecoration(true, 0, radius, ((int)c.Time, endTime), "rgba(250, 120, 0, 0.1)", new PositionConnector(jumpPosition)));
+                    }
+                    // Douse in Darkness
+                    var douseInDarkness = casts.Where(x => x.SkillId == DouseInDarkness).ToList();
+                    foreach (AbstractCastEvent c in douseInDarkness)
+                    {
+                        int jumpTime = 2500;
+                        int radius = 1500;
+                        int endJump = (int)c.Time + jumpTime;
+                        int pullTime = (int)c.Time + jumpTime + 1700;
+                        int finalTime = pullTime + 1500;
+                        int timings = 300;
+
+                        // Jump up
+                        replay.Decorations.Add(new CircleDecoration(true, endJump, radius, ((int)c.Time, endJump), "rgba(250, 120, 0, 0.1)", new AgentConnector(target)));
+                        replay.Decorations.Add(new CircleDecoration(true, 0, radius, ((int)c.Time, endJump), "rgba(250, 120, 0, 0.1)", new AgentConnector(target)));
+                        // Pull
+                        for (int i = 0; i < 4; i++)
+                        {
+                            int duration = (int)c.Time + jumpTime + timings * i;
+                            int end = (int)c.Time + jumpTime + timings * (i + 1);
+                            replay.Decorations.Add(new CircleDecoration(false, -duration, radius, (endJump, end), "rgba(255, 0, 0, 0.2)", new AgentConnector(target)));
+                        }
+                        // Landing
+                        replay.Decorations.Add(new CircleDecoration(true, finalTime, radius, (pullTime, finalTime), "rgba(255, 0, 0, 0.1)", new AgentConnector(target)));
+                        replay.Decorations.Add(new CircleDecoration(true, 0, radius, (pullTime, finalTime), "rgba(250, 120, 0, 0.1)", new AgentConnector(target)));
+                    }
+                    // Cascade
+                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator1, 200, 40);
+                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator2, 400, 80);
+                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator3, 600, 120);
+                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator4, 800, 160);
+                    AddCascadeDecoration(target, log, replay, EffectGUIDs.CascadeAoEIndicator5, 1000, 200);
+                    break;
+                case (int)ArcDPSEnums.TrashID.AberrantWisp:
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
+        {
+            // Grasp AoE Orange Indicator
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.GraspAoeIndicator, out IReadOnlyList<EffectEvent> indicators))
+            {
+                foreach (EffectEvent indicator in indicators)
+                {
+                    int duration = 1800;
+                    int start = (int)indicator.Time;
+                    int end = (int)indicator.Time + duration;
+                    EnvironmentDecorations.Add(new CircleDecoration(true, end, 100, (start, end), "rgba(250, 120, 0, 0.2)", new PositionConnector(indicator.Position)));
+                    EnvironmentDecorations.Add(new CircleDecoration(true, 0, 100, (start, end), "rgba(250, 120, 0, 0.2)", new PositionConnector(indicator.Position)));
+                }
+            }
+            // Grasp Claws Effect / Dark Red AoE
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.GraspClaws1, out IReadOnlyList<EffectEvent> claws))
+            {
+                foreach (EffectEvent claw in claws)
+                {
+                    int duration = 30000;
+                    int start = (int)claw.Time;
+                    int end = (int)claw.Time + duration;
+                    EnvironmentDecorations.Add(new CircleDecoration(true, 0, 100, (start, end), "rgba(71, 35, 32, 0.2)", new PositionConnector(claw.Position)));
+                    EnvironmentDecorations.Add(new DoughnutDecoration(true, 0, 95, 100, (start, end), "rgba(255, 0, 0, 0.2)", new PositionConnector(claw.Position)));
+                }
+            }
+        }
+
+        private static void AddCascadeDecoration(NPC target, ParsedEvtcLog log, CombatReplay replay, string guid, int width, int height)
+        {
+            if (log.CombatData.TryGetEffectEventsByGUID(guid, out IReadOnlyList<EffectEvent> rectangularIndicators))
+            {
+                foreach (EffectEvent indicator in rectangularIndicators)
+                {
+                    int duration = 360;
+                    int start = (int)indicator.Time;
+                    int end = (int)indicator.Time + duration;
+
+                    ParametricPoint3D point = target.GetCombatReplayPolledRotations(log).Where(x => x.Time > start && x.Time < end).FirstOrDefault();
+                    if (point != null)
+                    {
+                        double radian = Math.Atan2(point.X, point.Y);
+                        float degree = RadianToDegreeF(radian);
+
+                        replay.Decorations.Add(new RotatedRectangleDecoration(false, 0, width - 5, height - 5, -degree, (start, end), "rgba(255, 0, 0, 0.2)", new PositionConnector(indicator.Position)));
+                        replay.Decorations.Add(new RotatedRectangleDecoration(true, 0, width, height, -degree, (start, end), "rgba(250, 120, 0, 0.2)", new PositionConnector(indicator.Position)));
                     }
                 }
             }

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -911,7 +911,7 @@ namespace GW2EIEvtcParser
             CHOP = 16552,
             ProjectionArkk = 17613,
             // Ai
-            EnrageWaterSprite = 23270,
+            EnragedWaterSprite = 23270,
             TransitionSorrowDemon1 = 23265,
             TransitionSorrowDemon2 = 23242,
             TransitionSorrowDemon3 = 23279,

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -188,6 +188,16 @@ namespace GW2EIEvtcParser
         public const string CairnDashGreen = "D2E6D55CC94F79418BB907F063CBDD81";
         // CA
         public const string CAArmSmash = "B1AAD873DB07E04E9D69627156CA8918";
+        // Boneskinner
+        public const string GraspAoeIndicator = "B9B32815D670DC4E8B8CF71E92A9FFD5"; // Orange aoe indicator
+        public const string GraspClaws1 = "75B096EF78F3AB4CB1D05BAE9CA3235C"; // One is the claw, the other the red aoe indicator
+        public const string GraspClaws2 = "4C290CBF719C0E448391E9415EF307A7";
+        public const string CascadeBonesEffect = "3E370A8629BB134F83902A8F14B99CCE";
+        public const string CascadeAoEIndicator1 = "4692619BBBFE6346B409C4A2B93B9BA6";
+        public const string CascadeAoEIndicator2 = "8E8592D62B48834180C66FE806278C86";
+        public const string CascadeAoEIndicator3 = "89CB4BCA7B012244B0864DFAD7E9F3AC";
+        public const string CascadeAoEIndicator4 = "965355FD1C53F24085A9C422B8333780";
+        public const string CascadeAoEIndicator5 = "F26A2240C0F1E24E81EAEFDE64EFA3BF";
         // Ankka
         public const string DeathsEmbrace = "4AC57C4159E0804D8DBEB6F0F39F5EF3";
         public const string DeathsHandOnPlayerCM = "9A64DC8F21EEC046BA1D4412863F2940";

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -336,6 +336,8 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashAiDoubt = "https://i.imgur.com/IKmpccC.png";
         private const string TrashGuilt = "https://i.imgur.com/ko7137g.png";
         private const string TrashTransitionSorrow = "https://i.imgur.com/2rrUxX7.png";
+        private const string TrashEnragedWaterSprite = "https://i.imgur.com/TQ5vOrg.png";
+        //private const string TrashBoulders = "https://i.imgur.com/OAFzpxC.png"; // For future usage - 100CM boulders
 
         // Minion NPC Icons
         private const string MinionHoundOfBalthazar = "https://i.imgur.com/FFSYrzL.png";
@@ -766,6 +768,7 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.DoppelgangerWarrior2, TrashDoppelgangerWarrior },
             { ArcDPSEnums.TrashID.CharrTank, TrashGenericRedEnemySkull },
             { ArcDPSEnums.TrashID.PropagandaBallon, TrashGenericRedEnemySkull },
+            { ArcDPSEnums.TrashID.EnragedWaterSprite, TrashEnragedWaterSprite },
             { ArcDPSEnums.TrashID.FearDemon, TrashFear },
             { ArcDPSEnums.TrashID.GuiltDemon, TrashGuilt },
             { ArcDPSEnums.TrashID.AiDoubtDemon, TrashAiDoubt },


### PR DESCRIPTION
- Added decorations for Death Wind, Crushing Cruelty, Douse in Darkness, Cascade and Grasp
- Fixed a couple of typos
- Added a missing image for 100cm
- For Cascade, i have approssimated the aoe size based on this video https://youtu.be/os49oKKG0X8 and corrisponding log [20230531-160923.zip](https://github.com/baaron4/GW2-Elite-Insights-Parser/files/11618866/20230531-160923.zip) if you wanna take a look at the measurements
- The combay replay map is currently not scaled correctly and a bit squished (also for kodans and fraenir i believe), linus will take care of it in the next few days and re-draw it.