### PR TITLE
Added Qadim the Peerless decorations, fixed Jade Buster Cannon

### DIFF
--- a/GW2EIEvtcParser/EIData/Actors/AbstractActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractActor.cs
@@ -69,6 +69,26 @@ namespace GW2EIEvtcParser.EIData
             return AgentItem.IsSpecies(id);
         }
 
+        public bool IsAnySpecies(IReadOnlyList<ArcDPSEnums.TrashID> ids)
+        {
+            return AgentItem.IsAnySpecies(ids);
+        }
+
+        public bool IsAnySpecies(IReadOnlyList<ArcDPSEnums.TargetID> ids)
+        {
+            return AgentItem.IsAnySpecies(ids);
+        }
+
+        public bool IsAnySpecies(IReadOnlyList<ArcDPSEnums.MinionID> ids)
+        {
+            return AgentItem.IsAnySpecies(ids);
+        }
+
+        public bool IsAnySpecies(IReadOnlyList<ArcDPSEnums.ChestID> ids)
+        {
+            return AgentItem.IsAnySpecies(ids);
+        }
+
         // Getters
         // Damage logs
         public abstract IReadOnlyList<AbstractHealthDamageEvent> GetDamageEvents(AbstractSingleActor target, ParsedEvtcLog log, long start, long end);

--- a/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
@@ -100,6 +100,11 @@ namespace GW2EIEvtcParser.EIData
             (_, IReadOnlyList<Segment> downs, _) = _statusHelper.GetStatus(log);
             return downs.Any(x => x.ContainsPoint(time));
         }
+        public bool IsDowned(ParsedEvtcLog log, long start, long end)
+        {
+            (_, IReadOnlyList<Segment> downs, _) = _statusHelper.GetStatus(log);
+            return downs.Any(x => x.Start >= start && x.Start <= end);
+        }
         public bool IsDead(ParsedEvtcLog log, long time)
         {
             (IReadOnlyList<Segment> deads,_ , _) = _statusHelper.GetStatus(log);

--- a/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
@@ -100,11 +100,6 @@ namespace GW2EIEvtcParser.EIData
             (_, IReadOnlyList<Segment> downs, _) = _statusHelper.GetStatus(log);
             return downs.Any(x => x.ContainsPoint(time));
         }
