### PR TITLE
PlayerToNPCTethering API, multiple decorations, some reordering

### DIFF
--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplay.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplay.cs
@@ -158,6 +158,9 @@ namespace GW2EIEvtcParser.EIData
             RotationPolling(ParserHelper.CombatReplayPollingRate, fightDuration);
         }
 
+
+        #region DEBUG EFFECTS
+
         internal static void DebugEffects(AbstractSingleActor actor, ParsedEvtcLog log, CombatReplay replay, HashSet<long> knownEffectIDs, long start = long.MinValue, long end = long.MaxValue)
         {
             IReadOnlyList<EffectEvent> effectEventsOnAgent = log.CombatData.GetEffectEventsByDst(actor.AgentItem).Where(x => !knownEffectIDs.Contains(x.EffectID) && x.Time >= start && x.Time <= end).ToList();
@@ -212,6 +215,27 @@ namespace GW2EIEvtcParser.EIData
 
         }
 
+        internal static void DebugAllNPCEffects(ParsedEvtcLog log, CombatReplay replay, HashSet<long> knownEffectIDs, long start = long.MinValue, long end = long.MaxValue)
+        {
+            IReadOnlyList<EffectEvent> allEffectEvents = log.CombatData.GetEffectEvents().Where(x => !knownEffectIDs.Contains(x.EffectID) && !x.Src.GetFinalMaster().IsPlayer && (!x.IsAroundDst || !x.Dst.GetFinalMaster().IsPlayer) && x.Time >= start && x.Time <= end && x.EffectID > 0).ToList(); ;
+            var effectGUIDs = allEffectEvents.Select(x => log.CombatData.GetEffectGUIDEvent(x.EffectID).ContentGUID).ToList();
+            var effectGUIDsDistinct = effectGUIDs.GroupBy(x => x).ToDictionary(x => x.Key, x => x.ToList().Count);
+            foreach (EffectEvent effectEvt in allEffectEvents)
+            {
+                if (effectEvt.IsAroundDst)
+                {
+                    replay.Decorations.Insert(0, new CircleDecoration(true, 0, 180, ((int)effectEvt.Time, (int)effectEvt.Time + 100), "rgba(0, 255, 255, 0.5)", new AgentConnector(log.FindActor(effectEvt.Dst))));
+                }
+                else
+                {
+
+                    replay.Decorations.Insert(0, new CircleDecoration(true, 0, 180, ((int)effectEvt.Time, (int)effectEvt.Time + 100), "rgba(0, 255, 255, 0.5)", new PositionConnector(effectEvt.Position)));
+                }
+            }
+        }
+
+        #endregion DEBUG EFFECTS
+
         /// <summary>
         /// Add an overhead icon decoration
         /// </summary>
@@ -241,24 +265,64 @@ namespace GW2EIEvtcParser.EIData
             }
         }
 
