### PR TITLE
Overhead decorations 2

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -162,6 +162,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Corruption", Corruption1, Source.FightSpecific, BuffClassification.Other, BuffImages.LocustTrail),
             new Buff("Corruption 2", Corruption2, Source.FightSpecific, BuffClassification.Other, BuffImages.LocustTrail),
             new Buff("Sacrifice", MatthiasSacrifice, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Sacrifice Selection", MatthiasSacrificeSelection, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
             new Buff("Unbalanced", Unbalanced, Source.FightSpecific, BuffClassification.Other, BuffImages.Unbalanced),
             new Buff("Zealous Benediction", ZealousBenediction, Source.FightSpecific, BuffClassification.Other, BuffImages.Unstable),
             new Buff("Snowstorm", SnowstormBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.Snowstorm),
@@ -247,6 +248,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Form Up and Advance!", FormUpAndAdvance, Source.FightSpecific, BuffClassification.Other, BuffImages.FormUpAndAdvance),
             new Buff("Devour", Devour, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.Devour),
             new Buff("Unseen Burden (Deimos)", UnseenBurdenDeimos, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.UnseenBurdenDeimos),
+            new Buff("Green Selection", DeimosSelectedByGreen, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
             //////////////////////////////////////////////
             // Soulless Horror
             new Buff("Exile's Embrace", ExilesEmbrace, Source.FightSpecific, BuffClassification.Other, BuffImages.ExilesEmbrace),
@@ -383,9 +385,11 @@ namespace GW2EIEvtcParser.EIData
             // Shattered Observatory
             new Buff("Achievement Eligibility: Be Dynamic", AchievementEligibilityBeDynamic, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             new Buff("Cosmic Energy", CosmicEnergy, Source.FightSpecific, BuffClassification.Other, BuffImages.BreakOut),
+            // Skorvald
+            new Buff("Skorvald's Ire", SkorvaldsIre, Source.FightSpecific, BuffClassification.Other, BuffImages.Fixated),
             // Artsariiv
             new Buff("Enraged (Fractal)", EnragedFractal, Source.FightSpecific, BuffClassification.Other, BuffImages.Enraged),
-            new Buff("Corporeal Reassignment", CorporealReassignment, Source.FightSpecific, BuffClassification.Other, BuffImages.RedirectAnomaly),
+            new Buff("Corporeal Reassignment", CorporealReassignmentBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.RedirectAnomaly),
             new Buff("Blinding Radiance", BlindingRadiance, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
             new Buff("Determination (Viirastra)", DeterminationViirastra, Source.FightSpecific, BuffClassification.Other, BuffImages.GambitExhausted),
             // Arkk 

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -255,6 +256,16 @@ namespace GW2EIEvtcParser.EncounterLogic
                 case (int)TrashID.NightmareHallucinationSiax:
                     break;
                 default: break;
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Fixations
+            IEnumerable<Segment> fixations = p.GetBuffStatus(log, FixatedNightmare, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in fixations)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, segment, new AgentConnector(p)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
@@ -4,6 +4,7 @@ using System;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -29,7 +30,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             new PlayerDstHitMechanic(new long[] { StarbustCascade1, StarbustCascade2 }, "Starburst Cascade", new MechanicPlotlySetting(Symbols.CircleOpen,Colors.LightOrange), "Float Ring","Starburst Cascade (Expanding/Retracting Lifting Ring)", "Float Ring",500),
             new PlayerDstHitMechanic(HorizonStrikeNormal, "Horizon Strike Normal", new MechanicPlotlySetting(Symbols.Circle,Colors.DarkRed), "Horizon Strike norm","Horizon Strike (normal)", "Horizon Strike (normal)",0),
             new PlayerDstHitMechanic(OverheadSmash, "Overhead Smash", new MechanicPlotlySetting(Symbols.TriangleLeft,Colors.LightRed), "Smash","Overhead Smash","Overhead Smash",0),
-            new PlayerDstBuffApplyMechanic(CorporealReassignment, "Corporeal Reassignment", new MechanicPlotlySetting(Symbols.Diamond,Colors.Red), "Skull","Exploding Skull mechanic application", "Corporeal Reassignment",0),
+            new PlayerDstBuffApplyMechanic(CorporealReassignmentBuff, "Corporeal Reassignment", new MechanicPlotlySetting(Symbols.Diamond,Colors.Red), "Skull","Exploding Skull mechanic application", "Corporeal Reassignment",0),
             new PlayerDstHitMechanic(ExplodeArkk, "Explode", new MechanicPlotlySetting(Symbols.Circle,Colors.Yellow), "Bloom Explode","Hit by Solar Bloom explosion", "Bloom Explosion",0),
             new PlayerDstBuffApplyMechanic(new long[] {FixatedBloom1, FixatedBloom2, FixatedBloom3, FixatedBloom4}, "Fixate", new MechanicPlotlySetting(Symbols.StarOpen,Colors.Magenta), "Bloom Fix","Fixated by Solar Bloom", "Bloom Fixate",0),
             new PlayerDstBuffApplyMechanic(CosmicMeteor, "Cosmic Meteor", new MechanicPlotlySetting(Symbols.CircleOpen,Colors.Green), "Green","Temporal Realignment (Green) application", "Green",0),
@@ -193,6 +194,22 @@ namespace GW2EIEvtcParser.EncounterLogic
             if (counter == 5)
             {
                 InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityBeDynamic], 1));
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Corporeal Reassignment
+            IEnumerable<Segment> corpReass = p.GetBuffStatus(log, CorporealReassignmentBuff, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in corpReass)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.SkullOverhead, 20, 1, segment, new AgentConnector(p)));
+            }
+            // Fixations
+            IEnumerable<Segment> fixations = p.GetBuffStatus(log, new long[] { FixatedBloom1, FixatedBloom2, FixatedBloom3, FixatedBloom4 }, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in fixations)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, segment, new AgentConnector(p)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -4,6 +4,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -19,7 +20,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             MechanicList.AddRange(new List<Mechanic>
             {
-            new PlayerDstBuffApplyMechanic(CorporealReassignment, "Corporeal Reassignment", new MechanicPlotlySetting(Symbols.DiamondTall,Colors.Red), "Skull","Exploding Skull mechanic application","Corporeal Reassignment",0),
+            new PlayerDstBuffApplyMechanic(CorporealReassignmentBuff, "Corporeal Reassignment", new MechanicPlotlySetting(Symbols.DiamondTall,Colors.Red), "Skull","Exploding Skull mechanic application","Corporeal Reassignment",0),
             new PlayerDstHitMechanic(VaultArtsariiv, "Vault", new MechanicPlotlySetting(Symbols.TriangleDownOpen,Colors.Yellow), "Vault","Vault from Big Adds", "Vault (Add)",0),
             new PlayerDstHitMechanic(SlamArtsariiv, "Slam", new MechanicPlotlySetting(Symbols.Circle,Colors.LightOrange), "Slam","Slam (Vault) from Boss", "Vault (Arts)",0),
             new PlayerDstHitMechanic(TeleportLunge, "Teleport Lunge", new MechanicPlotlySetting(Symbols.StarTriangleDownOpen,Colors.LightOrange), "3 Jump","Triple Jump Mid->Edge", "Triple Jump",0),
@@ -195,6 +196,16 @@ namespace GW2EIEvtcParser.EncounterLogic
                 throw new MissingKeyActorsException("Artsariiv not found");
             }
             SetSuccessByBuffCount(combatData, fightData, GetParticipatingPlayerAgents(target, combatData, playerAgents), target, Determined762, 4);
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Corporeal Reassignment
+            IEnumerable<Segment> corpReass = p.GetBuffStatus(log, CorporealReassignmentBuff, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in corpReass)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.SkullOverhead, 20, 1, segment, new AgentConnector(p)));
+            }
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -573,6 +574,16 @@ namespace GW2EIEvtcParser.EncounterLogic
                     int attackEnd = start + aoeTimeout;
                     EnvironmentDecorations.Add(new CircleDecoration(true, 0, aoeRadius, (start, attackEnd), "rgba(250, 120, 0, 0.2)", new PositionConnector(mistBombEffect.Position)));
                 }
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Fixations
+            IEnumerable<Segment> fixations = p.GetBuffStatus(log, new long[] { FixatedBloom1, SkorvaldsIre }, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in fixations)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, segment, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
@@ -319,11 +319,11 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
 
             // Target Order Overhead
