### PR TITLE
Added Magnetic Inversion, Spectral Recall and Lesser Banish Enchantment

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
@@ -1510,6 +1510,7 @@
         internal const string HeatLvl1 = "https://i.imgur.com/nNQEVpb.png";
         internal const string HeatLvl2 = "https://i.imgur.com/LgfmRM4.png";
         internal const string HeatLvl3 = "https://i.imgur.com/Ti4NWys.png";
+        internal const string NecroticTraversal = "https://wiki.guildwars2.com/images/9/98/Necrotic_Traversal.png";
         // Consumables
         internal const string ReinforcedArmor = "https://wiki.guildwars2.com/images/8/83/Reinforced_Armor.png";
         internal const string SpeedBonus15 = "https://wiki.guildwars2.com/images/d/d7/Speed_Bonus_%28fifteen_percent%29.png";

--- a/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
@@ -1511,6 +1511,7 @@
         internal const string HeatLvl2 = "https://i.imgur.com/LgfmRM4.png";
         internal const string HeatLvl3 = "https://i.imgur.com/Ti4NWys.png";
         internal const string NecroticTraversal = "https://wiki.guildwars2.com/images/9/98/Necrotic_Traversal.png";
+        internal const string GrimSpecter = "https://wiki.guildwars2.com/images/3/30/Grim_Specter.png";
         // Consumables
         internal const string ReinforcedArmor = "https://wiki.guildwars2.com/images/8/83/Reinforced_Armor.png";
         internal const string SpeedBonus15 = "https://wiki.guildwars2.com/images/d/d7/Speed_Bonus_%28fifteen_percent%29.png";

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
+using static GW2EIEvtcParser.EIData.CastFinderHelpers;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 
@@ -55,6 +56,10 @@ namespace GW2EIEvtcParser.EIData
             new BuffGainCastFinder(SlickShoesSkill, SlickShoesEffect),
             new BuffGainCastFinder(IncendiaryAmmoSkill, IncendiaryAmmoEffect),
             new DamageCastFinder(OverchargedShot, OverchargedShot),
+            new DamageCastFinder(MagneticInversion, MagneticInversion).UsingDisableWithEffectData(),
+            new EffectCastFinderByDst(MagneticInversion, EffectGUIDs.EngineerMagneticInversion)
+                .UsingDstBaseSpecChecker(Spec.Engineer)
+                .UsingChecker((effect, combatData, agentData, skillData) => HasLostBuff(combatData, Absorb, effect.Dst, effect.Time)),
             // Kits
             new EngineerKitFinder(BombKit),
             new EngineerKitFinder(ElixirGun),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -86,6 +86,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Spectral Walk (Teleport)", SpectralWalkTeleportBuff, Source.Necromancer, BuffClassification.Other, BuffImages.SpectralWalk).WithBuilds(GW2Builds.December2018Balance, GW2Builds.EndOfLife),
             new Buff("Spectral Armor", SpectralArmorEffect, Source.Necromancer, BuffClassification.Other, BuffImages.SpectralArmor),
             new Buff("Locust Swarm", LocustSwarm, Source.Necromancer, BuffClassification.Other, BuffImages.LocustSwarm),
+            new Buff("Grim Specter", GrimSpecterBuff, Source.Necromancer, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.GrimSpecter),
             // Traits
             new Buff("Corrupter's Defense", CorruptersDefense, Source.Necromancer, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.CorruptersFervor).WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2019Balance),
             new Buff("Death's Carapace", DeathsCarapace, Source.Necromancer, BuffStackType.Stacking, 30, BuffClassification.Other, BuffImages.DeathsCarapace).WithBuilds(GW2Builds.October2019Balance, GW2Builds.EndOfLife),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using GW2EIEvtcParser.EIData.Buffs;
