### PR TITLE
Ai improvements

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
@@ -311,20 +311,19 @@ namespace GW2EIEvtcParser.EncounterLogic
                         phase.AddTarget(elementalAi);
                         if (i > 0)
                         {
-                            // try to use later of the two transition skills, fallback to first or to determined loss
+                            // try to use transition skill, fallback to determined loss
+                            // long skillId = _china ? 61388 : 61385;
                             long skillID = 61187;
-                            long fallbackSkillId = _china ? 61388 : 61385;
                             IReadOnlyList<AbstractCastEvent> casts = elementalAi.GetCastEvents(log, phase.Start, phase.End);
                             // use last cast since determined is fixed 5s and the transition out (ai flying up) can happen after loss
                             AbstractCastEvent castEvt = casts.LastOrDefault(x => x.SkillId == skillID);
-                            AbstractCastEvent fallbackCastEvt = casts.LastOrDefault(x => x.SkillId == fallbackSkillId);
                             if (castEvt != null)
                             {
                                 phase.OverrideStart(castEvt.Time);
                             }
-                            else if (fallbackCastEvt != null)
+                            else
                             {
-                                phase.OverrideStart(fallbackCastEvt.Time);
+                                phase.Name += " (Fallback)";
                             }
                         }
                     }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
@@ -306,21 +306,26 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var elementalPhases = GetPhasesByInvul(log, Determined762, elementalAi, false, true, log.FightData.FightStart, elementalAi.LastAware).Take(3).ToList();
                     for (int i = 0; i < elementalPhases.Count; i++)
                     {
-                        elementalPhases[i].Name = eleNames[i];
+                        PhaseData phase = elementalPhases[i];
+                        phase.Name = eleNames[i];
+                        phase.AddTarget(elementalAi);
                         if (i > 0)
                         {
-                            //long skillID = _china ? 61388 : 61385;
+                            // try to use later of the two transition skills, fallback to first or to determined loss
                             long skillID = 61187;
-                            AbstractCastEvent castEvt = elementalAi.GetCastEvents(log, eleStart, eleEnd).FirstOrDefault(x => x.SkillId == skillID && x.Time >= elementalPhases[i].Start && x.Time <= elementalPhases[i].End);
+                            long fallbackSkillId = _china ? 61388 : 61385;
+                            IReadOnlyList<AbstractCastEvent> casts = elementalAi.GetCastEvents(log, phase.Start, phase.End);
+                            // use last cast since determined is fixed 5s and the transition out (ai flying up) can happen after loss
+                            AbstractCastEvent castEvt = casts.LastOrDefault(x => x.SkillId == skillID);
+                            AbstractCastEvent fallbackCastEvt = casts.LastOrDefault(x => x.SkillId == fallbackSkillId);
                             if (castEvt != null)
                             {
-                                elementalPhases[i].OverrideStart(castEvt.Time);
-                                elementalPhases[i].AddTarget(elementalAi);
+                                phase.OverrideStart(castEvt.Time);
                             }
-                        } 
-                        else
-                        {
-                            elementalPhases[i].AddTarget(elementalAi);
+                            else if (fallbackCastEvt != null)
+                            {
+                                phase.OverrideStart(fallbackCastEvt.Time);
+                            }
                         }
                     }
                     phases.AddRange(elementalPhases);


### PR DESCRIPTION
Fixes incorrect phase start detections when transition out cast happened after Determined was lost.
Adds a fallback phase to Determined loss when cast not found. Any idea for a better fallback phase name?