### PR TITLE
Relics Instant Cast Finders

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
@@ -184,7 +184,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Relic of Lyhr", RelicOfLyhr, Source.Gear, BuffClassification.Gear, BuffImages.RelicOfLyhr),
             new Buff("Mabon's Strength", MabonsStrength, Source.Gear, BuffStackType.StackingConditionalLoss, 10, BuffClassification.Gear, BuffImages.RelicOfMabon),
             new Buff("Relic of Mabon", RelicOfMabon, Source.Gear, BuffClassification.Gear, BuffImages.RelicOfMabon),
-            new Buff("Relic of Peitha", RelicOfPeitha, Source.Gear, BuffClassification.Gear, BuffImages.RelicOfPeitha),
+            new Buff("Relic of Peitha", RelicOfPeithaTargetBuff, Source.Gear, BuffClassification.Gear, BuffImages.RelicOfPeitha),
             new Buff("Relic of Vass", RelicOfVass, Source.Gear, BuffStackType.StackingConditionalLoss, 3, BuffClassification.Gear, BuffImages.RelicOfVass),
         };
 

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/EffectCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/EffectCastFinder.cs
@@ -92,5 +92,7 @@ namespace GW2EIEvtcParser.EIData
             }
             return res;
         }
+
+        internal void OverrideSrc() { }
     }
 }

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/EffectCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/EffectCastFinder.cs
@@ -92,7 +92,5 @@ namespace GW2EIEvtcParser.EIData
             }
             return res;
         }