-            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder1, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder1Overhead);
-            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder2, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder2Overhead);
-            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder3, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder3Overhead);
-            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder4, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder4Overhead);
-            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder5, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder5Overhead);
+            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder1, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder1Overhead);
+            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder2, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder2Overhead);
+            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder3, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder3Overhead);
+            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder4, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder4Overhead);
+            AddTargetOrderDecoration(player, replay, player.GetBuffStatus(log, TargetOrder5, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder5Overhead);
         }
 
         internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
@@ -423,14 +423,11 @@ namespace GW2EIEvtcParser.EncounterLogic
         /// <param name="replay">Combat Replay.</param>
         /// <param name="targets">The <see cref="Segment"/> where the Target Order buff appears.</param>
         /// <param name="icon">The icon related to the respective Target Order buff.</param>
-        private static void AddTargetOrderDecoration(AbstractPlayer player, CombatReplay replay, IReadOnlyList<Segment> targets, string icon)
+        private static void AddTargetOrderDecoration(AbstractPlayer player, CombatReplay replay, IEnumerable<Segment> targets, string icon)
         {
             foreach (Segment target in targets)
             {
-                if (target.Value > 0)
-                {
-                    replay.Decorations.Add(new IconOverheadDecoration(icon, 20, 1, target, new AgentConnector(player)));
-                }
+                replay.Decorations.Add(new IconOverheadDecoration(icon, 20, 1, target, new AgentConnector(player)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.EncounterLogic.EncounterCategory;
@@ -12,7 +13,6 @@ using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
-using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -429,7 +429,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 if (target.Value > 0)
                 {
-                    replay.Decorations.Add(new IconOverheadDecoration(icon, 12, 1, target, new AgentConnector(player)));
+                    replay.Decorations.Add(new IconOverheadDecoration(icon, 20, 1, target, new AgentConnector(player)));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
@@ -116,7 +116,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             IEnumerable<Segment> segments = p.GetBuffStatus(log, SpectralDarkness, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
             foreach (Segment segment in segments)
             {
-                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.SpectralDarkness, 20, 1, segment, new AgentConnector(p)));
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.SpectralDarknessOverhead, 20, 1, segment, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
-using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -116,7 +116,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             IEnumerable<Segment> segments = p.GetBuffStatus(log, SpectralDarkness, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
             foreach (Segment segment in segments)
             {
-                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.SpectralDarkness, 12, 1, segment, new AgentConnector(p)));
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.SpectralDarkness, 20, 1, segment, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
@@ -9,6 +9,7 @@ using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
+using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -46,7 +47,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(HauntingAura, HauntingAura), // Haunting Aura
+                new DamageCastFinder(HauntingAura, HauntingAura),
             };
         }
         internal override List<PhaseData> GetPhases(ParsedEvtcLog log, bool requirePhases)
@@ -104,10 +105,18 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
         {
+            // Ghastly Prison - Eggs AoEs
             var eggs = p.GetBuffStatus(log, GhastlyPrison, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
             foreach (Segment seg in eggs)
             {
                 replay.Decorations.Add(new CircleDecoration(true, 0, 180, seg, "rgba(255, 160, 0, 0.3)", new AgentConnector(p)));
+            }
+
+            // Spectral Darkness - Orbs Debuff Overhead
+            IEnumerable<Segment> segments = p.GetBuffStatus(log, SpectralDarkness, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in segments)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.SpectralDarkness, 12, 1, segment, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
-using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -233,8 +233,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 replay.Decorations.Add(new CircleDecoration(false, 0, 180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(p)));
                 replay.Decorations.Add(new CircleDecoration(true, (int)seg.Start + 5000, 180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(p)));
-                // Overhead decoration
-                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.BombOverhead, 12, 1, seg, new AgentConnector(p)));
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.BombOverhead, 20, 1, seg, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -9,6 +9,7 @@ using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
+using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -232,6 +233,8 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 replay.Decorations.Add(new CircleDecoration(false, 0, 180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(p)));
                 replay.Decorations.Add(new CircleDecoration(true, (int)seg.Start + 5000, 180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(p)));
+                // Overhead decoration
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.BombOverhead, 12, 1, seg, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -243,9 +243,9 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
         {
             // Attunements Overhead
-            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementBlue, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorBlue);
-            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementGreen, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorGreen);
-            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementRed, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorRed);
+            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementBlue, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorBlueOverhead);
+            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementGreen, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorGreenOverhead);
+            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementRed, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorRedOverhead);
         }
 
         /// <summary>

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -10,6 +10,7 @@ using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
+using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -236,6 +237,29 @@ namespace GW2EIEvtcParser.EncounterLogic
                     break;
                 default:
                     break;
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Target Order Overhead
+            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementBlue, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorBlue);
+            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementGreen, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorGreen);
+            AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementRed, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorRed);
+        }
+
+        /// <summary>
+        /// Adds the Pylon Attunement overhead decoration.
+        /// </summary>
+        /// <param name="player">Player for the decoration.</param>
+        /// <param name="replay">Combat Replay.</param>
+        /// <param name="segments">The <see cref="Segment"/> where the Pylon Attunement buff appears.</param>
+        /// <param name="icon">The icon related to the respective Pylon Attunement buff.</param>
+        private static void AddPylonAttunementDecoration(AbstractPlayer player, CombatReplay replay, IEnumerable<Segment> segments, string icon)
+        {
+            foreach (Segment segment in segments)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(icon, 12, 1, segment, new AgentConnector(player)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -5,12 +5,12 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
-using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -242,7 +242,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
         {
-            // Target Order Overhead
+            // Attunements Overhead
             AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementBlue, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorBlue);
             AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementGreen, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorGreen);
             AddPylonAttunementDecoration(p, replay, p.GetBuffStatus(log, PylonAttunementRed, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.SensorRed);
@@ -259,7 +259,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             foreach (Segment segment in segments)
             {
-                replay.Decorations.Add(new IconOverheadDecoration(icon, 12, 1, segment, new AgentConnector(player)));
+                replay.Decorations.Add(new IconOverheadDecoration(icon, 20, 1, segment, new AgentConnector(player)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -254,6 +255,18 @@ namespace GW2EIEvtcParser.EncounterLogic
                     break;
                 default:
                     break;
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Sapper bombs
+            var sapperBombs = player.GetBuffStatus(log, SapperBombBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
+            foreach (Segment seg in sapperBombs)
+            {
+                replay.Decorations.Add(new CircleDecoration(false, 0, 180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(player)));
+                replay.Decorations.Add(new CircleDecoration(true, (int)seg.Start + 5000, 180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(player)));
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.BombOverhead, 20, 1, seg, new AgentConnector(player)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -316,8 +317,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
         {
             // Corruption
-            var corruptedMatthias = p.GetBuffStatus(log, Corruption1, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
-            corruptedMatthias.AddRange(p.GetBuffStatus(log, Corruption2, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0));
+            IEnumerable<Segment> corruptedMatthias = p.GetBuffStatus(log, new long[] { Corruption1, Corruption2 }, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
             foreach (Segment seg in corruptedMatthias)
             {
                 int corruptedMatthiasEnd = (int)seg.End;
@@ -329,6 +329,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     replay.Decorations.Add(new CircleDecoration(true, 0, 180, (corruptedMatthiasEnd, corruptedMatthiasEnd + 100000), "rgba(0, 0, 0, 0.3)", new InterpolatedPositionConnector(wellPrevPosition, wellNextPosition, corruptedMatthiasEnd)));
                     replay.Decorations.Add(new CircleDecoration(true, corruptedMatthiasEnd + 100000, 180, (corruptedMatthiasEnd, corruptedMatthiasEnd + 100000), "rgba(0, 0, 0, 0.3)", new InterpolatedPositionConnector(wellPrevPosition, wellNextPosition, corruptedMatthiasEnd)));
                 }
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.CorruptionOverhead, 20, 1, seg, new AgentConnector(p)));
             }
             // Well of profane
             var wellMatthias = p.GetBuffStatus(log, UnstableBloodMagic, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
@@ -343,6 +344,13 @@ namespace GW2EIEvtcParser.EncounterLogic
                 {
                     replay.Decorations.Add(new CircleDecoration(true, 0, 300, (wellMatthiasEnd, wellMatthiasEnd + 90000), "rgba(255, 0, 50, 0.5)", new InterpolatedPositionConnector(wellPrevPosition, wellNextPosition, wellMatthiasEnd)));
                 }
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.VolatilePoisonOverhead, 20, 1, seg, new AgentConnector(p)));
+            }
+            // Sacrifice Selection
+            IEnumerable<Segment> sacrificeSelection = p.GetBuffStatus(log, MatthiasSacrificeSelection, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in sacrificeSelection)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.RedArrowOverhead, 20, 1, segment, new AgentConnector(p)));
             }
             // Sacrifice
             var sacrificeMatthias = p.GetBuffStatus(log, MatthiasSacrifice, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
@@ -359,6 +367,12 @@ namespace GW2EIEvtcParser.EncounterLogic
                 int zealousEnd = zealousStart + 5000;
                 replay.Decorations.Add(new CircleDecoration(true, 0, 180, (zealousStart, zealousEnd), "rgba(200, 150, 0, 0.2)", new AgentConnector(p)));
                 replay.Decorations.Add(new CircleDecoration(true, zealousEnd, 180, (zealousStart, zealousEnd), "rgba(200, 150, 0, 0.4)", new AgentConnector(p)));
+            }
+            // Unbalanced
+            IEnumerable<Segment> unbalanced = p.GetBuffStatus(log, Unbalanced, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in unbalanced)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.UnbalancedOverhead, 20, 1, segment, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -83,7 +84,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(VolatileAura, VolatileAura), // Volatile Aura
+                new DamageCastFinder(VolatileAura, VolatileAura),
             };
         }
 