-        internal static void DebugAllNPCEffects(ParsedEvtcLog log, CombatReplay replay, HashSet<long> knownEffectIDs, long start = long.MinValue, long end = long.MaxValue)
+        /// <summary>
+        /// Add tether decorations from the <paramref name="player"/> to <paramref name="npcs"/>. <br></br>
+        /// Uses <see cref="List{T}"/> of <see cref="AbstractBuffEvent"/> to find the buff owner and attach the two agents.
+        /// </summary>
+        /// <param name="fixations">Buff events of the fixations.</param>
+        /// <param name="npcs">NPCs targetting the player.</param>
+        /// <param name="player">Player target of the tether.</param>
+        /// <param name="color">Color of the tether.</param>
+        internal void AddPlayerToNPCTethering(List<AbstractBuffEvent> fixations, IReadOnlyList<NPC> npcs, AbstractPlayer player, string color)
         {
-            IReadOnlyList<EffectEvent> allEffectEvents = log.CombatData.GetEffectEvents().Where(x => !knownEffectIDs.Contains(x.EffectID) && !x.Src.GetFinalMaster().IsPlayer && (!x.IsAroundDst || !x.Dst.GetFinalMaster().IsPlayer) && x.Time >= start && x.Time <= end && x.EffectID > 0).ToList(); ;
-            var effectGUIDs = allEffectEvents.Select(x => log.CombatData.GetEffectGUIDEvent(x.EffectID).ContentGUID).ToList();
-            var effectGUIDsDistinct = effectGUIDs.GroupBy(x => x).ToDictionary(x => x.Key, x => x.ToList().Count);
-            foreach (EffectEvent effectEvt in allEffectEvents)
+            int tetherStart = 0;
+            AbstractSingleActor actor = null;
+            foreach (AbstractBuffEvent fixation in fixations)
             {
-                if (effectEvt.IsAroundDst)
+                if (fixation is BuffApplyEvent)
                 {
-                    replay.Decorations.Insert(0, new CircleDecoration(true, 0, 180, ((int)effectEvt.Time, (int)effectEvt.Time + 100), "rgba(0, 255, 255, 0.5)", new AgentConnector(log.FindActor(effectEvt.Dst))));
+                    tetherStart = (int)fixation.Time;
+                    actor = npcs.FirstOrDefault(x => x.AgentItem == fixation.CreditedBy);
                 }
                 else
                 {
-
-                    replay.Decorations.Insert(0, new CircleDecoration(true, 0, 180, ((int)effectEvt.Time, (int)effectEvt.Time + 100), "rgba(0, 255, 255, 0.5)", new PositionConnector(effectEvt.Position)));
+                    int tetherEnd = (int)fixation.Time;
+                    if (actor != null)
+                    {
+                        Decorations.Add(new LineDecoration(0, (tetherStart, tetherEnd), color, new AgentConnector(player), new AgentConnector(actor)));
+                    }
                 }
             }
+        }
 
+        /// <summary>
+        /// Add tether decorations from the <paramref name="player"/> to <paramref name="npcs"/>. <br></br>
+        /// Uses <see cref="List{T}"/> of <see cref="AbstractBuffEvent"/> to find the buff owner and attach the two agents.
+        /// </summary>
+        /// <param name="fixations">Buff events of the fixations.</param>
+        /// <param name="npcs">NPCs targetting the player.</param>
+        /// <param name="player">Player target of the tether.</param>
+        /// <param name="color">Color of the tether.</param>
+        internal void AddPlayerToNPCTethering(List<AbstractBuffEvent> fixations, IReadOnlyList<AbstractSingleActor> npcs, AbstractPlayer player, string color)
+        {
+            int tetherStart = 0;
+            AbstractSingleActor actor = null;
+            foreach (AbstractBuffEvent fixation in fixations)
+            {
+                if (fixation is BuffApplyEvent)
+                {
+                    tetherStart = (int)fixation.Time;
+                    actor = npcs.FirstOrDefault(x => x.AgentItem == fixation.CreditedBy);
+                }
+                else
+                {
+                    int tetherEnd = (int)fixation.Time;
+                    if (actor != null)
+                    {
+                        Decorations.Add(new LineDecoration(0, (tetherStart, tetherEnd), color, new AgentConnector(player), new AgentConnector(actor)));
+                    }
+                }
+            }
         }
     }
 }

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplay.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplay.cs
@@ -273,7 +273,7 @@ namespace GW2EIEvtcParser.EIData
         /// <param name="npcs">NPCs targetting the player.</param>
         /// <param name="player">Player target of the tether.</param>
         /// <param name="color">Color of the tether.</param>
-        internal void AddPlayerToNPCTethering(List<AbstractBuffEvent> fixations, IReadOnlyList<NPC> npcs, AbstractPlayer player, string color)
+        internal void AddPlayerToNPCTethering(IReadOnlyList<AbstractBuffEvent> fixations, IReadOnlyList<NPC> npcs, AbstractPlayer player, string color)
         {
             int tetherStart = 0;
             AbstractSingleActor actor = null;
@@ -284,7 +284,7 @@ namespace GW2EIEvtcParser.EIData
                     tetherStart = (int)fixation.Time;
                     actor = npcs.FirstOrDefault(x => x.AgentItem == fixation.CreditedBy);
                 }
