### PR TITLE
New embodiments kill mechanics and naming scheme

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -583,6 +583,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Empowered Regret (Embodiment)", EmpoweredRegretEmbodiment, Source.FightSpecific, BuffClassification.Other, BuffImages.ExcessMagic),
             new Buff("Kryptis-Possessed", KryptisPossessed, Source.FightSpecific, BuffClassification.Other, BuffImages.Unknown),
             new Buff("Invulnerability (Cerus)", InvulnerabilityCerus, Source.FightSpecific, BuffClassification.Other, BuffImages.Determined),
+            new Buff("Invulnerability (Embodiment)", InvulnerabilityEmbodiment, Source.FightSpecific, BuffClassification.Other, BuffImages.Determined),
             //Open World Soo-Won
             new Buff("Jade Tech Offensive Overcharge", JadeTechOffensiveOvercharge, Source.FightSpecific, BuffStackType.Queue, 9, BuffClassification.Offensive, BuffImages.JadeTechOffensive),
             new Buff("Jade Tech Defensive Overcharge", JadeTechDefensiveOvercharge, Source.FightSpecific, BuffStackType.Queue, 9, BuffClassification.Defensive, BuffImages.JadeTechDefensive),

--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicPhaseUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicPhaseUtils.cs
@@ -50,9 +50,8 @@ namespace GW2EIEvtcParser.EncounterLogic
             invuls.RemoveAll(x => x.Time < 0);
             invuls.Sort((event1, event2) => event1.Time.CompareTo(event2.Time)); // Sort in case there were multiple skillIDs
             bool nextToAddIsSkipPhase = !beginWithStart;