-        public bool IsDowned(ParsedEvtcLog log, long start, long end)
-        {
-            (_, IReadOnlyList<Segment> downs, _) = _statusHelper.GetStatus(log);
-            return downs.Any(x => x.Start >= start && x.Start <= end);
-        }
         public bool IsDead(ParsedEvtcLog log, long time)
         {
             (IReadOnlyList<Segment> deads,_ , _) = _statusHelper.GetStatus(log);

--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -364,6 +364,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Unbridled Chaos", UnbridledChaos, Source.FightSpecific, BuffStackType.Stacking, 3, BuffClassification.Other, BuffImages.ExposedEyes),
             new Buff("Rebellious Power", RebelliousPower, Source.FightSpecific, BuffStackType.Stacking, 40, BuffClassification.Other, BuffImages.InfusedShield),
             new Buff("Charged Soul", ChargedSoul, Source.FightSpecific, BuffStackType.Stacking, 20, BuffClassification.Other, BuffImages.PartiallyProtected),
+            new Buff("Breakbar Target", QadimThePeerlessBreakbarTargetBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.Unknown),
             new Buff("Achievement Eligibility: Power Surge", AchievementEligibilityPowerSurge, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             //////////////////////////////////////////////
             // Fractals 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
@@ -390,7 +390,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             foreach (Segment seg in magmaDrop)
             {
                 // If a player has gone into downstate while in air, the magma field will not spawn
-                var hasPlayerDownedInAir = p.IsDowned(log, seg.Start, seg.End + 350);
+                var hasPlayerDownedInAir = log.CombatData.GetDownEvents(p.AgentItem).Any(x => x.Time >= seg.Start && x.Time <= seg.End);
                 long magmaDropEnd = seg.End;
                 replay.AddDecorationWithGrowing(new CircleDecoration(magmaRadius, seg, "rgba(255, 50, 0, 0.2)", new AgentConnector(p)), magmaDropEnd);
                 if (!log.CombatData.HasEffectData)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
@@ -339,6 +339,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                     replay.Decorations.Add(new CircleDecoration(450, (start, end), "rgba(255, 150, 0, 0.4)", new AgentConnector(target)));
                     break;
                 case (int)ArcDPSEnums.TrashID.FriendlyPeerlessQadimPylon:
+                    // Red tether from Qadim to the Pylon during breakbar
+                    List<AbstractBuffEvent> breakbarBuffs = GetFilteredList(log.CombatData, QadimThePeerlessBreakbarTargetBuff, target, true, true);
+                    replay.AddTether(breakbarBuffs, "rgba(255, 0, 0, 0.4)");
                     break;
                 case (int)ArcDPSEnums.TrashID.HostilePeerlessQadimPylon:
                     break;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
@@ -56,7 +56,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<int>()
             {
                 (int)ArcDPSEnums.TargetID.PeerlessQadim,
-                (int)ArcDPSEnums.TrashID.FriendlyPeerlessQadimPylon,
+                (int)ArcDPSEnums.TrashID.PeerlessQadimPylon,
                 (int)ArcDPSEnums.TrashID.EntropicDistortion,
             };
         }
@@ -65,12 +65,12 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<ArcDPSEnums.TrashID>()
             {
-                ArcDPSEnums.TrashID.HostilePeerlessQadimPylon,
+                //ArcDPSEnums.TrashID.PeerlessQadimAuraPylon,
                 ArcDPSEnums.TrashID.BigKillerTornado,
                 ArcDPSEnums.TrashID.EnergyOrb,
-                ArcDPSEnums.TrashID.Brandstorm,
+                //ArcDPSEnums.TrashID.Brandstorm,
                 ArcDPSEnums.TrashID.GiantQadimThePeerless,
-                ArcDPSEnums.TrashID.DummyPeerlessQadim,
+                //ArcDPSEnums.TrashID.DummyPeerlessQadim,
             };
         }
 
@@ -94,8 +94,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             base.EIEvtcParse(gw2Build, fightData, agentData, combatData, extensions);
 
             // Update pylon names with their cardinal locations.
-            IReadOnlyList<ArcDPSEnums.TrashID> pylons = new List<ArcDPSEnums.TrashID>() { ArcDPSEnums.TrashID.FriendlyPeerlessQadimPylon, ArcDPSEnums.TrashID.HostilePeerlessQadimPylon };
-            foreach (NPC target in Targets.Where(x => x.IsAnySpecies(pylons)).Cast<NPC>())
+            foreach (NPC target in Targets.Where(x => x.IsSpecies(ArcDPSEnums.TrashID.PeerlessQadimPylon)).Cast<NPC>())
             {
                 AddNameSuffixBasedOnInitialPosition(target, combatData, PylonLocations);
             }
@@ -309,7 +308,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         {
                             replay.AddDecorationWithGrowing(new CircleDecoration(radius, (start, end), "rgba(255, 220, 0, 0.2)", new PositionConnector(position)), end);
 
-                            foreach (NPC pylon in TrashMobs.Where(x => x.IsSpecies(ArcDPSEnums.TrashID.HostilePeerlessQadimPylon)))
+                            foreach (NPC pylon in TrashMobs.Where(x => x.IsSpecies(ArcDPSEnums.TrashID.PeerlessQadimAuraPylon)))
                             {
                                 replay.AddDecorationWithGrowing(new CircleDecoration(radius, (start, end), "rgba(255, 220, 0, 0.2)", new AgentConnector(pylon)), end);
                             }
@@ -338,12 +337,12 @@ namespace GW2EIEvtcParser.EncounterLogic
                 case (int)ArcDPSEnums.TrashID.BigKillerTornado:
                     replay.Decorations.Add(new CircleDecoration(450, (start, end), "rgba(255, 150, 0, 0.4)", new AgentConnector(target)));
                     break;
-                case (int)ArcDPSEnums.TrashID.FriendlyPeerlessQadimPylon:
+                case (int)ArcDPSEnums.TrashID.PeerlessQadimPylon:
                     // Red tether from Qadim to the Pylon during breakbar
                     List<AbstractBuffEvent> breakbarBuffs = GetFilteredList(log.CombatData, QadimThePeerlessBreakbarTargetBuff, target, true, true);
                     replay.AddTether(breakbarBuffs, "rgba(255, 0, 0, 0.4)");
                     break;
-                case (int)ArcDPSEnums.TrashID.HostilePeerlessQadimPylon:
+                case (int)ArcDPSEnums.TrashID.PeerlessQadimAuraPylon:
                     break;
                 case (int)ArcDPSEnums.TrashID.EnergyOrb:
                     replay.Decorations.Add(new CircleDecoration(200, (start, end), "rgba(0, 255, 0, 0.3)", new AgentConnector(target)));

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
@@ -431,7 +431,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     timeDeath = deadEvents.Where(x => x.Time > cast.Time).FirstOrDefault().Time;
                 }
                 var segment = new Segment(cast.Time, Math.Min(timeUnleash, timeDeath), 1);
-                replay.AddOverheadIcon(segment, p, "https://i.imgur.com/0EnjyQX.png");
+                replay.AddOverheadIcon(segment, p, ParserIcons.GenericBlueArrowUp);
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/KainengOverlook.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/KainengOverlook.cs
@@ -368,6 +368,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     // Jade Buster Cannon
                     var cannon = casts.Where(x => x.SkillId == JadeBusterCannonMechRider).ToList();
                     int warningDuration = 2800;
+                    var offset = new Point3D(0, -1400);
                     // Warning decoration
                     if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.KainengOverlookJadeBusterCannonWarning, out IReadOnlyList<EffectEvent> warningRectangle))
                     {
@@ -375,7 +376,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                         {
                             (long, long) lifespanWarning = ProfHelper.ComputeEffectLifespan(log, effect, warningDuration);
                             var connector = new AgentConnector(target);
-                            var rectangle = new RectangleDecoration(375, 3000, lifespanWarning, "rgba(200, 120, 0, 0.2)", connector.WithOffset(new Point3D(0, -1350), true));
+                            var rotationConnector = new AgentFacingConnector(target, 90, AgentFacingConnector.RotationOffsetMode.AddToMaster);
+                            var rectangle = (RectangleDecoration)new RectangleDecoration(375, 3000, lifespanWarning, "rgba(200, 120, 0, 0.2)", connector.WithOffset(offset, true)).UsingRotationConnector(rotationConnector);
                             replay.AddDecorationWithBorder(rectangle, "rgba(250, 50, 0, 0.2)");
                         }
                     }