@@ -225,6 +226,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 {
                     replay.Decorations.Add(new CircleDecoration(true, toDropStart + 90000, 900, (toDropEnd, toDropEnd + 90000), "rgba(255, 0, 0, 0.3)", new InterpolatedPositionConnector(poisonPrevPos, poisonNextPos, toDropEnd), 180));
                 }
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.VolatilePoisonOverhead, 20, 1, seg, new AgentConnector(p)));
             }
             // Transformation
             var slubTrans = p.GetBuffStatus(log, MagicTransformation, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
@@ -232,11 +234,12 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 replay.Decorations.Add(new CircleDecoration(true, 0, 180, seg, "rgba(0, 80, 255, 0.3)", new AgentConnector(p)));
             }
-            // fixated
+            // Fixated
             var fixatedSloth = p.GetBuffStatus(log, FixatedSlothasor, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
             foreach (Segment seg in fixatedSloth)
             {
                 replay.Decorations.Add(new CircleDecoration(true, 0, 120, seg, "rgba(255, 80, 255, 0.3)", new AgentConnector(p)));
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, seg, new AgentConnector(p)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
@@ -1,16 +1,17 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.EIData;
+using GW2EIEvtcParser.Exceptions;
+using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
-using static GW2EIEvtcParser.SkillIDs;
-using static GW2EIEvtcParser.ParserHelper;
-using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
+using GW2EIEvtcParser.ParserHelpers;
+using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
-using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
-using GW2EIEvtcParser.Exceptions;
-using System;
-using GW2EIEvtcParser.Extensions;
+using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
+using static GW2EIEvtcParser.ParserHelper;
+using static GW2EIEvtcParser.SkillIDs;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -74,7 +75,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     phase.Name = "McLeod Split " + (i) / 2;
                     AbstractSingleActor whiteMcLeod = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TrashID.RadiantMcLeod) && x.LastAware > phase.Start);
                     AbstractSingleActor redMcLeod = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TrashID.CrimsonMcLeod) && x.LastAware > phase.Start);
-                    phase.AddTarget(whiteMcLeod); 
+                    phase.AddTarget(whiteMcLeod);
                     phase.AddTarget(redMcLeod);
                     phase.OverrideTimes(log);
                 }
@@ -112,7 +113,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 preEventPhase.AddTargets(preEventWargs);
                 preEventPhase.AddTarget(Targets.FirstOrDefault(x => x.ID == (int)ArcDPSEnums.TargetID.DummyTarget));
                 phases.Add(preEventPhase);
-            } 
+            }
             phases.AddRange(GetMcLeodPhases(mcLeod, log));
             var mcLeodWargs = wargs.Where(x => x.FirstAware >= mcLeod.FirstAware && x.FirstAware <= mcLeod.LastAware).ToList();
             if (mcLeodWargs.Any())