+using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
@@ -28,6 +30,9 @@ namespace GW2EIEvtcParser.EIData
             new BuffGainCastFinder(SpectralArmorSkill, SpectralArmorEffect).WithBuilds(GW2Builds.December2018Balance),
             new BuffGainCastFinder(SpectralWalkSkill, SpectralWalkEffectOld).WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2018Balance),
             new BuffGainCastFinder(SpectralWalkSkill, SpectralWalkEffect).WithBuilds(GW2Builds.December2018Balance),
+            new BuffLossCastFinder(SpectralRecallSkill, SpectralWalkTeleportBuff)
+                .UsingChecker((evt, combatData, skillData, agentData) => !FindRelatedEvents(combatData.GetBuffData(SpectralWalkEffect).OfType<BuffRemoveAllEvent>(), evt.Time + 120).Any())
+                .WithBuilds(GW2Builds.December2018Balance),
             new EffectCastFinderByDst(PlagueSignetSkill, EffectGUIDs.NecromancerPlagueSignet).UsingDstBaseSpecChecker(Spec.Necromancer),
             
             // Minions

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -80,8 +80,10 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Signet of Undeath", SignetOfUndeath, Source.Necromancer, BuffClassification.Other, BuffImages.SignetOfUndeath),
             new Buff("Signet of Undeath (Shroud)", SignetOfUndeathShroud, Source.Necromancer, BuffClassification.Other, BuffImages.SignetOfUndeath),
             // Skills
-            new Buff("Spectral Walk", SpectralWalkEffectOld, Source.Necromancer, BuffClassification.Other, BuffImages.SpectralWalk).WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2018Balance),
+            new Buff("Spectral Walk", SpectralWalkEffectOld, Source.Necromancer, BuffClassification.Other, BuffImages.NecroticTraversal).WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2018Balance),
+            new Buff("Spectral Walk", SpectralWalkEffectOld, Source.Necromancer, BuffClassification.Other, BuffImages.SpectralWalk).WithBuilds(GW2Builds.July2018Balance, GW2Builds.December2018Balance),
             new Buff("Spectral Walk", SpectralWalkEffect, Source.Necromancer, BuffClassification.Other, BuffImages.SpectralWalk).WithBuilds(GW2Builds.December2018Balance, GW2Builds.EndOfLife),
+            new Buff("Spectral Walk (Teleport)", SpectralWalkTeleportBuff, Source.Necromancer, BuffClassification.Other, BuffImages.SpectralWalk).WithBuilds(GW2Builds.December2018Balance, GW2Builds.EndOfLife),
             new Buff("Spectral Armor", SpectralArmorEffect, Source.Necromancer, BuffClassification.Other, BuffImages.SpectralArmor),
             new Buff("Locust Swarm", LocustSwarm, Source.Necromancer, BuffClassification.Other, BuffImages.LocustSwarm),
             // Traits

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -28,6 +28,7 @@ namespace GW2EIEvtcParser.EIData
             new DamageCastFinder(CallOfTheAssassin, CallOfTheAssassin), // Call of the Assassin
             new DamageCastFinder(CallOfTheDwarf, CallOfTheDwarf), // Call of the Dwarf
             new DamageCastFinder(CallOfTheDemon, CallOfTheDemon), // Call of the Demon