@@ -385,8 +387,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                         int durationCastTime = 10367;
                         (long, long) lifespan = (c.Time + warningDuration, c.Time + durationCastTime - warningDuration);
                         var connector = new AgentConnector(target);
-                        var rectangle = new RectangleDecoration(375, 3000, lifespan, "rgba(30, 120, 40, 0.4)", connector.WithOffset(new Point3D(0, -1350), true));
-                        replay.AddDecorationWithBorder(rectangle, "rgba(250, 50, 0, 0.2)");
+                        var rotationConnector = new AgentFacingConnector(target, 90, AgentFacingConnector.RotationOffsetMode.AddToMaster);
+                        var rectangle = (RectangleDecoration)new RectangleDecoration(375, 3000, lifespan, "rgba(30, 120, 40, 0.4)", connector.WithOffset(offset, true)).UsingRotationConnector(rotationConnector);
+                        replay.AddDecorationWithBorder(rectangle, "rgba(255, 0, 0, 0.2)");
                     }
                     break;
                 case (int)ArcDPSEnums.TrashID.TheEnforcer:

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -617,7 +617,7 @@ namespace GW2EIEvtcParser.ParsedData
             // - Qadim the Peerless
             { FluxDisruptorActivateCast, "https://wiki.guildwars2.com/images/d/d5/Flux_Disruptor-_Activate.png" },
             { FluxDisruptorDeactivateCast, "https://wiki.guildwars2.com/images/3/34/Flux_Disruptor-_Deactivate.png" },
-            { PlayerLiftUpQadimThePeerless, "https://i.imgur.com/0EnjyQX.png" },
+            { PlayerLiftUpQadimThePeerless, ParserIcons.GenericBlueArrowUp },
             { UnleashSAK, "https://wiki.guildwars2.com/images/9/99/Touch_of_the_Sun.png" },
             // - Dadga (Cosmic Observatory)
             { PurifyingLight, "https://wiki.guildwars2.com/images/1/1e/Purifying_Light_%28Dagda%29.png" },

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -211,6 +211,7 @@ namespace GW2EIEvtcParser.ParsedData
             { FluxDisruptorActivateCast, "Flux Disruptor: Activate" },
             { FluxDisruptorDeactivateCast, "Flux Disruptor: Deactivate" },
             { PlayerLiftUpQadimThePeerless, "Player Lift Up Mechanic" },
+            { UnleashSAK, "Unleash" },
             //{56036, "Magma Bomb" },
             { ForceOfRetaliationCast, "Force of Retaliation Cast" },
             { PeerlessQadimTPCenter, "Teleport Center" },