-            for (int i = 0; i < invuls.Count; i++)
+            foreach (AbstractBuffEvent c in invuls)
             {
-                AbstractBuffEvent c = invuls[i];
                 if (c is BuffApplyEvent)
                 {
                     long curEnd = Math.Min(c.Time, end);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
@@ -177,7 +177,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 throw new MissingKeyActorsException("Cairn not found");
             }
             // spawn protection loss -- most reliable
-            CombatItem spawnProtectionLoss = combatData.Find(x => x.IsBuffRemove == ArcDPSEnums.BuffRemove.All && x.SrcMatchesAgent(target) && x.SkillID == 34113);
+            CombatItem spawnProtectionLoss = combatData.Find(x => x.IsBuffRemove == ArcDPSEnums.BuffRemove.All && x.SrcMatchesAgent(target) && x.SkillID == SpawnProtection);
             if (spawnProtectionLoss != null)
             {
                 return spawnProtectionLoss.Time;
@@ -187,7 +187,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 // get first end casting
                 CombatItem firstCastEnd = combatData.FirstOrDefault(x => x.EndCasting() && (x.Time - fightData.LogStart) < 2000 && x.SrcMatchesAgent(target));
                 // It has to Impact(38102), otherwise anomaly, player may have joined mid fight, do nothing
-                if (firstCastEnd != null && firstCastEnd.SkillID == 38102)
+                if (firstCastEnd != null && firstCastEnd.SkillID == CairnImpact)
                 {
                     // Action 4 from skill dump for 38102
                     long actionHappened = 1025;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -189,7 +189,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 throw new MissingKeyActorsException("Qadim not found");
             }
-            CombatItem startCast = combatData.FirstOrDefault(x => x.SkillID == 52496 && x.StartCasting());
+            CombatItem startCast = combatData.FirstOrDefault(x => x.SkillID == QadimInitialCast && x.StartCasting());
             CombatItem sanityCheckCast = combatData.FirstOrDefault(x => (x.SkillID == FlameSlash3 || x.SkillID == FlameSlash || x.SkillID == 58814) && x.StartCasting());
             if (startCast == null || sanityCheckCast == null)
             {

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
@@ -143,69 +143,51 @@ namespace GW2EIEvtcParser.EncounterLogic
                 switch (target.ID)
                 {
                     case (int)ArcDPSEnums.TrashID.EmbodimentOfDespair:
-                        CombatItem despair = combatData.FirstOrDefault(x => x.SkillID == EmpoweredDespairEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        CombatItem despair = combatData.FirstOrDefault(x => x.SkillID == EmpoweredDespairEmbodiment && x.DstMatchesAgent(target.AgentItem) && x.IsBuffApply());
+                        target.OverrideName(target.Character + " (P" + curDespair++ + ")");
                         if (despair != null && Math.Abs(target.FirstAware - despair.Time) <= ServerDelayConstant)
                         {
-                            target.OverrideName("Empowered " + target.Character + " (P" + curDespair++ + ")");
-                        }
-                        else
-                        {
-                            target.OverrideName(target.Character + " (P" + curDespair++ + ")");
+                            target.OverrideName("Empowered " + target.Character);
                         }
                         break;
                     case (int)ArcDPSEnums.TrashID.EmbodimentOfEnvy:
-                        CombatItem envy = combatData.FirstOrDefault(x => x.SkillID == EmpoweredEnvyEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        CombatItem envy = combatData.FirstOrDefault(x => x.SkillID == EmpoweredEnvyEmbodiment && x.DstMatchesAgent(target.AgentItem) && x.IsBuffApply());
+                        target.OverrideName(target.Character + " (P" + curEnvy++ + ")");
                         if (envy != null && Math.Abs(target.FirstAware - envy.Time) <= ServerDelayConstant)
                         {
                             target.OverrideName("Empowered " + target.Character + " (P" + curEnvy++ + ")");
                         }
-                        else
-                        {
-                            target.OverrideName(target.Character + " (P" + curEnvy++ + ")");
-                        }
                         break;
                     case (int)ArcDPSEnums.TrashID.EmbodimentOfGluttony:
-                        CombatItem gluttony = combatData.FirstOrDefault(x => x.SkillID == EmpoweredGluttonyEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        CombatItem gluttony = combatData.FirstOrDefault(x => x.SkillID == EmpoweredGluttonyEmbodiment && x.DstMatchesAgent(target.AgentItem) && x.IsBuffApply());
+                        target.OverrideName(target.Character + " (P" + curGluttony++ + ")");
                         if (gluttony != null && Math.Abs(target.FirstAware - gluttony.Time) <= ServerDelayConstant)
                         {
                             target.OverrideName("Empowered " + target.Character + " (P" + curGluttony++ + ")");
                         }
-                        else
-                        {
-                            target.OverrideName(target.Character + " (P" + curGluttony++ + ")");
-                        }
                         break;
                     case (int)ArcDPSEnums.TrashID.EmbodimentOfMalice:
-                        CombatItem malice = combatData.FirstOrDefault(x => x.SkillID == EmpoweredMaliceEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        CombatItem malice = combatData.FirstOrDefault(x => x.SkillID == EmpoweredMaliceEmbodiment && x.DstMatchesAgent(target.AgentItem) && x.IsBuffApply());
+                        target.OverrideName(target.Character + " (P" + curMalice++ + ")");
                         if (malice != null && Math.Abs(target.FirstAware - malice.Time) <= ServerDelayConstant)
                         {
                             target.OverrideName("Empowered " + target.Character + " (P" + curMalice++ + ")");
                         }
-                        else
-                        {
-                            target.OverrideName(target.Character + " (P" + curMalice++ + ")");
-                        }
                         break;
                     case (int)ArcDPSEnums.TrashID.EmbodimentOfRage:
-                        CombatItem rage = combatData.FirstOrDefault(x => x.SkillID == EmpoweredRageEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        CombatItem rage = combatData.FirstOrDefault(x => x.SkillID == EmpoweredRageEmbodiment && x.DstMatchesAgent(target.AgentItem) && x.IsBuffApply());
+                        target.OverrideName(target.Character + " (P" + curRage++ + ")");
                         if (rage != null && Math.Abs(target.FirstAware - rage.Time) <= ServerDelayConstant)
                         {
                             target.OverrideName("Empowered " + target.Character + " (P" + curRage++ + ")");
                         }
-                        else
-                        {
-                            target.OverrideName(target.Character + " (P" + curRage++ + ")");
-                        }
                         break;
                     case (int)ArcDPSEnums.TrashID.EmbodimentOfRegret:
-                        CombatItem regret = combatData.FirstOrDefault(x => x.SkillID == EmpoweredRegretEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        CombatItem regret = combatData.FirstOrDefault(x => x.SkillID == EmpoweredRegretEmbodiment && x.DstMatchesAgent(target.AgentItem) && x.IsBuffApply());
+                        target.OverrideName(target.Character + " (P" + curRegret++ + ")");
                         if (regret != null && Math.Abs(target.FirstAware - regret.Time) <= ServerDelayConstant)
                         {
                             target.OverrideName("Empowered " + target.Character + " (P" + curRegret++ + ")");
-                        }
-                        else
-                        {
-                            target.OverrideName(target.Character + " (P" + curRegret++ + ")");
                         }
                         break;
                     default:

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
@@ -41,6 +41,18 @@ namespace GW2EIEvtcParser.EncounterLogic
                 new EnemyDstBuffApplyMechanic(EmpoweredMaliceCerus, "Empowered Malice", new MechanicPlotlySetting(Symbols.Square, Colors.LightBlue), "EmpMal.A", "Gained Empowered Malice", "Empowered Malice Application", 0),
                 new EnemyDstBuffApplyMechanic(EmpoweredRageCerus, "Empowered Rage", new MechanicPlotlySetting(Symbols.Square, Colors.LightOrange), "EmpRage.A", "Gained Empowered Rage", "Empowered Rage Application", 0),
                 new EnemyDstBuffApplyMechanic(EmpoweredRegretCerus, "Empowered Regret", new MechanicPlotlySetting(Symbols.Square, Colors.LightGrey), "EmpReg.A", "Gained Empowered Regret", "Empowered Regret Application", 0),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.LightRed), "Despair.K", "Embodiment of Despair Killed", "Despair Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfDespair) && !bae.To.HasBuff(log, EmpoweredDespairEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.LightBlue), "Envy.K", "Embodiment of Envy Killed", "Envy Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfEnvy) && !bae.To.HasBuff(log, EmpoweredEnvyEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.LightOrange), "Gluttony.K", "Embodiment of Gluttony Killed", "Gluttony Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfGluttony) && ! bae.To.HasBuff(log, EmpoweredGluttonyEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.LightGrey), "Malice.K", "Embodiment of Malice Killed", "Malice Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfMalice) && !bae.To.HasBuff(log, EmpoweredMaliceEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.LightPurple), "Rage.K", "Embodiment of Rage Killed", "Rage Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfRage) && !bae.To.HasBuff(log, EmpoweredRageEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.White), "Regret.K", "Embodiment of Regret Killed", "Regret Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfRegret) && !bae.To.HasBuff(log, EmpoweredRegretEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.Red), "Emp.Despair.K", "Empowered Embodiment of Despair Killed", "Empowered Despair Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfDespair) && bae.To.HasBuff(log, EmpoweredDespairEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.Blue), "Emp.Envy.K", "Empowered Embodiment of Envy Killed", "Empowered Envy Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfEnvy) && bae.To.HasBuff(log, EmpoweredEnvyEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.Orange), "Emp.Gluttony.K", "Empowered Embodiment of Gluttony Killed", "Empowered Gluttony Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfGluttony) && bae.To.HasBuff(log, EmpoweredGluttonyEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.Grey), "Emp.Malice.K", "Empowered Embodiment of Malice Killed", "Empowered Malice Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfMalice) && bae.To.HasBuff(log, EmpoweredMaliceEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.Purple), "Emp.Rage.K", "Empowered Embodiment of Rage Killed", "Empowered Rage Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfRage) && bae.To.HasBuff(log, EmpoweredRageEmbodiment, bae.Time)),
+                new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.StarOpen, Colors.Black), "Emp.Regret.K", "Empowered Embodiment of Regret Killed", "Empowered Regret Killed", 0).UsingChecker((bae, log) => bae.To.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfRegret) && bae.To.HasBuff(log, EmpoweredRegretEmbodiment, bae.Time)),
                 new EnemyCastStartMechanic(EnragedSmash, "Enraged Smash", new MechanicPlotlySetting(Symbols.Star, Colors.Blue), "EnrSmash.C", "Casted Enraged Smash", "Enraged Smash Cast", 0),
                 new EnemyCastStartMechanic(new long [] { InsatiableHunger1, InsatiableHunger2, InsatiableHunger3, InsatiableHunger4, InsatiableHunger5, InsatiableHunger6, InsatiableHunger7, InsatiableHunger8, InsatiableHunger9, InsatiableHunger10 }, "Insatiable Hunger", new MechanicPlotlySetting(Symbols.HourglassOpen, Colors.Pink), "InsHun.C", "Casted Insatiable Hunger", "Insatiable Hunger Cast", 0),
                 new EnemyCastStartMechanic(EnviousGaze, "Envious Gaze", new MechanicPlotlySetting(Symbols.TriangleDownOpen, Colors.Red), "EnvGaz.C", "Casted Envious Gaze (One Beam)", "Envious Gaze Cast (One Beam)", 0),
@@ -128,29 +140,76 @@ namespace GW2EIEvtcParser.EncounterLogic
             int curRegret = 1;
             foreach (AbstractSingleActor target in Targets)
             {
-                if (target.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfDespair))
+                switch (target.ID)
                 {
-                    target.OverrideName(target.Character + " " + curDespair++);
-                }
-                if (target.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfEnvy))
-                {
-                    target.OverrideName(target.Character + " " + curEnvy++);
-                }
-                if (target.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfGluttony))
-                {
-                    target.OverrideName(target.Character + " " + curGluttony++);
-                }
-                if (target.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfMalice))
-                {
-                    target.OverrideName(target.Character + " " + curMalice++);
-                }
-                if (target.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfRage))
-                {
-                    target.OverrideName(target.Character + " " + curRage++);
-                }
-                if (target.IsSpecies(ArcDPSEnums.TrashID.EmbodimentOfRegret))
-                {
-                    target.OverrideName(target.Character + " " + curRegret++);
+                    case (int)ArcDPSEnums.TrashID.EmbodimentOfDespair:
+                        CombatItem despair = combatData.FirstOrDefault(x => x.SkillID == EmpoweredDespairEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        if (despair != null && Math.Abs(target.FirstAware - despair.Time) <= ServerDelayConstant)
+                        {
+                            target.OverrideName("Empowered " + target.Character + " (P" + curDespair++ + ")");
+                        }
+                        else
+                        {
+                            target.OverrideName(target.Character + " (P" + curDespair++ + ")");
+                        }
+                        break;
+                    case (int)ArcDPSEnums.TrashID.EmbodimentOfEnvy:
+                        CombatItem envy = combatData.FirstOrDefault(x => x.SkillID == EmpoweredEnvyEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        if (envy != null && Math.Abs(target.FirstAware - envy.Time) <= ServerDelayConstant)
+                        {
+                            target.OverrideName("Empowered " + target.Character + " (P" + curEnvy++ + ")");
+                        }
+                        else
+                        {
+                            target.OverrideName(target.Character + " (P" + curEnvy++ + ")");
+                        }
+                        break;
+                    case (int)ArcDPSEnums.TrashID.EmbodimentOfGluttony:
+                        CombatItem gluttony = combatData.FirstOrDefault(x => x.SkillID == EmpoweredGluttonyEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        if (gluttony != null && Math.Abs(target.FirstAware - gluttony.Time) <= ServerDelayConstant)
+                        {
+                            target.OverrideName("Empowered " + target.Character + " (P" + curGluttony++ + ")");
+                        }
+                        else
+                        {
+                            target.OverrideName(target.Character + " (P" + curGluttony++ + ")");
+                        }
+                        break;
+                    case (int)ArcDPSEnums.TrashID.EmbodimentOfMalice:
+                        CombatItem malice = combatData.FirstOrDefault(x => x.SkillID == EmpoweredMaliceEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        if (malice != null && Math.Abs(target.FirstAware - malice.Time) <= ServerDelayConstant)
+                        {
+                            target.OverrideName("Empowered " + target.Character + " (P" + curMalice++ + ")");
+                        }
+                        else
+                        {
+                            target.OverrideName(target.Character + " (P" + curMalice++ + ")");
+                        }
+                        break;
+                    case (int)ArcDPSEnums.TrashID.EmbodimentOfRage:
+                        CombatItem rage = combatData.FirstOrDefault(x => x.SkillID == EmpoweredRageEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        if (rage != null && Math.Abs(target.FirstAware - rage.Time) <= ServerDelayConstant)
+                        {
+                            target.OverrideName("Empowered " + target.Character + " (P" + curRage++ + ")");
+                        }
+                        else
+                        {
+                            target.OverrideName(target.Character + " (P" + curRage++ + ")");
+                        }
+                        break;
+                    case (int)ArcDPSEnums.TrashID.EmbodimentOfRegret:
+                        CombatItem regret = combatData.FirstOrDefault(x => x.SkillID == EmpoweredRegretEmbodiment && x.DstAgent == target.AgentItem.Agent);
+                        if (regret != null && Math.Abs(target.FirstAware - regret.Time) <= ServerDelayConstant)
+                        {
+                            target.OverrideName("Empowered " + target.Character + " (P" + curRegret++ + ")");
+                        }
+                        else
+                        {
+                            target.OverrideName(target.Character + " (P" + curRegret++ + ")");
+                        }
+                        break;
+                    default:
+                        break;
                 }
             }
         }

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1752,6 +1752,7 @@
         public const long SpatialManipulation5 = 38074;
         public const long SpectralAgony = 38077;
         public const long Countdown = 38098;
+        public const long CairnImpact = 38102;
         public const long CairnDisplacement = 38113;
         public const long BrutalizeCast = 38136;
         public const long UnseenBurden = 38153;
@@ -2359,6 +2360,7 @@
         public const long SeaOfFlame = 52461;
         public const long Parry = 52464;
         public const long AquaticDetainment = 52477;
+        public const long QadimInitialCast = 52496;
         public const long ElementalBreath = 52520;
         public const long BurningCrucible = 52522;
         public const long FlameSlash3 = 52528;
@@ -3634,6 +3636,7 @@
         public const long RelicOfTheBrawler = 70913;
         public const long EmpoweredEnvyCerus = 70974;
         public const long RelicOfTheScourge = 70975;
+        public const long InvulnerabilityEmbodiment = 70986;
         public const long DimensionBreach = 71002;
         public const long DemonicFever = 71047;
         public const long RelicOfTheIce = 71051;


### PR DESCRIPTION
- Added mechanics to track wether an empowered or a small embodiment was killed.
- Added buff simulation for the invulnerability buff the small embodiments have during p2
- Added a couple of skill ids from cairn and qadim to SkillIDs
- Updated the naming scheme of the embodiments to include wether they are empowered or not and which phase they are active in.

Bonus note: Qadim's line 193 has x.SkillID == 58814 which never appears in any of my 775 logs, i have other ids related to flame slash though.
![6040](https://github.com/baaron4/GW2-Elite-Insights-Parser/assets/23245218/ffbb4297-b65b-47ac-a9b8-a46759609432)