-                else
+                else if (fixation is BuffRemoveAllEvent)
                 {
                     int tetherEnd = (int)fixation.Time;
                     if (actor != null)
@@ -303,7 +303,7 @@ namespace GW2EIEvtcParser.EIData
         /// <param name="npcs">NPCs targetting the player.</param>
         /// <param name="player">Player target of the tether.</param>
         /// <param name="color">Color of the tether.</param>
-        internal void AddPlayerToNPCTethering(List<AbstractBuffEvent> fixations, IReadOnlyList<AbstractSingleActor> npcs, AbstractPlayer player, string color)
+        internal void AddPlayerToNPCTethering(IReadOnlyList<AbstractBuffEvent> fixations, IReadOnlyList<AbstractSingleActor> npcs, AbstractPlayer player, string color)
         {
             int tetherStart = 0;
             AbstractSingleActor actor = null;
@@ -314,7 +314,7 @@ namespace GW2EIEvtcParser.EIData
                     tetherStart = (int)fixation.Time;
                     actor = npcs.FirstOrDefault(x => x.AgentItem == fixation.CreditedBy);
                 }
-                else
+                else if (fixation is BuffRemoveAllEvent)
                 {
                     int tetherEnd = (int)fixation.Time;
                     if (actor != null)

--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
@@ -114,6 +114,16 @@ namespace GW2EIEvtcParser.EncounterLogic
             return GetFilteredList(combatData, buffID, target.AgentItem, beginWithStart, padEnd);
         }
 
+        internal static List<AbstractBuffEvent> GetFilteredList(CombatData combatData, long[] buffIDs, AbstractSingleActor target, bool beginWithStart, bool padEnd)
+        {
+            var filteredList = new List<AbstractBuffEvent>();
+            foreach (long buffID in buffIDs)
+            {
+                filteredList.AddRange(GetFilteredList(combatData, buffID, target.AgentItem, beginWithStart, padEnd));
+            }
+            return filteredList;
+        }
+
         internal static bool AtLeastOnePlayerAlive(CombatData combatData, FightData fightData, long timeToCheck, IReadOnlyCollection<AgentItem> playerAgents)
         {
             int playerDeadOrDCCount = 0;

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -266,7 +266,9 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             // Fixations
             IEnumerable<Segment> fixations = p.GetBuffStatus(log, FixatedNightmare, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            List<AbstractBuffEvent> fixationEvents = GetFilteredList(log.CombatData, FixatedNightmare, p, true, true);
             replay.AddOverheadIcons(fixations, p, ParserIcons.FixationPurpleOverhead);
+            replay.AddPlayerToNPCTethering(fixationEvents, TrashMobs, p, "rgba(255, 0, 255, 0.5)");
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
@@ -204,7 +204,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             replay.AddOverheadIcons(corpReass, p, ParserIcons.SkullOverhead);
             // Fixations
             IEnumerable<Segment> fixations = p.GetBuffStatus(log, new long[] { FixatedBloom1, FixatedBloom2, FixatedBloom3, FixatedBloom4 }, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+            List<AbstractBuffEvent> fixationEvents = GetFilteredList(log.CombatData, new long[] { FixatedBloom1, FixatedBloom2, FixatedBloom3, FixatedBloom4 }, p, true, true);
             replay.AddOverheadIcons(fixations, p, ParserIcons.FixationPurpleOverhead);
+            replay.AddPlayerToNPCTethering(fixationEvents, TrashMobs, p, "rgba(255, 0, 255, 0.5)");
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
@@ -61,6 +61,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             new PlayerDstHitMechanic(NegativeBurst, "Negative Burst", new MechanicPlotlySetting(Symbols.DiamondWide,Colors.LightPurple), "N.Brst.","Negative Burst", "Negative Burst",500),
             new PlayerDstHitMechanic(Terrorstorm, "Terrorstorm", new MechanicPlotlySetting(Symbols.DiamondTall,Colors.LightPurple), "TrrStrm","Terrorstorm", "Terrorstorm",0),
             new PlayerDstBuffApplyMechanic(CrushingGuilt, "Crushing Guilt", new MechanicPlotlySetting(Symbols.StarOpen,Colors.LightPurple), "Crsh.Glt.","Crushing Guilt", "Crushing Guilt",0),
+            new PlayerDstBuffApplyMechanic(new long [] { FixatedFear1, FixatedFear2, FixatedFear3, FixatedFear4 }, "Fixated (Fear)", new MechanicPlotlySetting(Symbols.Bowtie, Colors.Purple), "Fear.Fix.A", "Fixated by Fear", "Fixated Application", 0),
             new PlayerDstBuffRemoveMechanic(CrushingGuilt, "Crushing Guilt Down", new MechanicPlotlySetting(Symbols.Star,Colors.LightPurple), "Crsh.Glt.Dwn.","Downed by Crushing Guilt", "Crushing Guilt Down",0).UsingChecker((evt, log) => evt.RemovedStacks == 10 && Math.Abs(evt.RemovedDuration - 90000) < 10 * ServerDelayConstant && log.CombatData.GetBuffData(Downed).Any(x => Math.Abs(x.Time - evt.Time) < 50 && x is BuffApplyEvent bae && bae.To == evt.To)),
             new EnemyCastStartMechanic(EmpathicManipulationFear, "Empathic Manipulation (Fear)", new MechanicPlotlySetting(Symbols.TriangleUp,Colors.LightPurple), "Fear Mnp.", "Empathic Manipulation (Fear)", "Empathic Manipulation (Fear)", 0),
             new EnemyCastEndMechanic(EmpathicManipulationFear, "Empathic Manipulation (Fear) Interrupt", new MechanicPlotlySetting(Symbols.TriangleUpOpen,Colors.LightPurple), "IntFear.Mnp.", "Empathic Manipulation (Fear) Interrupt", "Empathic Manipulation (Fear) Interrupt", 0).UsingChecker((evt, log) => evt is AnimatedCastEvent ace && ace.Status == AbstractCastEvent.AnimationStatus.Interrupted),
@@ -388,6 +389,13 @@ namespace GW2EIEvtcParser.EncounterLogic
                     }
                 }
             }
+        }
+
+        internal override void ComputePlayerCombatReplayActors(AbstractPlayer p, ParsedEvtcLog log, CombatReplay replay)
+        {
+            // Tethering Players to Fears
+            List<AbstractBuffEvent> fearFixations = GetFilteredList(log.CombatData, new long[] { FixatedFear1, FixatedFear2, FixatedFear3, FixatedFear4 }, p, true, true);
+            replay.AddPlayerToNPCTethering(fearFixations, TrashMobs, p, "rgba(255, 0, 255, 0.5)");
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
@@ -425,26 +425,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                 replay.Decorations.Add(new CircleDecoration(true, (int)seg.End, 550, seg, "rgba(200, 150, 0, 0.4)", new AgentConnector(p)));
 
             }