@@ -616,6 +617,7 @@ namespace GW2EIEvtcParser.ParsedData
             // - Qadim the Peerless
             { FluxDisruptorActivateCast, "https://wiki.guildwars2.com/images/d/d5/Flux_Disruptor-_Activate.png" },
             { FluxDisruptorDeactivateCast, "https://wiki.guildwars2.com/images/3/34/Flux_Disruptor-_Deactivate.png" },
+            { PlayerLiftUpQadimThePeerless, "https://i.imgur.com/0EnjyQX.png" },
             { UnleashSAK, "https://wiki.guildwars2.com/images/9/99/Touch_of_the_Sun.png" },
             // - Dadga (Cosmic Observatory)
             { PurifyingLight, "https://wiki.guildwars2.com/images/1/1e/Purifying_Light_%28Dagda%29.png" },

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -770,8 +770,8 @@ namespace GW2EIEvtcParser
             SmallKillerTornado = 21957,
             BigKillerTornado = 21987,
             // Peerless Qadim
-            FriendlyPeerlessQadimPylon = 21996,
-            HostilePeerlessQadimPylon = 21962,
+            PeerlessQadimPylon = 21996,
+            PeerlessQadimAuraPylon = 21962,
             EntropicDistortion = 21973,
             EnergyOrb = 21946,
             Brandstorm = 21978,

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -774,6 +774,9 @@ namespace GW2EIEvtcParser
             HostilePeerlessQadimPylon = 21962,
             EntropicDistortion = 21973,
             EnergyOrb = 21946,
+            Brandstorm = 21978,
+            GiantQadimThePeerless = 21953,
+            DummyPeerlessQadim = 22005,
             // Fraenir
             IcebroodElemental = 22576,
             BoundIcebroodElemental = ArcDPSEnums.BoundIcebroodElemental,

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -351,6 +351,26 @@ namespace GW2EIEvtcParser
         public const string CairnDashGreen = "D2E6D55CC94F79418BB907F063CBDD81";
         // CA
         public const string CAArmSmash = "B1AAD873DB07E04E9D69627156CA8918";
+        // Qadim the Peerless
+        public const string QadimPeerlessRainOfChaos = "D8259BFD4E6B8348AF15D862F7DBC8FA";
+        public const string QadimPeerlessResidualImpactFireAoE = "EFAC2FC0F661404D84F0291CAB76FF0E";
+        public const string QadimPeerlessChaosCalledElectricShark = "7A5A2002C855A440BCC22E2C76B0C405";
+        public const string QadimPeerlessForceOfHavoc1 = "5F3B01764915FD41A02B2FBAD788651B"; // 2000 duration
+        public const string QadimPeerlessForceOfHavoc2 = "B2396CC1F4A73B4EAEA86F66978DC895"; // 1000 duration
+        public const string QadimPeerlessForceOfHavoc3 = "A2E91B50829AB64097D217E468189F52"; // 22400 duration
+        public const string QadimPeerlessEtherStrikesOrbs = "625838F1175E25459A5293CA6C911290"; // 1500 duration
+        public const string QadimPeerlessEtherStrikesAoEs = "A89E436B20CFC142B159F3D2195F75AE"; // 0 duration
+        public const string QadimPeerlessShowerOfChaosAoE = "845D252D05631740B3B2309457FB4338"; // 5000 duration
+        public const string QadimPeerlessShowerOfChaosExplosion = "3AAEF82C63C4424FAA0F55CD02256E00";
+        public const string QadimPeerlessShowerOfChaosOnPlayer1 = "27B83B9DF241F94DB16414852EA68354";
+        public const string QadimPeerlessShowerOfChaosOnPlayer2 = "0BA57434DC93604096B870FB98B3C4F1"; // Src Qadim
+        public const string QadimPeerlessMeteorIllusion1 = "00C4F7C59E4D8449B565CC00FC30D9DD"; // 5000 duration
+        public const string QadimPeerlessMeteorIllusion2 = "ED04DA4F2B31D74CBEF501CAFFDAFAAD"; // 4294967295 duration - Usable with ComputeDynamicEffectLifespan
+        public const string QadimPeerlessBrandstormLightning1 = "C5B4846F6A548D47B0856AA8A2CE283C"; // 0 duration
+        public const string QadimPeerlessBrandstormLightning2 = "995E6709BB16B44DBABCC707F10E5345"; // 3000 duration
+        public const string QadimPeerlessMagmaWarningAoE = "E269977C2FC9474EAAD1051CDAFAD653"; // 4000 duration - Src player
+        public const string QadimPeerlessMagmaLandingExplosion = "6617FA23565EE646ADAA7A646C895927"; // 1000 duration - No Src
+        public const string QadimPeerlessMagmaDamagingAoE = "BABE69EC5AC7AF48A2F14A9FB8920C7F"; // 600000 duration - Src Qadim
         // Boneskinner
         public const string GraspAoeIndicator = "B9B32815D670DC4E8B8CF71E92A9FFD5"; // Orange aoe indicator
         public const string GraspClaws1 = "75B096EF78F3AB4CB1D05BAE9CA3235C"; // One is the claw, the other the red aoe indicator

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -21,6 +21,11 @@ namespace GW2EIEvtcParser.ParserHelpers
         /// </summary>
         public const string GenericEnemyIcon = "https://i.imgur.com/ZnFcOIA.png";
 