-
-        internal void OverrideSrc() { }
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -28,33 +28,34 @@ namespace GW2EIEvtcParser.EIData
             // Relics
             new BuffGainCastFinder(RelicOfVass, RelicOfVass).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new BuffGainCastFinder(RelicOfTheFirebrand, RelicOfTheFirebrand).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-            new BuffGainCastFinder(RelicOfIsgarrenTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
-            {
-                return combatData.GetBuffData(RelicOfIsgarrenTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
-            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-            new BuffGainCastFinder(RelicOfTheDragonhunterTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
-            {
-                return combatData.GetBuffData(RelicOfTheDragonhunterTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
-            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            //new BuffGainCastFinder(RelicOfIsgarrenTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
+            //{
+            //    return combatData.GetBuffData(RelicOfIsgarrenTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
+            //}).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            //new BuffGainCastFinder(RelicOfTheDragonhunterTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
+            //{
+            //    return combatData.GetBuffData(RelicOfTheDragonhunterTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
+            //}).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new BuffLossCastFinder(RelicOfFireworksBuffLoss, RelicOfFireworks).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfCerusHit, EffectGUIDs.RelicOfCerusEye).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfTheIce, EffectGUIDs.RelicOfIce).UsingICD(1000).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-            //new EffectCastFinder(RelicOfFireworks, EffectGUIDs.RelicOfFireworks).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfFireworks, EffectGUIDs.RelicOfFireworks).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfPeithaTargetBuff, EffectGUIDs.RelicOfPeitha).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-            new EffectCastFinder(RelicOfTheCitadel, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
-            {
-                combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheCitadelExplosion, out IReadOnlyList<EffectEvent> effects);
-                return effects != null && effects.Any(x => x.Time > evt.Time);
-            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-            new EffectCastFinder(RelicOfTheNightmare, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
-            {
-                combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheNightmare, out IReadOnlyList<EffectEvent> effects);
-                return effects != null && effects.Any(x => x.Time > evt.Time);
-            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-            new EffectCastFinder(RelicOfTheKrait, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
-            {
-                combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheKrait, out IReadOnlyList<EffectEvent> effects);
-                return effects != null && effects.Any(x => x.Time > evt.Time);
-            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            //new EffectCastFinder(RelicOfTheCitadel, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
+            //{
+            //    combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheCitadelExplosion, out IReadOnlyList<EffectEvent> effects);
+            //    return effects != null && effects.Any(x => x.Time > evt.Time);
+            //}).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            //new EffectCastFinder(RelicOfTheNightmare, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
+            //{
+            //    combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheNightmare, out IReadOnlyList<EffectEvent> effects);
+            //    return effects != null && effects.Any(x => x.Time > evt.Time);
+            //}).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            //new EffectCastFinder(RelicOfTheKrait, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
+            //{
+            //    combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheKrait, out IReadOnlyList<EffectEvent> effects);
+            //    return effects != null && effects.Any(x => x.Time > evt.Time);
+            //}).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfTheWizardsTower, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
             {
                 combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheWizardsTower, out IReadOnlyList<EffectEvent> effects);

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -32,19 +32,14 @@ namespace GW2EIEvtcParser.EIData
             {
                 return combatData.GetBuffData(RelicOfIsgarrenTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
             }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-
-            new BuffGainCastFinder(RelicOfPeithaTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
-            {
-                return combatData.GetBuffData(RelicOfPeithaTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
-            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-
             new BuffGainCastFinder(RelicOfTheDragonhunterTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
             {
                 return combatData.GetBuffData(RelicOfTheDragonhunterTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
             }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfCerusHit, EffectGUIDs.RelicOfCerusEye).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfTheIce, EffectGUIDs.RelicOfIce).UsingICD(1000).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-            new EffectCastFinder(RelicOfFireworks, EffectGUIDs.RelicOfFireworks).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            //new EffectCastFinder(RelicOfFireworks, EffectGUIDs.RelicOfFireworks).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfPeithaTargetBuff, EffectGUIDs.RelicOfPeitha).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfTheCitadel, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
             {
                 combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheCitadelExplosion, out IReadOnlyList<EffectEvent> effects);
@@ -63,7 +58,7 @@ namespace GW2EIEvtcParser.EIData
             new EffectCastFinder(RelicOfTheWizardsTower, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
             {
                 combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheWizardsTower, out IReadOnlyList<EffectEvent> effects);
-                return effects != null && effects.Any(x => x.Time >= evt.Time);
+                return effects != null && effects.Any(x => x.Time >= evt.Time && x.Src == evt.Src);
             }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         };
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -25,6 +25,46 @@ namespace GW2EIEvtcParser.EIData
             new EffectCastFinderByDst(RuneOfNightmare, EffectGUIDs.RuneOfNightmare).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new BuffGainCastFinder(PortalEntranceWhiteMantleWatchwork, PortalWeavingWhiteMantleWatchwork),
             new BuffGainCastFinder(PortalExitWhiteMantleWatchwork, PortalUsesWhiteMantleWatchwork).UsingBeforeWeaponSwap(true),
+            // Relics
+            new BuffGainCastFinder(RelicOfVass, RelicOfVass).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new BuffGainCastFinder(RelicOfTheFirebrand, RelicOfTheFirebrand).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new BuffGainCastFinder(RelicOfIsgarrenTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
+            {
+                return combatData.GetBuffData(RelicOfIsgarrenTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
+            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+
+            new BuffGainCastFinder(RelicOfPeithaTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
+            {
+                return combatData.GetBuffData(RelicOfPeithaTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
+            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+
+            new BuffGainCastFinder(RelicOfTheDragonhunterTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
+            {
+                return combatData.GetBuffData(RelicOfTheDragonhunterTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
+            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfCerusHit, EffectGUIDs.RelicOfCerusEye).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfTheIce, EffectGUIDs.RelicOfIce).UsingICD(1000).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfFireworks, EffectGUIDs.RelicOfFireworks).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfTheCitadel, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
+            {
+                combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheCitadelExplosion, out IReadOnlyList<EffectEvent> effects);
+                return effects != null && effects.Any(x => x.Time > evt.Time);
+            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfTheNightmare, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
+            {
+                combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheNightmare, out IReadOnlyList<EffectEvent> effects);
+                return effects != null && effects.Any(x => x.Time > evt.Time);
+            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfTheKrait, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
+            {
+                combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheKrait, out IReadOnlyList<EffectEvent> effects);
+                return effects != null && effects.Any(x => x.Time > evt.Time);
+            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfTheWizardsTower, EffectGUIDs.RelicWhiteCircle).UsingChecker((evt, combatData, agentData, skillData) =>
+            {
+                combatData.TryGetEffectEventsByGUID(EffectGUIDs.RelicOfTheWizardsTower, out IReadOnlyList<EffectEvent> effects);
+                return effects != null && effects.Any(x => x.Time >= evt.Time);
+            }).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         };
 
         internal static void AttachMasterToGadgetByCastData(CombatData combatData, IReadOnlyCollection<AgentItem> gadgets, IReadOnlyList<long> castIDS, long castEndThreshold)

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -54,6 +54,11 @@ namespace GW2EIEvtcParser.ParsedData
             { SmashBottle, "Smash (Bottle)" },
             { ThrowBottle, "Throw (Bottle)" },
             { ThrowNetUnderwaterNet, "Throw Net (Underwater Net)" },
+            // Relics
+            { RelicOfTheWizardsTower, "Relic of the Wizard's Tower" },
+            { RelicOfIsgarrenTargetBuff, "Relic of Isgarren" },
+            { RelicOfTheDragonhunterTargetBuff, "Relic of the Dragonhunter" },
+            { RelicOfPeithaTargetBuff, "Relic of Peitha" },
             // Elementalist
             { DualFireAttunement, "Dual Fire Attunement" },
             { FireWaterAttunement, "Fire Water Attunement" },
@@ -256,9 +261,15 @@ namespace GW2EIEvtcParser.ParsedData
             { RelicOfTheNightmare, "https://wiki.guildwars2.com/images/5/51/Relic_of_the_Nightmare.png" },
             { RelicOfTheSunless, "https://wiki.guildwars2.com/images/b/b6/Relic_of_the_Sunless.png" },
             { RelicOfAkeem, "https://wiki.guildwars2.com/images/5/50/Relic_of_Akeem.png" },
+            { RelicOfTheWizardsTower, "https://wiki.guildwars2.com/images/e/ea/Relic_of_the_Wizard%27s_Tower.png" },
             { RelicOfCerusHit, BuffImages.RelicOfCerus },
             { RelicOfDagdaHit, BuffImages.RelicOfDagda },
-            { RelicOfTheWizardsTower, "https://wiki.guildwars2.com/images/e/ea/Relic_of_the_Wizard%27s_Tower.png" },
+            { RelicOfFireworks, BuffImages.RelicOfFireworks },
+            { RelicOfVass, BuffImages.RelicOfVass },
+            { RelicOfTheFirebrand, BuffImages.RelicOfTheFirebrand },
+            { RelicOfIsgarrenTargetBuff, BuffImages.RelicOfIsgarren },
+            { RelicOfTheDragonhunterTargetBuff, BuffImages.RelicOfTheDragonhunter },
+            { RelicOfPeithaTargetBuff, BuffImages.RelicOfPeitha },
             // Freezie
             { FireSnowball, "https://wiki.guildwars2.com/images/d/d0/Fire_Snowball.png" },
             // Escort

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -59,6 +59,7 @@ namespace GW2EIEvtcParser.ParsedData
             { RelicOfIsgarrenTargetBuff, "Relic of Isgarren" },
             { RelicOfTheDragonhunterTargetBuff, "Relic of the Dragonhunter" },
             { RelicOfPeithaTargetBuff, "Relic of Peitha" },
+            { RelicOfFireworksBuffLoss, "Relic of Fireworks (Buff Loss)" },
             // Elementalist
             { DualFireAttunement, "Dual Fire Attunement" },
             { FireWaterAttunement, "Fire Water Attunement" },
@@ -270,6 +271,7 @@ namespace GW2EIEvtcParser.ParsedData
             { RelicOfIsgarrenTargetBuff, BuffImages.RelicOfIsgarren },
             { RelicOfTheDragonhunterTargetBuff, BuffImages.RelicOfTheDragonhunter },
             { RelicOfPeithaTargetBuff, BuffImages.RelicOfPeitha },
+            { RelicOfFireworksBuffLoss, "https://i.imgur.com/o9suJSt.png" },
             // Freezie
             { FireSnowball, "https://wiki.guildwars2.com/images/d/d0/Fire_Snowball.png" },
             // Escort

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -33,6 +33,7 @@ namespace GW2EIEvtcParser
         public const string RelicOfTheKrait = "0685880038B8F441B191439DB678A5F8";
         public const string RelicOfTheSunless = "B1FFFAEFC0A3C74D96851E07C75B3FC7";
         public const string RelicOfTheWizardsTower = "2A1D0C23F448C348A83E9A4F2669B73F";
+        public const string RelicOfPeitha = "0CBFB70434661647B68003ECD77207E6"; // Projectile
         // Mesmer
         public const string MesmerThePrestigeDisappear1 = "48B69FBC3090E144BFC067D6C0208878";
         public const string MesmerThePrestigeDisappear2 = "5FA6527231BB8041AC783396142C6200"; // also used with elementalist cleansing fire

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -20,6 +20,19 @@ namespace GW2EIEvtcParser
         public const string StealthReveal = "A37F8E2B550B254DA89F933BDF654B41"; // also used with e.g. infiltrators strike, infiltrators arrow, shadowstep, shadow return, infiltrators signet
         public const string WhiteMantlePortalInactive = "D43373FEFA19A54DA2A2B6BB7834A338";
         public const string WhiteMantlePortalActive = "388CF9246218A34DB2F8107E19FCA471";
+        // Relics
+        public const string RelicWhiteCircle = "866307A6A0E34242BDC3067AB24A549D"; // Appears for Nightmare, Citadel, Krait
+        public const string RelicOfCerusEye = "1066BEACB107C743908D860DA2D59796";
+        public const string RelicOfCerusEye2 = "521b6C72BF291E4E8A895A0827AF1727";
+        public const string RelicOfCerusBeam = "513AEEF08C217942A798831BD9F4903E"; // 1 second delayed
+        public const string RelicOfCerusBeam2 = "43F06D75DF774C4DBB1383B8621B1047"; // 1 second delayed
+        public const string RelicOfIce = "54F2B4920F7E2D4FAA56CED739BA2C41";
+        public const string RelicOfTheCitadelExplosion = "DE4373D3B08DE04E903B99B6F9194F74"; // 2.5 seconds delayed
+        public const string RelicOfFireworks = "2BC033D40C0AEB40A77EEF28D51AE263";
+        public const string RelicOfTheNightmare = "0FCF4B1F75575949AA4997365FAE0288";
+        public const string RelicOfTheKrait = "0685880038B8F441B191439DB678A5F8";
+        public const string RelicOfTheSunless = "B1FFFAEFC0A3C74D96851E07C75B3FC7";
+        public const string RelicOfTheWizardsTower = "2A1D0C23F448C348A83E9A4F2669B73F";
         // Mesmer
         public const string MesmerThePrestigeDisappear1 = "48B69FBC3090E144BFC067D6C0208878";
         public const string MesmerThePrestigeDisappear2 = "5FA6527231BB8041AC783396142C6200"; // also used with elementalist cleansing fire

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -3516,7 +3516,7 @@
         public const long RelicOfTheNightmare = 69849;
         public const long RelicOfFireworks = 69855;
         public const long RelicOfCerusBuff = 69867;
-        public const long RelicOfPeitha = 69882;
+        public const long RelicOfPeithaTargetBuff = 69882;
         public const long RelicOfVass = 69961;
         public const long RelicOfMabon = 69992;
         public const long RelicOfAkeem = 70044;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -47,6 +47,7 @@
         public const long HealingMistOrSoothingDetonation = -29;
         public const long SadisticSearingActivation = -30;
         public const long BladeBurstOrParticleAccelerator = -31;
+        public const long RelicOfFireworksBuffLoss = -32;
         ////////////////
         internal const long ArcDPSDodge = 65001;
         internal const long ArcDPSGenericBreakbar = 65002;


### PR DESCRIPTION
Tracked:

- Vass
- Firebrand
- Isgarren
- Peitha
- Dragonhunter
- Cerus
- Ice
- Fireworks
- Citadel
- Nightmare
- Krait
- Wizard's Tower

Also added some more icons and renamed some relics that were showing the number or UNKNOWN in the html.

Zip with the test logs:
[relics.zip](https://github.com/baaron4/GW2-Elite-Insights-Parser/files/12448140/relics.zip)