@@ -126,7 +127,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 phase.OverrideTimes(log);
                 phases.Add(phase);
             }
-            
+
             return phases;
         }
 
@@ -190,7 +191,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 if (mcLeod.FirstAware - fightData.LogStart > MinimumInCombatDuration)
                 {
                     _hasPreEvent = true;
-                } 
+                }
                 else
                 {
                     startToUse = GetEnterCombatTime(fightData, agentData, combatData, logStartNPCUpdate.Time);
@@ -221,7 +222,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
         {
-            return new List<ArcDPSEnums.TrashID>() { 
+            return new List<ArcDPSEnums.TrashID>() {
                 ArcDPSEnums.TrashID.MushroomCharger,
                 ArcDPSEnums.TrashID.MushroomKing,
                 ArcDPSEnums.TrashID.MushroomSpikeThrower,
@@ -269,5 +270,28 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
             }
         }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Attunements Overhead
+            AddAttunementDecoration(p, replay, p.GetBuffStatus(log, CrimsonAttunementPhantasm, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.CrimsonAttunementOverhead);
+            AddAttunementDecoration(p, replay, p.GetBuffStatus(log, RadiantAttunementPhantasm, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.RadiantAttunementOverhead);
+        }
+
+        /// <summary>
+        /// Adds the Attunement overhead decoration.
+        /// </summary>
+        /// <param name="player">Player for the decoration.</param>
+        /// <param name="replay">Combat Replay.</param>
+        /// <param name="segments">The <see cref="Segment"/> where the Attunement buff appears.</param>
+        /// <param name="icon">The icon related to the respective Attunement buff.</param>
+        private static void AddAttunementDecoration(AbstractPlayer player, CombatReplay replay, IEnumerable<Segment> segments, string icon)
+        {
+            foreach (Segment segment in segments)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(icon, 20, 1, segment, new AgentConnector(player)));
+            }
+        }
     }
 }
+

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
@@ -112,17 +112,17 @@ namespace GW2EIEvtcParser.EncounterLogic
             IEnumerable<Segment> madness = player.GetBuffStatus(log, Madness, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
             foreach (Segment segment in madness)
             {
-                if (segment.Value >= 30)
+                if (segment.Value >= 90)
                 {
-                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessSilverOverhead, 20, 1, segment, new AgentConnector(player)));
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessRedOverhead, 20, 1, segment, new AgentConnector(player)));
                 }
                 else if (segment.Value >= 60)
                 {
                     replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessGoldOverhead, 20, 1, segment, new AgentConnector(player)));
                 }
-                else if (segment.Value >= 90)
+                else if (segment.Value >= 30)
                 {
-                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessRedOverhead, 20, 1, segment, new AgentConnector(player)));
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessSilverOverhead, 20, 1, segment, new AgentConnector(player)));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -102,6 +103,27 @@ namespace GW2EIEvtcParser.EncounterLogic
                 //    break;
                 default:
                     break;
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Madness - 0 to 29 nothing, 30 to 59 Silver, 60 to 89 Gold, 90 to 99 Red
+            IEnumerable<Segment> madness = player.GetBuffStatus(log, Madness, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in madness)
+            {
+                if (segment.Value >= 30)
+                {
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessSilverOverhead, 20, 1, segment, new AgentConnector(player)));
+                }
+                else if (segment.Value >= 60)
+                {
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessGoldOverhead, 20, 1, segment, new AgentConnector(player)));
+                }
+                else if (segment.Value >= 90)
+                {
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.MadnessRedOverhead, 20, 1, segment, new AgentConnector(player)));
+                }
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
@@ -334,20 +334,20 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
         {
             // Derangement - 0 to 29 nothing, 30 to 59 Silver, 60 to 89 Gold, 90 to 99 Red
-            IEnumerable<Segment> madness = player.GetBuffStatus(log, Derangement, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
-            foreach (Segment segment in madness)
+            IEnumerable<Segment> derangement = player.GetBuffStatus(log, Derangement, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in derangement)
             {
-                if (segment.Value >= 30)
+                if (segment.Value >= 90)
                 {
-                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementSilverOverhead, 20, 1, segment, new AgentConnector(player)));
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementRedOverhead, 20, 1, segment, new AgentConnector(player)));
                 }
                 else if (segment.Value >= 60)
                 {
                     replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementGoldOverhead, 20, 1, segment, new AgentConnector(player)));
                 }
-                else if (segment.Value >= 90)
+                else if (segment.Value >= 30)
                 {
-                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementRedOverhead, 20, 1, segment, new AgentConnector(player)));
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementSilverOverhead, 20, 1, segment, new AgentConnector(player)));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
@@ -4,6 +4,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -327,6 +328,27 @@ namespace GW2EIEvtcParser.EncounterLogic
                     break;
                 default:
                     break;
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Derangement - 0 to 29 nothing, 30 to 59 Silver, 60 to 89 Gold, 90 to 99 Red
+            IEnumerable<Segment> madness = player.GetBuffStatus(log, Derangement, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in madness)
+            {
+                if (segment.Value >= 30)
+                {
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementSilverOverhead, 20, 1, segment, new AgentConnector(player)));
+                }
+                else if (segment.Value >= 60)
+                {
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementGoldOverhead, 20, 1, segment, new AgentConnector(player)));
+                }
+                else if (segment.Value >= 90)
+                {
+                    replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.DerangementRedOverhead, 20, 1, segment, new AgentConnector(player)));
+                }
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -76,7 +77,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(DemonicAura, DemonicAura ), // Demonic Aura
+                new DamageCastFinder(DemonicAura, DemonicAura),
             };
         }
         protected override HashSet<int> GetUniqueNPCIDs()
@@ -621,6 +622,12 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 replay.Decorations.Add(new CircleDecoration(true, 0, 180, seg, "rgba(0, 150, 0, 0.3)", new AgentConnector(p)));
                 replay.Decorations.Add(new CircleDecoration(true, (int)seg.End, 180, seg, "rgba(0, 150, 0, 0.3)", new AgentConnector(p)));
+            }
+            // Tear Instability
+            IEnumerable<Segment> tearInstab = p.GetBuffStatus(log, TearInstability, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
+            foreach (Segment seg in tearInstab)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.TearInstabilityOverhead, 20, 1, seg, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -56,7 +57,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(PunishementAura, PunishementAura ), // PunishementAura
+                new DamageCastFinder(PunishementAura, PunishementAura),
             };
         }
 
@@ -109,6 +110,15 @@ namespace GW2EIEvtcParser.EncounterLogic
                     break;
                 default:
                     break;
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
+        {
+            IEnumerable<Segment> claim = player.GetBuffStatus(log, ClaimBuff, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in claim)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, segment, new AgentConnector(player)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
@@ -4,6 +4,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -62,7 +63,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(BrutalAura , BrutalAura ), // Brutal aura
+                new DamageCastFinder(BrutalAura, BrutalAura),
             };
         }
 