+        /// <summary>
+        /// Generic blue arrow up.
+        /// </summary>
+        public const string GenericBlueArrowUp = "https://i.imgur.com/0EnjyQX.png";
+
         // High Resolution Icons 200px
         private const string HighResUntamed = "https://wiki.guildwars2.com/images/3/33/Untamed_tango_icon_200px.png";
         private const string HighResSoulbeast = "https://wiki.guildwars2.com/images/f/f6/Soulbeast_tango_icon_200px.png";

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -244,8 +244,8 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashHandOfErosionEruption = "https://i.imgur.com/reGQHhr.png";
         private const string TrashVoltaicWisp = "https://i.imgur.com/C1mvNGZ.png";
         private const string TrashParalyzingWisp = "https://i.imgur.com/YBl8Pqo.png";
-        private const string TrashFriendlyPeerlessQadimPylon = "https://i.imgur.com/CXbs6up.png";
-        private const string TrashHostilePeerlessQadimPylon = "https://i.imgur.com/ojjQQlR.png";
+        private const string TrashPeerlessQadimPylon = "https://i.imgur.com/Db5Pi3b.png";
+        private const string TrashPeerlessQadimAuraPylon = "https://i.imgur.com/ojjQQlR.png";
         private const string TrashEntropicDistortion = "https://i.imgur.com/MIpP5pK.png";
         private const string TrashGiantQadimThePeerless = "https://i.imgur.com/qRhJSgR.png";
         private const string TrashSmallJumpyTornado = "https://i.imgur.com/WBJNgp7.png";
@@ -971,12 +971,12 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.HandOfEruption, TrashHandOfErosionEruption },
             { ArcDPSEnums.TrashID.VoltaicWisp, TrashVoltaicWisp },
             { ArcDPSEnums.TrashID.ParalyzingWisp, TrashParalyzingWisp },
-            { ArcDPSEnums.TrashID.FriendlyPeerlessQadimPylon, TrashFriendlyPeerlessQadimPylon },
-            { ArcDPSEnums.TrashID.HostilePeerlessQadimPylon, TrashHostilePeerlessQadimPylon },
+            { ArcDPSEnums.TrashID.PeerlessQadimPylon, TrashPeerlessQadimPylon },
+            //{ ArcDPSEnums.TrashID.PeerlessQadimAuraPylon, TrashPeerlessQadimAuraPylon },
             { ArcDPSEnums.TrashID.EntropicDistortion, TrashEntropicDistortion },
-            { ArcDPSEnums.TrashID.Brandstorm, GenericEnemyIcon },
+            //{ ArcDPSEnums.TrashID.Brandstorm, GenericEnemyIcon },
             { ArcDPSEnums.TrashID.GiantQadimThePeerless, TrashGiantQadimThePeerless },
-            { ArcDPSEnums.TrashID.DummyPeerlessQadim, GenericEnemyIcon },
+            //{ ArcDPSEnums.TrashID.DummyPeerlessQadim, GenericEnemyIcon },
             { ArcDPSEnums.TrashID.SmallJumpyTornado, TrashSmallJumpyTornado },
             { ArcDPSEnums.TrashID.OrbSpider, TrashOrbSpider },
             { ArcDPSEnums.TrashID.Seekers, TrashSeekers },

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -244,8 +244,10 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashHandOfErosionEruption = "https://i.imgur.com/reGQHhr.png";
         private const string TrashVoltaicWisp = "https://i.imgur.com/C1mvNGZ.png";
         private const string TrashParalyzingWisp = "https://i.imgur.com/YBl8Pqo.png";