-            //fixated Statue
+            // Fixated Statue tether to Player
             var fixatedStatue = GetFilteredList(log.CombatData, StatueFixated1, p, true, true).Concat(GetFilteredList(log.CombatData, StatueFixated2, p, true, true)).ToList();
-            int fixationStatueStart = 0;
-            AbstractSingleActor statue = null;
-            foreach (AbstractBuffEvent c in fixatedStatue)
-            {
-                if (c is BuffApplyEvent)
-                {
-                    fixationStatueStart = (int)c.Time;
-                    statue = Targets.FirstOrDefault(x => x.AgentItem == c.CreditedBy);
-                }
-                else
-                {
-                    int fixationStatueEnd = (int)c.Time;
-                    if (statue != null)
-                    {
-                        replay.Decorations.Add(new LineDecoration(0, (fixationStatueStart, fixationStatueEnd), "rgba(255, 0, 255, 0.5)", new AgentConnector(p), new AgentConnector(statue)));
-                    }
-                }
-            }
+            replay.AddPlayerToNPCTethering(fixatedStatue, Targets, p, "rgba(255, 0, 255, 0.5)");
             // Fixation Overhead
             IEnumerable<Segment> fixations = p.GetBuffStatus(log, new long[] { StatueFixated1, StatueFixated2 }, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
             replay.AddOverheadIcons(fixations, p, ParserIcons.FixationPurpleOverhead);

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/KainengOverlook.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/KainengOverlook.cs
@@ -204,6 +204,8 @@ namespace GW2EIEvtcParser.EncounterLogic
             replay.AddOverheadIcons(p.GetBuffStatus(log, TargetOrder5, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), p, ParserIcons.TargetOrder5Overhead);
             // Fixation
             replay.AddOverheadIcons(p.GetBuffStatus(log, FixatedAnkkaKainengOverlook, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), p, ParserIcons.FixationPurpleOverhead);
+            List<AbstractBuffEvent> fixationEvents = GetFilteredList(log.CombatData, FixatedAnkkaKainengOverlook, p, true, true);
+            replay.AddPlayerToNPCTethering(fixationEvents, Targets, p, "rgba(255, 0, 255, 0.5)");
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
@@ -431,26 +431,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                     }
                 }
             }