@@ -227,6 +228,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             foreach (Segment seg in fixatedSam)
             {
                 replay.Decorations.Add(new CircleDecoration(true, 0, 80, seg, "rgba(255, 80, 255, 0.3)", new AgentConnector(p)));
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, seg, new AgentConnector(p)));
             }
             //fixated Ghuldem
             var fixatedGuldhem = p.GetBuffStatus(log, FixatedGuldhem, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -83,7 +84,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(DeathlyAura, DeathlyAura), // Deathly Aura
+                new DamageCastFinder(DeathlyAura, DeathlyAura),
             };
         }
 
@@ -423,6 +424,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 replay.Decorations.Add(new CircleDecoration(true, 0, 100, seg, "rgba(80, 180, 0, 0.3)", new AgentConnector(p)));
                 replay.Decorations.Add(new CircleDecoration(true, (int)seg.Start + 13000, 100, seg, "rgba(80, 180, 0, 0.5)", new AgentConnector(p)));
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.BombTimerFullOverhead, 20, 1, seg, new AgentConnector(p)));
             }
             // shackles connection
             var shackles = GetFilteredList(log.CombatData, DhuumShacklesApplication, p, true, true).Concat(GetFilteredList(log.CombatData, DhuumShackles2, p, true, true)).ToList();

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -47,7 +48,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(ChillingAura, ChillingAura), // Chilling Aura
+                new DamageCastFinder(ChillingAura, ChillingAura),
             };
         }
 
@@ -287,6 +288,15 @@ namespace GW2EIEvtcParser.EncounterLogic
                     break;
             }
 
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
+        {
+            IEnumerable<Segment> fixations = player.GetBuffStatus(log, FixatedSH, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in fixations)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, segment, new AgentConnector(player)));
+            }
         }
 
         internal override FightData.EncounterMode GetEncounterMode(CombatData combatData, AgentData agentData, FightData fightData)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -62,8 +63,8 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(NikareAquaticAura , NikareAquaticAura ), // Nikare Aquatic Aura
-                new DamageCastFinder(KenutAquaticAura , KenutAquaticAura ), // Kenut Aquatic Aura
+                new DamageCastFinder(NikareAquaticAura, NikareAquaticAura),
+                new DamageCastFinder(KenutAquaticAura, KenutAquaticAura),
             };
         }
 
@@ -324,6 +325,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     replay.Decorations.Add(new CircleDecoration(true, toDropStart + duration, radius, (toDropEnd, toDropEnd + duration), "rgba(100, 100, 100, 0.3)", new InterpolatedPositionConnector(poisonPrevPos, poisonNextPos, toDropEnd), debuffRadius));
                     replay.Decorations.Add(new CircleDecoration(false, toDropStart + duration, radius, (toDropEnd, toDropEnd + duration), "rgba(230, 230, 230, 0.4)", new InterpolatedPositionConnector(poisonPrevPos, poisonNextPos, toDropEnd), debuffRadius));
                 }
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.TidalPoolOverhead, 20, 1, seg, new AgentConnector(p)));
             }
             // Bubble (Aquatic Detainment)
             var bubble = p.GetBuffStatus(log, AquaticDetainmentBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -110,6 +111,16 @@ namespace GW2EIEvtcParser.EncounterLogic
                     break;
             }
 
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Bomb Selection
+            var bomb = player.GetBuffStatus(log, new long[] { MaiTrinCMBeamsTargetBlue, MaiTrinCMBeamsTargetGreen, MaiTrinCMBeamsTargetRed }, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0).ToList();
+            foreach (Segment segment in bomb)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.BombOverhead, 20, 1, segment, new AgentConnector(player)));
+            }
         }
 
         private AbstractSingleActor GetEchoOfScarletBriar(FightData fightData)

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/KainengOverlook.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/KainengOverlook.cs
@@ -3,12 +3,12 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
-using GW2EIEvtcParser.ParserHelpers;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -194,29 +194,28 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
         {
-            // Target Order Overhead
-            AddTargetOrderDecoration(p, replay, p.GetBuffStatus(log, TargetOrder1, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder1Overhead);
-            AddTargetOrderDecoration(p, replay, p.GetBuffStatus(log, TargetOrder2, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder2Overhead);
-            AddTargetOrderDecoration(p, replay, p.GetBuffStatus(log, TargetOrder3, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder3Overhead);
-            AddTargetOrderDecoration(p, replay, p.GetBuffStatus(log, TargetOrder4, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder4Overhead);
-            AddTargetOrderDecoration(p, replay, p.GetBuffStatus(log, TargetOrder5, log.FightData.LogStart, log.FightData.LogEnd), ParserIcons.TargetOrder5Overhead);
+            // Target Order
+            AddOverheadDecorations(p, replay, p.GetBuffStatus(log, TargetOrder1, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder1Overhead);
+            AddOverheadDecorations(p, replay, p.GetBuffStatus(log, TargetOrder2, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder2Overhead);
+            AddOverheadDecorations(p, replay, p.GetBuffStatus(log, TargetOrder3, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder3Overhead);
+            AddOverheadDecorations(p, replay, p.GetBuffStatus(log, TargetOrder4, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder4Overhead);
+            AddOverheadDecorations(p, replay, p.GetBuffStatus(log, TargetOrder5, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.TargetOrder5Overhead);
+            // Fixation
+            AddOverheadDecorations(p, replay, p.GetBuffStatus(log, FixatedAnkkaKainengOverlook, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), ParserIcons.FixationPurpleOverhead);
         }
 
         /// <summary>
-        /// Adds the Target Order overhead decoration.
+        /// Adds the overhead decorations.
         /// </summary>
         /// <param name="player">Player for the decoration.</param>
         /// <param name="replay">Combat Replay.</param>
-        /// <param name="targets">The <see cref="Segment"/> where the Target Order buff appears.</param>
-        /// <param name="icon">The icon related to the respective Target Order buff.</param>
-        private static void AddTargetOrderDecoration(AbstractPlayer player, CombatReplay replay, IReadOnlyList<Segment> targets, string icon)
+        /// <param name="buffSegments">The <see cref="Segment"/> where the buff appears.</param>
+        /// <param name="icon">The icon related to the respective buff.</param>
+        private static void AddOverheadDecorations(AbstractPlayer player, CombatReplay replay, IEnumerable<Segment> buffSegments, string icon)
         {
-            foreach (Segment target in targets)
+            foreach (Segment segment in buffSegments)
             {
-                if (target.Value > 0)
-                {
-                    replay.Decorations.Add(new IconOverheadDecoration(icon, 12, 1, target, new AgentConnector(player)));
-                }
+                replay.Decorations.Add(new IconOverheadDecoration(icon, 20, 1, segment, new AgentConnector(player)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -277,6 +278,40 @@ namespace GW2EIEvtcParser.EncounterLogic
                         break;
                     }
                 }
+            }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Fixation
+            IEnumerable<AbstractBuffEvent> fixatedVermillion = log.CombatData.GetBuffData(FixatedOldLionsCourt)
+                .Where(buff => buff.To == p.AgentItem && (buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeVermilion) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeVermilionCM)));
+            IEnumerable<AbstractBuffEvent> fixatedArsenite = log.CombatData.GetBuffData(FixatedOldLionsCourt)
+                .Where(buff => buff.To == p.AgentItem && (buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeArsenite) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeArseniteCM)));
+            IEnumerable<AbstractBuffEvent> fixatedIndigo = log.CombatData.GetBuffData(FixatedOldLionsCourt)
+                .Where(buff => buff.To == p.AgentItem && (buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeIndigo) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeIndigoCM)));
+
+            AddFixatedDecorations(p, log, replay, fixatedVermillion, ParserIcons.FixationRedOverhead);
+            AddFixatedDecorations(p, log, replay, fixatedArsenite, ParserIcons.FixationGreenOverhead);
+            AddFixatedDecorations(p, log, replay, fixatedIndigo, ParserIcons.FixationBlueOverhead);
+        }
+
+        /// <summary>
+        /// Adds the Fixated decorations.
+        /// </summary>
+        /// <param name="player">Player for the decoration.</param>
+        /// <param name="replay">Combat Replay.</param>
+        /// <param name="fixations">The <see cref="AbstractBuffEvent"/> where the buff appears.</param>
+        /// <param name="icon">The icon related to the respective buff.</param>
+        private static void AddFixatedDecorations(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay, IEnumerable<AbstractBuffEvent> fixations, string icon)
+        {
+            IEnumerable<AbstractBuffEvent> applications = fixations.Where(x => x is BuffApplyEvent);
+            IEnumerable<AbstractBuffEvent> removals = fixations.Where(x => x is BuffRemoveAllEvent);
+            foreach (BuffApplyEvent bae in applications.Cast<BuffApplyEvent>())
+            {
+                long start = bae.Time;
+                long end = removals.FirstOrDefault(x => x.Time > start) != null ? removals.FirstOrDefault(x => x.Time > start).Time : log.FightData.LogEnd;
+                replay.Decorations.Add(new IconOverheadDecoration(icon, 20, 1, ((int)start, (int)end), new AgentConnector(player)));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
@@ -284,12 +284,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
         {
             // Fixation
-            IEnumerable<AbstractBuffEvent> fixatedVermillion = log.CombatData.GetBuffData(FixatedOldLionsCourt)
-                .Where(buff => buff.To == p.AgentItem && (buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeVermilion) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeVermilionCM)));
-            IEnumerable<AbstractBuffEvent> fixatedArsenite = log.CombatData.GetBuffData(FixatedOldLionsCourt)
-                .Where(buff => buff.To == p.AgentItem && (buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeArsenite) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeArseniteCM)));
-            IEnumerable<AbstractBuffEvent> fixatedIndigo = log.CombatData.GetBuffData(FixatedOldLionsCourt)
-                .Where(buff => buff.To == p.AgentItem && (buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeIndigo) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeIndigoCM)));
+            IEnumerable<AbstractBuffEvent> fixations = log.CombatData.GetBuffData(FixatedOldLionsCourt).Where(buff => buff.To == p.AgentItem);
+            IEnumerable<AbstractBuffEvent> fixatedVermillion = fixations.Where(buff => buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeVermilion) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeVermilionCM));
+            IEnumerable<AbstractBuffEvent> fixatedArsenite = fixations.Where(buff => buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeArsenite) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeArseniteCM));
+            IEnumerable<AbstractBuffEvent> fixatedIndigo = fixations.Where(buff => buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeIndigo) || buff.CreditedBy.IsSpecies(ArcDPSEnums.TargetID.PrototypeIndigoCM));
 
             AddFixatedDecorations(p, log, replay, fixatedVermillion, ParserIcons.FixationRedOverhead);
             AddFixatedDecorations(p, log, replay, fixatedArsenite, ParserIcons.FixationGreenOverhead);

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
@@ -320,13 +320,10 @@ namespace GW2EIEvtcParser.EncounterLogic
                     }
 
                     // Power of the Void