-        private const string TrashHostilePeerlessQadimPylon = "https://i.imgur.com/b33vAEQ.png";
+        private const string TrashFriendlyPeerlessQadimPylon = "https://i.imgur.com/CXbs6up.png";
+        private const string TrashHostilePeerlessQadimPylon = "https://i.imgur.com/ojjQQlR.png";
         private const string TrashEntropicDistortion = "https://i.imgur.com/MIpP5pK.png";
+        private const string TrashGiantQadimThePeerless = "https://i.imgur.com/qRhJSgR.png";
         private const string TrashSmallJumpyTornado = "https://i.imgur.com/WBJNgp7.png";
         private const string TrashOrbSpider = "https://i.imgur.com/FB5VM9X.png";
         private const string TrashSeekers = "https://i.imgur.com/FrPoluz.png";
@@ -969,8 +971,12 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.HandOfEruption, TrashHandOfErosionEruption },
             { ArcDPSEnums.TrashID.VoltaicWisp, TrashVoltaicWisp },
             { ArcDPSEnums.TrashID.ParalyzingWisp, TrashParalyzingWisp },
+            { ArcDPSEnums.TrashID.FriendlyPeerlessQadimPylon, TrashFriendlyPeerlessQadimPylon },
             { ArcDPSEnums.TrashID.HostilePeerlessQadimPylon, TrashHostilePeerlessQadimPylon },
             { ArcDPSEnums.TrashID.EntropicDistortion, TrashEntropicDistortion },
+            { ArcDPSEnums.TrashID.Brandstorm, GenericEnemyIcon },
+            { ArcDPSEnums.TrashID.GiantQadimThePeerless, TrashGiantQadimThePeerless },
+            { ArcDPSEnums.TrashID.DummyPeerlessQadim, GenericEnemyIcon },
             { ArcDPSEnums.TrashID.SmallJumpyTornado, TrashSmallJumpyTornado },
             { ArcDPSEnums.TrashID.OrbSpider, TrashOrbSpider },
             { ArcDPSEnums.TrashID.Seekers, TrashSeekers },
@@ -989,7 +995,6 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.VigilTactician, TrashGenericFriendlyTarget },
             { ArcDPSEnums.TrashID.Prisoner1, TrashGenericFriendlyTarget },
             { ArcDPSEnums.TrashID.Prisoner2, TrashGenericFriendlyTarget },
-            { ArcDPSEnums.TrashID.FriendlyPeerlessQadimPylon, TrashGenericFriendlyTarget },
             { ArcDPSEnums.TrashID.Mine, TrashMine },
             { ArcDPSEnums.TrashID.FleshWurm, TrashFleshWurm },
             { ArcDPSEnums.TrashID.Hands, TrashHands },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -2524,6 +2524,7 @@
         public const long ExponentialRepercussion = 56223;
         public const long Invulnerability56227 = 56227;
         public const long CleansedConductor = 56237;
+        public const long QadimThePeerlessBreakbarTargetBuff = 56245;
         public const long Incorporeal = 56250;
         public const long FlashDischargeSAK = 56251;
         public const long ExponentialRepercussionQadimShield = 56254;


### PR DESCRIPTION
# Qadim the Peerless
- Added Pylons and Entropic Distortions as targets
- Added Brandstorm, Dummy Qadim and Giant Qadim to trash targets
- Added location points of the pylons and overridden their names to include which direction they are located at
- Updated Magma Drop decoration for logs without effects
- Fixed an issue in which Magma Drop would spawn a damaging aoe decoration incorrectly (when the player downstates while in air)
- Added Magma Drop decorations using effects
- Added a stun overhead icon for stunned distortions
- Added an arrow overhead icon for the players lifted up during the 40-30-20 % mechanic in CM
- Updated the Entropic Distortion spawn decoration to better visualize their offset position compared to the orb spawn location
- Added Rain of Chaos aoes
- Added Residual Impact fires
- Added Chaos Called (shark)
- Added Ether Strikes aoes
- Added orb spawn aoes (red if failed, white if caught)
- Added meteor illusion orbs to collect during 40-30-20%
- Added brandstorm lightning aoes
- Fixed name of the SAK during 40-30-20% CM mechanic
- Updated icons for friendly and enemy pylons
- Added icon for giant Qadim
- Added tether between Qadim and a pylon during breakbars

# Kaineng Overlook
- Fixed jade buster cannon rotation and offset

# API
- Added IsAnySpecies to AbstractSingleActor

# Tests
[qtp_tests.zip](https://github.com/baaron4/GW2-Elite-Insights-Parser/files/13210241/qtp_tests.zip)