-            //
+            // Tethering Players to Lich
             List<AbstractBuffEvent> lichTethers = GetFilteredList(log.CombatData, AnkkaLichHallucinationFixation, p, true, true);
-            int lichTetherStart = 0;
-            AbstractSingleActor lichTetherSource = null;
-            foreach (AbstractBuffEvent lichTether in lichTethers)
-            {
-                if (lichTether is BuffApplyEvent)
-                {
-                    lichTetherStart = (int)lichTether.Time;
-                    lichTetherSource = TrashMobs.FirstOrDefault(x => x.AgentItem == lichTether.CreditedBy);
-                }
-                else
-                {
-                    int tetherEnd = (int)lichTether.Time;
-                    if (lichTetherSource != null)
-                    {
-                        replay.Decorations.Add(new LineDecoration(0, (lichTetherStart, tetherEnd), "rgba(0, 255, 255, 0.5)", new AgentConnector(p), new AgentConnector(lichTetherSource)));
-                    }
-                }
-            }
+            replay.AddPlayerToNPCTethering(lichTethers, TrashMobs, p, "rgba(0, 255, 255, 0.5)");
             // Reanimated Hatred Fixation
             IEnumerable<Segment> hatredFixations = p.GetBuffStatus(log, FixatedAnkkaKainengOverlook, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
             replay.AddOverheadIcons(hatredFixations, p, ParserIcons.FixationPurpleOverhead);


### PR DESCRIPTION
- Reordered the debug methods in Combat Replay and located them inside a region
- Added AddPlayerToNPCTethering API to be used for tethering decorations.
- New GetFilteredList for multiple buff events
- Added tethering decorations for Ai Fears, Siax Hallucinations, Arkk Blooms, Kaineng Mindblade & Enforcer
- Moved Keep Construct Ghosts and Ankka Lich decorations to the new methods.
- Added mechanic to Ai that tracks the number of Fear fixations

Let me know if there is a way to merge the two AddPlayerToNPCTethering to be using only one type of list, for TrashMobs and Targets
Wanted to add a tether for the Soul Feast on Dagda and Reanimated Hatred on Ankka but the buffs are applied by Dagda and Ankka respectively and not the npc that chases the player