-                    IReadOnlyList<Segment> potvSegments = target.GetBuffStatus(log, PowerOfTheVoid, log.FightData.LogStart, log.FightData.LogEnd);
+                    IEnumerable<Segment> potvSegments = target.GetBuffStatus(log, PowerOfTheVoid, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
                     foreach(Segment segment in potvSegments)
                     {
-                        if (segment.Value > 0)
-                        {
-                            replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.PowerOfTheVoidOverhead, 20, 1, segment, new AgentConnector(target)));
-                        }
+                        replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.PowerOfTheVoidOverhead, 20, 1, segment, new AgentConnector(target)));
                     }
                     break;
                 case (int)ArcDPSEnums.TrashID.KraitsHallucination:

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
@@ -325,7 +325,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     {
                         if (segment.Value > 0)
                         {
-                            replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.PowerOfTheVoidOverhead, 12, 1, segment, new AgentConnector(target)));
+                            replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.PowerOfTheVoidOverhead, 20, 1, segment, new AgentConnector(target)));
                         }
                     }
                     break;
@@ -451,6 +451,12 @@ namespace GW2EIEvtcParser.EncounterLogic
                         replay.Decorations.Add(new LineDecoration(0, (lichTetherStart, tetherEnd), "rgba(0, 255, 255, 0.5)", new AgentConnector(p), new AgentConnector(lichTetherSource)));
                     }
                 }
+            }
+            // Reanimated Hatred Fixation
+            IEnumerable<Segment> hatredFixations = p.GetBuffStatus(log, FixatedAnkkaKainengOverlook, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            foreach (Segment segment in hatredFixations)
+            {
+                replay.Decorations.Add(new IconOverheadDecoration(ParserIcons.FixationPurpleOverhead, 20, 1, segment, new AgentConnector(p)));
             }
         }
 

--- a/GW2EIEvtcParser/ParserHelpers/MarkerGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/MarkerGUIDs.cs
@@ -92,6 +92,31 @@ namespace GW2EIEvtcParser
             { TriangleOverhead, ParserIcons.TriangleSquadMarkerOverhead },
             { XOverhead, ParserIcons.XSquadMarkerOverhead },
         };