+            new DamageCastFinder(LesserBanishEnchantment, LesserBanishEnchantment).WithBuilds(GW2Builds.December2018Balance, GW2Builds.February2020Balance),
             new EXTHealingCastFinder(CallOfTheCentaur, CallOfTheCentaur), // Call of the Centaur
             new EffectCastFinder(ProjectTranquility, EffectGUIDs.RevenantTabletAutoHeal).UsingChecker((evt, combatData, agentData, skillData) => evt.Src.IsSpecies(MinionID.VentariTablet)),
             new EffectCastFinderByDstFromMinion(VentarisWill, EffectGUIDs.RevenantTabletVentarisWill).UsingChecker((evt, combatData, agentData, skillData) => evt.Dst.IsSpecies(MinionID.VentariTablet)),

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -301,6 +301,7 @@ namespace GW2EIEvtcParser.ParsedData
             { DeathDropDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
             { SaintsShieldDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
             { ImperialImpactDodge, "https://wiki.guildwars2.com/images/archive/b/b2/20150601155307%21Dodge.png" },
+            { LesserBanishEnchantment, "https://wiki.guildwars2.com/images/e/ec/Banish_Enchantment.png" },
             // Thief
             { ThrowMagneticBomb, "https://wiki.guildwars2.com/images/e/e7/Throw_Magnetic_Bomb.png" },
             { DetonatePlasma, "https://wiki.guildwars2.com/images/3/3d/Detonate_Plasma.png" },
@@ -367,28 +368,28 @@ namespace GW2EIEvtcParser.ParsedData
         };
 
         private static readonly Dictionary<long, ulong> _nonCritable = new Dictionary<long, ulong>
-                    {
-                        { LightningStrikeSigil, GW2Builds.StartOfLife }, 
-                        { FlameBlastSigil, GW2Builds.StartOfLife },
-                        { FireAttunementSkill, GW2Builds.December2018Balance }, 
-                        { Mug, GW2Builds.StartOfLife },
-                        { PulmonaryImpactSkill, GW2Builds.HoTRelease },
-                        { ConjuredSlashPlayer, GW2Builds.StartOfLife },
-                        { LightningJolt, GW2Builds.StartOfLife },
-                        { Sunspot, GW2Builds.December2018Balance },
-                        { EarthenBlast, GW2Builds.December2018Balance },
-                        { ChillingNova, GW2Builds.December2018Balance },
-                                         // Spontaneous Destruction GW2Builds.December2018Balance
-                        {LesserEnfeeble, GW2Builds.December2018Balance },
-                        {SpitefulSpirit, GW2Builds.December2018Balance },
-                        {LesserSpinalShivers, GW2Builds.December2018Balance }, 
-                                         // Power block GW2Builds.December2018Balance
-                        {ShatteredAegis, GW2Builds.December2018Balance }, 
-                        {GlacialHeart, GW2Builds.December2018Balance }, 
-                        {ThermalReleaseValve, GW2Builds.December2018Balance },
-                        {LossAversion, GW2Builds.December2018Balance },
-                        // 
-                    };
+        {
+            { LightningStrikeSigil, GW2Builds.StartOfLife }, 
+            { FlameBlastSigil, GW2Builds.StartOfLife },
+            { FireAttunementSkill, GW2Builds.December2018Balance }, 
+            { Mug, GW2Builds.StartOfLife },
+            { PulmonaryImpactSkill, GW2Builds.HoTRelease },
+            { ConjuredSlashPlayer, GW2Builds.StartOfLife },
+            { LightningJolt, GW2Builds.StartOfLife },
+            { Sunspot, GW2Builds.December2018Balance },
+            { EarthenBlast, GW2Builds.December2018Balance },
+            { ChillingNova, GW2Builds.December2018Balance },
+            { LesserBanishEnchantment, GW2Builds.December2018Balance },
+            { LesserEnfeeble, GW2Builds.December2018Balance },
+            { SpitefulSpirit, GW2Builds.December2018Balance },
+            { LesserSpinalShivers, GW2Builds.December2018Balance },
+            { PowerBlock, GW2Builds.December2018Balance },
+            { ShatteredAegis, GW2Builds.December2018Balance }, 
+            { GlacialHeart, GW2Builds.December2018Balance }, 
+            { ThermalReleaseValve, GW2Builds.December2018Balance },
+            { LossAversion, GW2Builds.December2018Balance },
+            { Epidemic, GW2Builds.May2017Balance },
+        };
 
         private const string DefaultIcon = "https://render.guildwars2.com/file/1D55D34FB4EE20B1962E315245E40CA5E1042D0E/62248.png";
 

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -13,6 +13,7 @@ namespace GW2EIEvtcParser
             //
             internal const ulong HoTRelease = 54485;
             internal const ulong February2017Balance = 72781;
+            internal const ulong May2017Balance = 76706;
             internal const ulong December2017Balance = 84832;
             internal const ulong February2018Balance = 86181;
             internal const ulong May2018Balance = 88541;

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -121,6 +121,7 @@ namespace GW2EIEvtcParser
         public const string DragonhunterFragmentsOfFaith = "C84644DDAA59E542989FDB98CD69134C";
         // Engineer
         public const string EngineerHealingMist = "B02D3D0FF0A4FC47B23B1478D8E770AE";
+        public const string EngineerMagneticInversion = "F8BD502E5B0D9444AA6DC5B5918801EE";
         public const string ScrapperBulwarkGyro = "611D90C69ECF8142BEEE84139F333388";
         public const string ScrapperPurgeGyro = "0DBE4F7115EADC4889F1E00232B2398B";
         public const string ScrapperDefenseField = "9E2D190A92E2B5498A88722910A9DECD";

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -182,6 +182,7 @@
         public const long StaticShield = 6055;
         public const long Absorb = 6056;
         public const long RocketTurretDamage = 6108;
+        public const long MagneticInversion = 6126;
         public const long OverchargedShot = 6154;
         public const long SupplyCrateUW = 6183;
         public const long HaresSpeedSkill = 6221;
@@ -647,6 +648,8 @@
         public const long LifeLeechUW = 10640;
         public const long GatheringPlague = 10643;
         public const long SpectralWalkSkill = 10685;
+        public const long SpectralWalkTeleportBuff = 10686;
+        public const long SpectralRecallSkill = 10687;
         public const long UnholyFeast = 10701;
         public const long Technobabble = 12318;
         public const long PowerSuit = 12326;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -639,6 +639,7 @@
         public const long HauntSkill = 10590;
         public const long LifeTransfer = 10594;
         public const long NecroticTraversal = 10600;
+        public const long Epidemic = 10606;
         public const long SignetOfUndeath = 10610;
         public const long SignetOfTheLocust = 10614;
         public const long DeadlyFeast = 10619;
@@ -736,6 +737,7 @@
         public const long ArcaneLightning = 13423;
         public const long SelflessDaring = 13594;
         public const long LesserSymbolOfProtection = 13684;
+        public const long PowerBlock = 13752;
         public const long StrengthinNumbers = 13796;
         public const long FleshOfTheMaster = 13810;
         public const long LesserSpinalShivers = 13906;
@@ -1003,6 +1005,7 @@
         public const long FacetOfElementsEffect = 28243;
         public const long EnchantedDaggers2 = 28313;
         public const long RelinquishPower = 28382;
+        public const long LesserBanishEnchantment = 28388;
         public const long FacetOfDarknessSkill = 28379;
         public const long PhaseTraversal = 28395;
         public const long LegendaryDwarfStanceSkill = 28419;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1807,6 +1807,7 @@
         public const long Chapter3HeatedRebuke = 42449;
         public const long LesserSignetOfStone = 42470;
         public const long BerserkersPower = 42539;
+        public const long GrimSpecterBuff = 42651;
         public const long UnravelEffect = 42683;
         public const long HiddenKiller = 42720;
         public const long Kneeling = 42869;


### PR DESCRIPTION
- For Magnetic Inversion it checks the loss of the absorption buff and the visual effect, for logs pre-effcts it's restricted to checking for a damage hit.
- For Spectral Recall, i've restricted it to post december 2018 builds because i don't know the behaviour of the skill was before that. There is a hidden buff 10686 that is lost upon teleporting back or when spectral walk duration runs off. The 10686 buff gets removed 120ms before the Spectral Walk buff is removed, meaning you can safely let the skill run out and it won't trigger Recall.
In this example i've let it run out 3 times, used recall 3 times, ran out once and recalled once
![5455](https://github.com/baaron4/GW2-Elite-Insights-Parser/assets/23245218/332355e5-50f9-4eda-8f89-90a01ee01020)
- Added some missing non-crittables
- Added Lesser Banish Enchantments to revenant
- Added Grim Specter buff