+
+        /// <summary>
+        /// Matches the Commander/Catmander Tag GUIDs to the relative icons.
+        /// </summary>
+        public static IReadOnlyDictionary<string, string> CommanderTagToIcon { get; set; } = new Dictionary<string, string>()
+        {
+            { RedCommanderTag, ParserIcons.RedCommanderTagOverhead },
+            { OrangeCommanderTag, ParserIcons.OrangeCommanderTagOverhead },
+            { YellowCommanderTag, ParserIcons.YellowCommanderTagOverhead },
+            { GreenCommanderTag, ParserIcons.GreenCommanderTagOverhead },
+            { CyanCommanderTag, ParserIcons.CyanCommanderTagOverhead },
+            { BlueCommanderTag, ParserIcons.BlueCommanderTagOverhead },
+            { PurpleCommanderTag, ParserIcons.PurpleCommanderTagOverhead },
+            { PinkCommanderTag, ParserIcons.PinkCommanderTagOverhead },
+            { WhiteCommanderTag, ParserIcons.WhiteCommanderTagOverhead },
+            { RedCatmanderTag, ParserIcons.RedCatmanderTagOverhead },
+            { OrangeCatmanderTag, ParserIcons.OrangeCatmanderTagOverhead },
+            { YellowCatmanderTag, ParserIcons.YellowCatmanderTagOverhead },
+            { GreenCatmanderTag, ParserIcons.GreenCatmanderTagOverhead },
+            { CyanCatmanderTag, ParserIcons.CyanCatmanderTagOverhead },
+            { BlueCatmanderTag, ParserIcons.BlueCatmanderTagOverhead },
+            { PurpleCatmanderTag, ParserIcons.PurpleCatmanderTagOverhead },
+            { PinkCatmanderTag, ParserIcons.PinkCatmanderTagOverhead },
+            { WhiteCatmanderTag, ParserIcons.WhiteCatmanderTagOverhead },
+        };
     }
 
 }

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -507,6 +507,11 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string TidalPoolOverhead = "https://wiki.guildwars2.com/images/e/e7/Tidal_Pool_%28overhead_icon%29.png";
         internal const string SkullOverhead = "https://wiki.guildwars2.com/images/f/f6/Jade_Maw_agony_attack.png";
         internal const string PowerOfTheVoidOverhead = "https://wiki.guildwars2.com/images/f/f4/Power_of_the_Void_%28overhead_icon%29.png";
+        internal const string SpectralDarkness = "https://wiki.guildwars2.com/images/f/f6/Spectral_Darkness_%28overhead_icon%29.png";
+        // - Sensors
+        internal const string SensorBlue = "https://wiki.guildwars2.com/images/a/aa/Sensor_Tracking_icon_%28blue%29.png";
+        internal const string SensorGreen = "https://wiki.guildwars2.com/images/1/18/Sensor_Tracking_icon_%28green%29.png";
+        internal const string SensorRed = "https://wiki.guildwars2.com/images/3/38/Sensor_Tracking_icon_%28red%29.png";
         // - Target Orders
         internal const string TargetOrder1Overhead = "https://wiki.guildwars2.com/images/6/6f/Target_Order-1_%28overhead_icon%29.png";
         internal const string TargetOrder2Overhead = "https://wiki.guildwars2.com/images/8/87/Target_Order-2_%28overhead_icon%29.png";

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -531,7 +531,7 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string TidalPoolOverhead = "https://wiki.guildwars2.com/images/e/e7/Tidal_Pool_%28overhead_icon%29.png";
         internal const string SkullOverhead = "https://wiki.guildwars2.com/images/f/f6/Jade_Maw_agony_attack.png";
         internal const string PowerOfTheVoidOverhead = "https://wiki.guildwars2.com/images/f/f4/Power_of_the_Void_%28overhead_icon%29.png";
-        internal const string SpectralDarkness = "https://wiki.guildwars2.com/images/f/f6/Spectral_Darkness_%28overhead_icon%29.png";
+        internal const string SpectralDarknessOverhead = "https://wiki.guildwars2.com/images/f/f6/Spectral_Darkness_%28overhead_icon%29.png";
         internal const string CorruptionOverhead = "https://wiki.guildwars2.com/images/2/2d/Disarm_Poison_Gas_Mine.png";
         internal const string ConjuredShieldEmptyOverhead = "https://wiki.guildwars2.com/images/4/41/Conjured_Shield_%28overhead_icon%29.png";
         internal const string GreatswordPowerEmptyOverhead = "https://wiki.guildwars2.com/images/c/c1/Greatsword_Power_%28overhead_icon%29.png";
@@ -547,9 +547,9 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string DerangementGoldOverhead = "https://wiki.guildwars2.com/images/c/cb/Derangement_%28overhead_icon_yellow%29.png";
         internal const string DerangementRedOverhead = "https://wiki.guildwars2.com/images/a/a1/Derangement_%28overhead_icon_red%29.png";
         // - Sensors
-        internal const string SensorBlue = "https://wiki.guildwars2.com/images/a/aa/Sensor_Tracking_icon_%28blue%29.png";
-        internal const string SensorGreen = "https://wiki.guildwars2.com/images/1/18/Sensor_Tracking_icon_%28green%29.png";
-        internal const string SensorRed = "https://wiki.guildwars2.com/images/3/38/Sensor_Tracking_icon_%28red%29.png";
+        internal const string SensorBlueOverhead = "https://wiki.guildwars2.com/images/a/aa/Sensor_Tracking_icon_%28blue%29.png";
+        internal const string SensorGreenOverhead = "https://wiki.guildwars2.com/images/1/18/Sensor_Tracking_icon_%28green%29.png";
+        internal const string SensorRedOverhead = "https://wiki.guildwars2.com/images/3/38/Sensor_Tracking_icon_%28red%29.png";
         // - Target Orders
         internal const string TargetOrder1Overhead = "https://wiki.guildwars2.com/images/6/6f/Target_Order-1_%28overhead_icon%29.png";
         internal const string TargetOrder2Overhead = "https://wiki.guildwars2.com/images/8/87/Target_Order-2_%28overhead_icon%29.png";

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -486,7 +486,10 @@ namespace GW2EIEvtcParser.ParserHelpers
 
         // Overhead icons
         // - Fixations
-        internal const string FixationPurpleOverhead = "https://wiki.guildwars2.com/images/6/68/Fixate_IG.png";
+        internal const string FixationBlueOverhead = "https://i.imgur.com/EUoDTln.png";
+        internal const string FixationGreenOverhead = "https://i.imgur.com/cDmJWrY.png";
+        internal const string FixationPurpleOverhead = "https://i.imgur.com/UImUF0H.png";
+        internal const string FixationRedOverhead = "https://i.imgur.com/wIYRfY6.png";
         // - Squad Markers
         internal const string ArrowSquadMarkerOverhead = "https://wiki.guildwars2.com/images/e/ef/Commander_arrow_marker.png";
         internal const string CircleSquadMarkerOverhead = "https://wiki.guildwars2.com/images/6/60/Commander_circle_marker.png";
@@ -496,7 +499,28 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string StarSquadMarkerOverhead = "https://wiki.guildwars2.com/images/3/31/Commander_star_marker.png";
         internal const string TriangleSquadMarkerOverhead = "https://wiki.guildwars2.com/images/e/ea/Commander_triangle_marker.png";
         internal const string XSquadMarkerOverhead = "https://wiki.guildwars2.com/images/b/b9/Commander_x_marker.png";
+        // - Commander Tags
+        internal const string BlueCommanderTagOverhead = "https://wiki.guildwars2.com/images/5/54/Commander_tag_%28blue%29.png";
+        internal const string CyanCommanderTagOverhead = "https://wiki.guildwars2.com/images/2/2b/Commander_tag_%28cyan%29.png";
+        internal const string GreenCommanderTagOverhead = "https://wiki.guildwars2.com/images/5/5e/Commander_tag_%28green%29.png";
+        internal const string PinkCommanderTagOverhead = "https://wiki.guildwars2.com/images/b/ba/Commander_tag_%28magenta%29.png";
+        internal const string OrangeCommanderTagOverhead = "https://wiki.guildwars2.com/images/1/1c/Commander_tag_%28orange%29.png";
+        internal const string PurpleCommanderTagOverhead = "https://wiki.guildwars2.com/images/c/cb/Commander_tag_%28purple%29.png";
+        internal const string RedCommanderTagOverhead = "https://wiki.guildwars2.com/images/4/40/Commander_tag_%28red%29.png";
+        internal const string WhiteCommanderTagOverhead = "https://wiki.guildwars2.com/images/f/f1/Commander_tag_%28white%29.png";
+        internal const string YellowCommanderTagOverhead = "https://wiki.guildwars2.com/images/c/cb/Commander_tag_%28yellow%29.png";
+        // - Catmander Tags
+        internal const string BlueCatmanderTagOverhead = "https://wiki.guildwars2.com/images/1/16/Catmander_tag_%28blue%29.png";
+        internal const string CyanCatmanderTagOverhead = "https://wiki.guildwars2.com/images/9/9d/Catmander_tag_%28cyan%29.png";
+        internal const string GreenCatmanderTagOverhead = "https://wiki.guildwars2.com/images/f/fd/Catmander_tag_%28green%29.png";
+        internal const string PinkCatmanderTagOverhead = "https://wiki.guildwars2.com/images/9/94/Catmander_tag_%28magenta%29.png";
+        internal const string OrangeCatmanderTagOverhead = "https://wiki.guildwars2.com/images/2/2a/Catmander_tag_%28orange%29.png";
+        internal const string PurpleCatmanderTagOverhead = "https://wiki.guildwars2.com/images/f/ff/Catmander_tag_%28purple%29.png";
+        internal const string RedCatmanderTagOverhead = "https://wiki.guildwars2.com/images/5/59/Catmander_tag_%28red%29.png";
+        internal const string WhiteCatmanderTagOverhead = "https://wiki.guildwars2.com/images/5/51/Catmander_tag_%28white%29.png";
+        internal const string YellowCatmanderTagOverhead = "https://wiki.guildwars2.com/images/a/a3/Catmander_tag_%28yellow%29.png";
         // - Miscellaneous
+        internal const string RedArrowOverhead = "https://wiki.guildwars2.com/images/3/33/Generic_red_arrow_down.png";
         internal const string EnragedOverhead = "https://wiki.guildwars2.com/images/thumb/8/8e/Enraged_%28overhead_icon%29.png/120px-Enraged_%28overhead_icon%29.png";
         internal const string BombOverhead = "https://wiki.guildwars2.com/images/d/da/Bomb_%28overhead_icon%29.png";
         internal const string VolatilePoisonOverhead = "https://wiki.guildwars2.com/images/d/db/Volatile_Poison_IG.png";
@@ -508,6 +532,20 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string SkullOverhead = "https://wiki.guildwars2.com/images/f/f6/Jade_Maw_agony_attack.png";
         internal const string PowerOfTheVoidOverhead = "https://wiki.guildwars2.com/images/f/f4/Power_of_the_Void_%28overhead_icon%29.png";
         internal const string SpectralDarkness = "https://wiki.guildwars2.com/images/f/f6/Spectral_Darkness_%28overhead_icon%29.png";
+        internal const string CorruptionOverhead = "https://wiki.guildwars2.com/images/2/2d/Disarm_Poison_Gas_Mine.png";
+        internal const string ConjuredShieldEmptyOverhead = "https://wiki.guildwars2.com/images/4/41/Conjured_Shield_%28overhead_icon%29.png";
+        internal const string GreatswordPowerEmptyOverhead = "https://wiki.guildwars2.com/images/c/c1/Greatsword_Power_%28overhead_icon%29.png";
+        // - Bomb Timer
+        internal const string BombTimerEmptyOverhead = "https://wiki.guildwars2.com/images/a/a0/Timer_empty_%28overhead_icon%29.png";
+        internal const string BombTimerFullOverhead = "https://wiki.guildwars2.com/images/d/d9/Timer_full_%28overhead_icon%29.png";
+        // - Madness
+        internal const string MadnessSilverOverhead = "https://wiki.guildwars2.com/images/a/a8/Madness_%28overhead_icon_silver%29.png";
+        internal const string MadnessGoldOverhead = "https://wiki.guildwars2.com/images/c/ce/Madness_%28overhead_icon_gold%29.png";
+        internal const string MadnessRedOverhead = "https://wiki.guildwars2.com/images/f/f4/Madness_%28overhead_icon_red%29.png";
+        // - Derangement
+        internal const string DerangementSilverOverhead = "https://wiki.guildwars2.com/images/4/44/Derangement_%28overhead_icon_white%29.png";
+        internal const string DerangementGoldOverhead = "https://wiki.guildwars2.com/images/c/cb/Derangement_%28overhead_icon_yellow%29.png";
+        internal const string DerangementRedOverhead = "https://wiki.guildwars2.com/images/a/a1/Derangement_%28overhead_icon_red%29.png";
         // - Sensors
         internal const string SensorBlue = "https://wiki.guildwars2.com/images/a/aa/Sensor_Tracking_icon_%28blue%29.png";
         internal const string SensorGreen = "https://wiki.guildwars2.com/images/1/18/Sensor_Tracking_icon_%28green%29.png";

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1421,6 +1421,7 @@
         public const long VolatilePoisonBuff = 34387;
         public const long Targeted = 34392;
         public const long Target = 34393;
+        public const long MatthiasSacrificeSelection = 34399;
         public const long ShardsOfRageHuman = 34404;
         public const long Eat = 34408;
         public const long ShardsOfRageAbomination = 34411;
@@ -1753,7 +1754,7 @@
         public const long DeterminationViirastra = 38841;
         public const long OverheadSmash = 38844;
         public const long MistChargedChop = 38846;
-        public const long CorporealReassignment = 38880;
+        public const long CorporealReassignmentBuff = 38880;
         public const long PunishingKickSkorvald = 38896;
         public const long RadiantFury = 38926;
         public const long VaultArtsariiv = 38977;
@@ -1777,7 +1778,7 @@
         public const long CosmicEnergy = 39237;
         public const long FocusedAnger = 39257;
         public const long CosmicMeteor = 39268;
-        public const long CorporealReassignment2 = 39275;
+        public const long CorporealReassignmentSkill = 39275;
         public const long SolarStomp = 39298;
         public const long HorizonStrikeNormal = 39297;
         public const long FriedOysters = 39302;


### PR DESCRIPTION
Covers most of the #795 

Additionally:
- Fixed exception trigger for Deimos in #796 (DeimosSelectedByGreen wasn't in the Buff Simulator)
- Added some new buffs to the simulator
- Created a dictionary for commander/catmander tags guids to relative overhead icons for future usage
- Increased the pixel sizes from 12 to 20 for the decorations in #797 

Once merged I will edit #795 and strikethrough the completed decorations.
