### PR TITLE
Added encounter related cast detections

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffImages.cs
@@ -1547,6 +1547,7 @@
         internal const string HeatTheSoul = "https://wiki.guildwars2.com/images/5/58/Heat_the_Soul.png";
         internal const string CompoundingChemicals = "https://wiki.guildwars2.com/images/c/c9/Alchemical_Tinctures.png";
         internal const string CounterMagicSkill = "https://wiki.guildwars2.com/images/6/69/Counter_Magic_%28skill%29.png";
+        internal const string CelestialDash = "https://wiki.guildwars2.com/images/5/56/Celestial_Dash.png";
         // Consumables
         internal const string ReinforcedArmor = "https://wiki.guildwars2.com/images/8/83/Reinforced_Armor.png";
         internal const string SpeedBonus15 = "https://wiki.guildwars2.com/images/d/d7/Speed_Bonus_%28fifteen_percent%29.png";

--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -211,7 +211,8 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Bending Chaos", BendingChaos, Source.FightSpecific, BuffStackType.Stacking, 11, BuffClassification.Other, BuffImages.Target2),
             new Buff("Shifting Chaos", ShiftingChaos, Source.FightSpecific, BuffStackType.Stacking, 11, BuffClassification.Other, BuffImages.ShiftingChaos),
             new Buff("Twisting Chaos", TwistingChaos, Source.FightSpecific, BuffStackType.Stacking, 11, BuffClassification.Other, BuffImages.TwistingChaos),
-            new Buff("Intervention", Intervention, Source.FightSpecific, BuffClassification.Other, BuffImages.Intervention),
+            new Buff("Intervention (SAK)", InterventionSkillOwnerBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.Intervention),
+            new Buff("Intervention (Invuln)", InterventionInvulnerabilityBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.Intervention),
             new Buff("Bloodstone Protection", BloodstoneProtection, Source.FightSpecific, BuffClassification.Other, BuffImages.BloodstoneProtection),
             new Buff("Bloodstone Blessed", BloodstoneBlessed, Source.FightSpecific, BuffClassification.Other, BuffImages.BloodstoneBlessed),
             new Buff("Void Zone", VoidZone, Source.FightSpecific, BuffClassification.Other, BuffImages.VoidZone),
@@ -226,6 +227,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Unseen Burden", UnseenBurden, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Debuff, BuffImages.UnseenBurden),
             new Buff("Countdown", Countdown, Source.FightSpecific, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.Countdown),
             new Buff("Gaze Avoidance", GazeAvoidance, Source.FightSpecific, BuffClassification.Other, BuffImages.GazeAvoidance),
+            new Buff("Celestial Dash", CelestialDashBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.CelestialDash),
             // Mursaat Overseer
             new Buff("Empowered", Empowered, Source.FightSpecific, BuffStackType.Stacking, 4, BuffClassification.Other, BuffImages.Empowered),
             new Buff("Mursaat Overseer's Shield", MursaatOverseersShield, Source.FightSpecific, BuffClassification.Other, BuffImages.Dispel),
@@ -394,6 +396,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Corporeal Reassignment", CorporealReassignmentBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.RedirectAnomaly),
             new Buff("Blinding Radiance", BlindingRadiance, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
             new Buff("Determination (Viirastra)", DeterminationViirastra, Source.FightSpecific, BuffClassification.Other, BuffImages.GambitExhausted),
+            new Buff("Nova Launch", NovaLaunchBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.CelestialDash),
             // Arkk 
             new Buff("Fixated (Bloom 3)", FixatedBloom3, Source.FightSpecific, BuffClassification.Other, BuffImages.Fixated),
             new Buff("Fixated (Bloom 2)", FixatedBloom2, Source.FightSpecific, BuffClassification.Other, BuffImages.Fixated),
@@ -402,6 +405,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Cosmic Meteor", CosmicMeteor, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
             new Buff("Diaphanous Shielding", DiaphanousShielding, Source.FightSpecific, BuffStackType.Stacking, 4, BuffClassification.Other, BuffImages.RedirectAnomaly),
             new Buff("Electrocuted", Electrocuted, Source.FightSpecific, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.AirAttunement),
+            new Buff("Hypernova Launch", HypernovaLaunchBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.CelestialDash),
             // Ai, Keeper of the Peak
             new Buff("Tidal Barrier", TidalBarrier, Source.FightSpecific, BuffClassification.Other, BuffImages.PrimedBottle),
             new Buff("Whirlwind Shield", WhirlwindShield, Source.FightSpecific, BuffClassification.Other, BuffImages.PrimedBottle),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -260,19 +260,6 @@ namespace GW2EIEvtcParser.EIData
             return res;
         }
 
-        public static IReadOnlyList<AnimatedCastEvent> ComputeRideTheLightningCastEvents(Player player, CombatData combatData, SkillData skillData, AgentData agentData)
-        {
-            var res = new List<AnimatedCastEvent>();
-            SkillItem skill = skillData.Get(RideTheLightningSkill);
-            var applies = combatData.GetBuffData(RideTheLightningBuff).OfType<BuffApplyEvent>().Where(x => x.To == player.AgentItem).ToList();
-            var removals = combatData.GetBuffData(RideTheLightningBuff).OfType<BuffRemoveAllEvent>().Where(x => x.To == player.AgentItem).ToList();
-            for (int i = 0; i < applies.Count && i < removals.Count; i++)
-            {
-                res.Add(new AnimatedCastEvent(player.AgentItem, skill, applies[i].Time, removals[i].Time - applies[i].Time));
-            }
-            return res;
-        }
-
         internal static void ComputeProfessionCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
         {
             Color color = Colors.Elementalist;

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -603,5 +603,18 @@ namespace GW2EIEvtcParser.EIData
             long end = ComputeEffectEndTime(log, effect, durationToUse, agent, associatedBuff);
             return (start, end);
         }
+
+        internal static IReadOnlyList<AnimatedCastEvent> ComputeDashCastEvents(Player player, CombatData combatData, SkillData skillData, AgentData agentData, long skillId, long buffId)
+        {
+            var res = new List<AnimatedCastEvent>();
+            SkillItem skill = skillData.Get(skillId);
+            var applies = combatData.GetBuffData(buffId).OfType<BuffApplyEvent>().Where(x => x.To == player.AgentItem).ToList();
+            var removals = combatData.GetBuffData(buffId).OfType<BuffRemoveAllEvent>().Where(x => x.To == player.AgentItem).ToList();
+            for (int i = 0; i < applies.Count && i < removals.Count; i++)
+            {
+                res.Add(new AnimatedCastEvent(player.AgentItem, skill, applies[i].Time, removals[i].Time - applies[i].Time));
+            }
+            return res;
+        }
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -271,19 +271,6 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Poison Master", PoisonMasterBuff, Source.Ranger, BuffClassification.Other, BuffImages.PoisonMaster),
         };
 
-        public static IReadOnlyList<AnimatedCastEvent> ComputeAncestralGraceCastEvents(Player player, CombatData combatData, SkillData skillData, AgentData agentData)
-        {
-            var res = new List<AnimatedCastEvent>();
-            SkillItem skill = skillData.Get(AncestralGraceSkill);
-            var applies = combatData.GetBuffData(AncestralGraceBuff).OfType<BuffApplyEvent>().Where(x => x.To == player.AgentItem).ToList();
-            var removals = combatData.GetBuffData(AncestralGraceBuff).OfType<BuffRemoveAllEvent>().Where(x => x.To == player.AgentItem).ToList();
-            for (int i = 0; i < applies.Count && i < removals.Count; i++)
-            {
-                res.Add(new AnimatedCastEvent(player.AgentItem, skill, applies[i].Time, removals[i].Time - applies[i].Time));
-            }
-            return res;
-        }
-
         public static void ProcessGadgets(IReadOnlyList<Player> players, CombatData combatData)
         {
             var playerAgents = new HashSet<AgentItem>(players.Select(x => x.AgentItem));

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
@@ -100,6 +100,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 new DamageCastFinder(SpontaneousCombustion, SpontaneousCombustion),
                 new DamageCastFinder(SnowstormSkill, SnowstormSkill),
                 new DamageCastFinder(DownpourSkill, DownpourSkill),
+                new BuffLossCastFinder(UnstableBloodMagic, UnstableBloodMagic),
             };
         }
         internal override List<PhaseData> GetPhases(ParsedEvtcLog log, bool requirePhases)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -85,6 +85,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<InstantCastFinder>()
             {
                 new DamageCastFinder(VolatileAura, VolatileAura),
+                new BuffLossCastFinder(PurgeSlothasor, VolatilePoisonBuff),
             };
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
@@ -28,6 +28,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 new PlayerDstHitMechanic(FireMortarEscortHit, "Fire Mortar", new MechanicPlotlySetting(Symbols.Hourglass, Colors.DarkPurple), "Shrd.H", "Hit by Mortar Fire (Bloodstone Turrets)", "Mortar Fire Hit", 0),
                 new PlayerDstBuffApplyMechanic(RadiantAttunementPhantasm, "Radiant Attunement", new MechanicPlotlySetting(Symbols.Diamond, Colors.White), "Rad.A", "Radiant Attunement Application", "Radiant Attunement Application", 150),
                 new PlayerDstBuffApplyMechanic(CrimsonAttunementPhantasm, "Crimson Attunement", new MechanicPlotlySetting(Symbols.Diamond, Colors.Red), "Crim.A", "Crimson Attunement Application", "Crimson Attunement Application", 150),
+                new PlayerSrcEffectMechanic(EffectGUIDs.EscortOverHere, "Over Here!", new MechanicPlotlySetting(Symbols.Star, Colors.White), "OverHere.C", "Used Over Here! (Special Action Key)", "Over Here! Cast", 0),
                 new EnemyDstBuffApplyMechanic(Invulnerability757, "Invulnerability", new MechanicPlotlySetting(Symbols.DiamondOpen, Colors.LightBlue), "Inv.A", "Invulnerability Applied", "Invulnerability Applied", 150),
                 new EnemyCastStartMechanic(TeleportDisplacementField, "Teleport Displacement Field", new MechanicPlotlySetting(Symbols.Square, Colors.LightPurple), "Tel.C", "Teleport Cast", "Teleport Cast", 150),
             }
@@ -276,6 +277,14 @@ namespace GW2EIEvtcParser.EncounterLogic
             // Attunements Overhead
             replay.AddOverheadIcons(p.GetBuffStatus(log, CrimsonAttunementPhantasm, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), p, ParserIcons.CrimsonAttunementOverhead);
             replay.AddOverheadIcons(p.GetBuffStatus(log, RadiantAttunementPhantasm, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), p, ParserIcons.RadiantAttunementOverhead);
+        }
+
+        internal override List<InstantCastFinder> GetInstantCastFinders()
+        {
+            return new List<InstantCastFinder>()
+            {
+                new EffectCastFinder(OverHere, EffectGUIDs.EscortOverHere),
+            };
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
@@ -37,7 +37,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             new PlayerDstBuffApplyMechanic(BendingChaos, "Bending Chaos", new MechanicPlotlySetting(Symbols.TriangleDownOpen,Colors.Yellow), "Button1","Bending Chaos (Stood on 1st Button)", "Button 1",0),
             new PlayerDstBuffApplyMechanic(ShiftingChaos, "Shifting Chaos", new MechanicPlotlySetting(Symbols.TriangleNEOpen,Colors.Yellow), "Button2","Bending Chaos (Stood on 2nd Button)", "Button 2",0),
             new PlayerDstBuffApplyMechanic(TwistingChaos, "Twisting Chaos", new MechanicPlotlySetting(Symbols.TriangleNWOpen,Colors.Yellow), "Button3","Bending Chaos (Stood on 3rd Button)", "Button 3",0),
-            new PlayerDstBuffApplyMechanic(InterventionSAK, "Intervention SAK", new MechanicPlotlySetting(Symbols.Square,Colors.Blue), "Shield","Intervention (got Special Action Key)", "Shield",0),
+            new PlayerDstBuffApplyMechanic(InterventionSkillOwnerBuff, "Intervention SAK", new MechanicPlotlySetting(Symbols.Square,Colors.Blue), "Shield","Intervention (got Special Action Key)", "Shield",0),
             new PlayerDstBuffApplyMechanic(GravityWellXera, "Gravity Well", new MechanicPlotlySetting(Symbols.CircleXOpen,Colors.Magenta), "Gravity Half","Half-platform Gravity Well", "Gravity Well",4000),
             new PlayerDstBuffApplyMechanic(HerosDeparture, "Hero's Depature", new MechanicPlotlySetting(Symbols.Circle,Colors.DarkGreen), "TP Out","Hero's Departure (Teleport to Platform)","TP",0),
             new PlayerDstBuffApplyMechanic(HerosReturn, "Hero's Return", new MechanicPlotlySetting(Symbols.Circle,Colors.Green), "TP Back","Hero's Return (Teleport back)", "TP back",0),
@@ -59,6 +59,14 @@ namespace GW2EIEvtcParser.EncounterLogic
                             (-5992, -5992, 69, -522)/*,
                             (-12288, -27648, 12288, 27648),
                             (1920, 12160, 2944, 14464)*/);
+        }
+
+        internal override List<InstantCastFinder> GetInstantCastFinders()
+        {
+            return new List<InstantCastFinder>()
+            {
+                new BuffLossCastFinder(InterventionSAK, InterventionSkillOwnerBuff),
+            };
         }
 
         internal override List<AbstractBuffEvent> SpecialBuffEventProcess(CombatData combatData, SkillData skillData)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
@@ -65,7 +65,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new BuffLossCastFinder(InterventionSAK, InterventionSkillOwnerBuff),
+                new EffectCastFinder(InterventionSAK, EffectGUIDs.XeraIntervention1),
             };
         }
 
@@ -356,6 +356,24 @@ namespace GW2EIEvtcParser.EncounterLogic
                 else if (segment.Value >= 30)
                 {
                     replay.AddOverheadIcon(segment, player, ParserIcons.DerangementSilverOverhead);
+                }
+            }
+        }
+
+        internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
+        {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
+            // Intervention Bubble
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.XeraIntervention1, out IReadOnlyList<EffectEvent> intervention))
+            {
+                foreach (EffectEvent effect in intervention)
+                {
+                    // Effect has duration of 4294967295 but the skill lasts only 6000
+                    (long, long) lifespan = ProfHelper.ComputeDynamicEffectLifespan(log, effect, 6000);
+                    var circle = new CircleDecoration(240, lifespan, "rgba(255, 200, 0, 0.3)", new PositionConnector(effect.Position));
+                    EnvironmentDecorations.Add(circle);
+                    EnvironmentDecorations.Add(circle.GetBorderDecoration("rgba(0, 50, 200, 0.4)"));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
@@ -135,10 +135,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<AbstractCastEvent> res = base.SpecialCastEventProcess(combatData, skillData);
 
             var claimApply = combatData.GetBuffData(ClaimBuff).OfType<BuffApplyEvent>().ToList();
-            var claimRemove = combatData.GetBuffData(ClaimBuff).OfType<BuffRemoveAllEvent>().ToList();
-
             var dispelApply = combatData.GetBuffData(DispelBuff).OfType<BuffApplyEvent>().ToList();
-            var dispelRemove = combatData.GetBuffData(DispelBuff).OfType<BuffRemoveAllEvent>().ToList();
 
             SkillItem claimSkill = skillData.Get(ClaimSAK);
             SkillItem dispelSkill = skillData.Get(DispelSAK);
@@ -148,11 +145,11 @@ namespace GW2EIEvtcParser.EncounterLogic
                 foreach (EffectEvent effect in claims)
                 {
                     // Find the player agent that has the claim buff when the effect event happens
-                    if (claimApply.Where(x => x.Time < effect.Time).Any() && claimRemove.Where(x => x.Time > effect.Time).Any())
+                    BuffApplyEvent src = claimApply.LastOrDefault(x => x.Time <= effect.Time);
+                    if (src != null) 
                     {
-                        AgentItem player = claimApply.Where(x => x.Time < effect.Time).FirstOrDefault().To;
-                        res.Add(new AnimatedCastEvent(player, claimSkill, effect.Time, effect.Time));
-                    }
+                        res.Add(new InstantCastEvent(effect.Time, claimSkill, src.To));
+                    };
                 }
             }
 
@@ -160,12 +157,11 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 foreach (EffectEvent effect in dispels)
                 {
-                    // Find the player agent that has the dispel buff when the effect event happens
-                    if (dispelApply.Where(x => x.Time < effect.Time).Any() && dispelRemove.Where(x => x.Time > effect.Time).Any())
+                    BuffApplyEvent src = dispelApply.LastOrDefault(x => x.Time <= effect.Time);
+                    if (src != null)
                     {
-                        AgentItem player = dispelApply.Where(x => x.Time < effect.Time).FirstOrDefault().To;
-                        res.Add(new AnimatedCastEvent(player, dispelSkill, effect.Time, effect.Time));
-                    }
+                        res.Add(new InstantCastEvent(effect.Time, dispelSkill, src.To));
+                    };
                 }
             }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
@@ -144,7 +144,6 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 foreach (EffectEvent effect in claims)
                 {
-                    // Find the player agent that has the claim buff when the effect event happens
                     BuffApplyEvent src = claimApply.LastOrDefault(x => x.Time <= effect.Time);
                     if (src != null) 
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -86,6 +86,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<InstantCastFinder>()
             {
                 new DamageCastFinder(DeathlyAura, DeathlyAura),
+                new BuffLossCastFinder(ExpelEnergySAK, ArcingAffliction)
             };
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -86,7 +86,21 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<InstantCastFinder>()
             {
                 new DamageCastFinder(DeathlyAura, DeathlyAura),
-                new BuffLossCastFinder(ExpelEnergySAK, ArcingAffliction)
+                new BuffLossCastFinder(ExpelEnergySAK, ArcingAffliction).UsingChecker((brae, combatData, agentData, skillData) =>
+                {
+                    bool state = true;
+                    // Buff loss caused by the Greather Death Mark
+                    if (combatData.GetDamageData(GreaterDeathMark).Any(x => Math.Abs(x.Time - brae.Time) < 100 && x.To == brae.To))
+                    {
+                        state = false;
+                    }
+                    // Buff loss at the time of the 10% starting
+                    if (combatData.GetBuffData(SourcePureOblivionBuff).Any(x => Math.Abs(x.Time - brae.Time) < 100 && x.To == brae.To))
+                    {
+                        state = false;
+                    }
+                    return state;
+                }),
             };
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
@@ -50,6 +50,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<InstantCastFinder>()
             {
                 new DamageCastFinder(ChillingAura, ChillingAura),
+                new BuffGainCastFinder(IssueChallengeSAK, FixatedSH),
             };
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
@@ -68,7 +68,8 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(BoltBreakSabir, BoltBreakSabir), // Bolt Break
+                new DamageCastFinder(BoltBreakSabir, BoltBreakSabir),
+                new EffectCastFinder(FlashDischargeSAK, EffectGUIDs.SabirFlashDischarge),
             };
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
@@ -112,6 +112,16 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         }
 
+        internal override List<InstantCastFinder> GetInstantCastFinders()
+        {
+            return new List<InstantCastFinder>()
+            {
+                new BuffLossCastFinder(ReverseThePolaritySAK, MaiTrinCMBeamsTargetGreen),
+                new BuffLossCastFinder(ReverseThePolaritySAK, MaiTrinCMBeamsTargetBlue),
+                new BuffLossCastFinder(ReverseThePolaritySAK, MaiTrinCMBeamsTargetRed),
+            };
+        }
+
         internal override void ComputePlayerCombatReplayActors(AbstractPlayer player, ParsedEvtcLog log, CombatReplay replay)
         {
             // Bomb Selection

--- a/GW2EIEvtcParser/ParsedData/CombatData.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatData.cs
@@ -280,8 +280,10 @@ namespace GW2EIEvtcParser.ParsedData
             }
             var instantCastsFinder = new HashSet<InstantCastFinder>(ProfHelper.GetProfessionInstantCastFinders(players));
             fightData.Logic.GetInstantCastFinders().ForEach(x => instantCastsFinder.Add(x));
+            var instantCasts = new List<InstantCastEvent>(ComputeInstantCastEventsFromFinders(agentData, skillData, instantCastsFinder.ToList()));
+            instantCasts.AddRange(toAdd.OfType<InstantCastEvent>());
             //
-            foreach (InstantCastEvent ice in ComputeInstantCastEventsFromFinders(agentData, skillData, instantCastsFinder.ToList()))
+            foreach (InstantCastEvent ice in instantCasts)
             {
                 if (_instantCastData.TryGetValue(ice.Caster, out List<InstantCastEvent> instantCastList))
                 {

--- a/GW2EIEvtcParser/ParsedData/CombatData.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatData.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Extensions;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.ParserHelper;
+using static GW2EIEvtcParser.SkillIDs;
 
 namespace GW2EIEvtcParser.ParsedData
 {
@@ -201,7 +202,7 @@ namespace GW2EIEvtcParser.ParsedData
             foreach (Player p in players) {
                 switch(p.Spec)
                 {
-                    case ParserHelper.Spec.Willbender:
+                    case Spec.Willbender:
                         toAdd.AddRange(WillbenderHelper.ComputeFlowingResolveCastEvents(p, this, skillData, agentData));
                         break;
                     default:
@@ -209,16 +210,22 @@ namespace GW2EIEvtcParser.ParsedData
                 }
                 switch(p.BaseSpec)
                 {
-                    case ParserHelper.Spec.Ranger:
-                        toAdd.AddRange(RangerHelper.ComputeAncestralGraceCastEvents(p, this, skillData, agentData));
+                    case Spec.Ranger:
+                        toAdd.AddRange(ProfHelper.ComputeDashCastEvents(p, this, skillData, agentData, AncestralGraceSkill, AncestralGraceBuff));
                         break;
                     case Spec.Elementalist:
                         toAdd.AddRange(ElementalistHelper.ComputeUpdraftCastEvents(p, this, skillData, agentData));
-                        toAdd.AddRange(ElementalistHelper.ComputeRideTheLightningCastEvents(p, this, skillData, agentData));
+                        toAdd.AddRange(ProfHelper.ComputeDashCastEvents(p, this, skillData, agentData, RideTheLightningSkill, RideTheLightningBuff));
                         break;
                     default:
                         break;
                 }
+                // Cairn
+                toAdd.AddRange(ProfHelper.ComputeDashCastEvents(p, this, skillData, agentData, CelestialDashSAK, CelestialDashBuff));
+                // Artsariiv
+                toAdd.AddRange(ProfHelper.ComputeDashCastEvents(p, this, skillData, agentData, NovaLaunchSAK, NovaLaunchBuff));
+                // Arkk
+                toAdd.AddRange(ProfHelper.ComputeDashCastEvents(p, this, skillData, agentData, HypernovaLaunchSAK, HypernovaLaunchBuff));
             }
             //
             var castIDsToSort = new HashSet<long>();

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -183,18 +183,27 @@ namespace GW2EIEvtcParser.ParsedData
             { TantrumSkill, "Tantrum Start" },
             { NarcolepsySkill, "Sleeping" },
             { FearMeSlothasor, "Fear Me!" },
+            { PurgeSlothasor, "Purge" },
             // Matthias
             { ShieldHuman, "Shield (Human)" },
             { AbominationTransformation, "Abomination Transformation" },
             { ShieldAbomination, "Shield (Abomination)" },
             // Escort
             { GlennaCap, "Capture" },
-            // Generic
-            //{-5, "Phase out" },
-            // Deimos
-            //{-6, "Roleplay" },
+            { OverHere, "Over Here!" },
+            // Xera
+            { InterventionSAK, "Intervetion" },
+            // Cairn
+            { CelestialDashSAK, "Celestial Dash" },
+            // Mursaar Overseer
+            { ClaimSAK, "Claim" },
+            { DispelSAK, "Dispel" },
+            { ProtectSAK, "Protect" },
+            // Soulless Horror
+            { IssueChallengeSAK, "Issue Challenge" },
             // Dhuum
             { MajorSoulSplit, "Major Soul Split" },
+            { ExpelEnergySAK, "Expel Energy" },
             // Keep Construct
             { MagicBlastCharge, "Magic Blast Charge" },
             // Conjured Amalgamate
@@ -219,6 +228,12 @@ namespace GW2EIEvtcParser.ParsedData
             { BigMagmaDrop, "Big Magma Drop" },
             // Voice and Claw
             { KodanTeleport, "Kodan Teleport" },
+            // Mai Trin (Aetherblade Hideout)
+            { ReverseThePolaritySAK, "Reverse the Polarity!" },
+            // Artsariiv
+            { NovaLaunchSAK, "Nova Launch" },
+            // Arkk
+            { HypernovaLaunchSAK, "Hypernova Launch" },
             // Kanaxai
             { FrighteningSpeedWindup, "Frightening Speed (Windup)" },
             { FrighteningSpeedReturn, "Frightening Speed (Return)" },
@@ -605,8 +620,24 @@ namespace GW2EIEvtcParser.ParsedData
             { ShatteredPsycheTier4, "https://wiki.guildwars2.com/images/6/68/Shattered_Psyche.png" },
             // - Sabetha
             { SapperBombSkill, "https://wiki.guildwars2.com/images/b/ba/Sapper_Bomb.png" },
+            // - Slothasor
+            { PurgeSlothasor, "https://wiki.guildwars2.com/images/a/aa/Purge.png" },
+            // - Matthias
+            { UnstableBloodMagic, "https://wiki.guildwars2.com/images/a/aa/Purge.png" },
+            // - Escort Glenna
+            { OverHere, "https://wiki.guildwars2.com/images/b/b7/Over_Here%21.png" },
+            // - Xera
+            { InterventionSAK, "https://wiki.guildwars2.com/images/3/3f/Intervention.png" },
             // - Cairn
-            { CelestialDash, "https://wiki.guildwars2.com/images/5/56/Celestial_Dash.png" },
+            { CelestialDashSAK, "https://wiki.guildwars2.com/images/5/56/Celestial_Dash.png" },
+            // - Mursaar Overseer
+            { ClaimSAK, BuffImages.Claim },
+            { DispelSAK, BuffImages.Dispel },
+            { ProtectSAK, BuffImages.Protect },
+            // - Soulless Horror
+            { IssueChallengeSAK, "https://wiki.guildwars2.com/images/1/13/Rally_the_Crowd.png" },
+            // - Dhuum
+            { ExpelEnergySAK, "https://wiki.guildwars2.com/images/c/c1/Core_Capture.png" },
             // - Conjured Amalgamate
             { ConjuredSlashPlayer, "https://wiki.guildwars2.com/images/5/59/Conjured_Slash.png" },
             { ConjuredProtection, "https://wiki.guildwars2.com/images/0/02/Conjured_Protection.png" },
@@ -619,8 +650,14 @@ namespace GW2EIEvtcParser.ParsedData
             { FluxDisruptorDeactivateCast, "https://wiki.guildwars2.com/images/3/34/Flux_Disruptor-_Deactivate.png" },
             { PlayerLiftUpQadimThePeerless, ParserIcons.GenericBlueArrowUp },
             { UnleashSAK, "https://wiki.guildwars2.com/images/9/99/Touch_of_the_Sun.png" },
+            // - Mai Trin (Aetherble Hideout)
+            { ReverseThePolaritySAK, "https://wiki.guildwars2.com/images/f/f8/Prod.png" },
             // - Dadga (Cosmic Observatory)
             { PurifyingLight, "https://wiki.guildwars2.com/images/1/1e/Purifying_Light_%28Dagda%29.png" },
+            // - Artsariiv
+            { NovaLaunchSAK, "https://wiki.guildwars2.com/images/5/56/Celestial_Dash.png" },
+            // - Arkk
+            { HypernovaLaunchSAK, "https://wiki.guildwars2.com/images/5/56/Celestial_Dash.png" },
         };
 
         private static readonly Dictionary<long, ulong> _nonCritable = new Dictionary<long, ulong>

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -348,6 +348,10 @@ namespace GW2EIEvtcParser
         public const string ValeGuardianMagicSpike = "55364633145D264A934935C3F026B19F";
         // Escort Glenna
         public const string EscortOverHere = "64CD79C1A121EC42B1278DEF9280ED35";
+        // Xera
+        public const string XeraIntervention1 = "63C34770B4EFF64B8EAA21BB835BB560"; // 4294967295 duration - Src Player - Usable with ComputeDynamicEffectLifespan
+        public const string XeraIntervention2 = "79EA3F01274B4F418B2C571BAE1B9E17"; // 0 duration - Src Player
+        public const string XeraIntervention3 = "5FA6527231BB8041AC783396142C6200"; // 0 duration - No Src No Dst
         // Cairn
         public const string CairnDisplacement = "7798B97ED6B6EB489F7E33DF9FE6BD99";
         public const string CairnDashGreen = "D2E6D55CC94F79418BB907F063CBDD81";

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -346,11 +346,20 @@ namespace GW2EIEvtcParser
         // Vale Guardian
         public const string ValeGuardianDistributedMagic = "43FD739499BB6040BBF9EEF37781B2CE";
         public const string ValeGuardianMagicSpike = "55364633145D264A934935C3F026B19F";
+        // Escort Glenna
+        public const string EscortOverHere = "64CD79C1A121EC42B1278DEF9280ED35";
         // Cairn
         public const string CairnDisplacement = "7798B97ED6B6EB489F7E33DF9FE6BD99";
         public const string CairnDashGreen = "D2E6D55CC94F79418BB907F063CBDD81";
+        // Mursaat Overseen
+        public const string MursaarOverseerDispelProjectile = "DE71A86A0867764BB5789265E8C0CF6A"; // No Src - Dst Jade Scout
+        public const string MursaarOverseerProtectBubble = "17BC358A51ED2D43BF2ABE8AB642B86B"; // Src player
+        public const string MursaarOverseerClaimMarker = "94F3501D777FAC439E78E143CE756B0A"; // No Src - No Dst
+        public const string MursaarOverseerShockwave = "0F62A1315A00FC438B2F1273E6BC4054";
         // CA
         public const string CAArmSmash = "B1AAD873DB07E04E9D69627156CA8918";
+        // Sabir
+        public const string SabirFlashDischarge = "40818C8E9CC6EF4388C2821FCC26A9EC";
         // Qadim the Peerless
         public const string QadimPeerlessRainOfChaos = "D8259BFD4E6B8348AF15D862F7DBC8FA";
         public const string QadimPeerlessResidualImpactFireAoE = "EFAC2FC0F661404D84F0291CAB76FF0E";

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1522,6 +1522,7 @@
         public const long ToxicCloud1 = 34565;
         public const long DownpourMatthias = 34568;
         public const long BloodstoneBisque = 34570;
+        public const long PurgeSlothasor = 34599;
         public const long CanOfMushroomAndAsparagusRisotto = 34604;
         public const long CannedTarragonBread = 34608;
         public const long CannedMixedBerryPie = 34612;
@@ -1575,6 +1576,7 @@
         public const long SummonFragments = 34887;
         public const long AchievementEligibilityEvasiveManeuver = 34890;
         public const long SpatialDenial = 34899;
+        public const long OverHere = 34903;
         public const long StatueFixated1 = 34912;
         public const long TemporalShredAoE = 34913;
         public const long WhiteOrb = 34914;
@@ -1588,7 +1590,7 @@
         public const long ConstructAura = 34946;
         public const long Outnumbered = 34947;
         public const long SoothingWaters = 34955;
-        public const long InterventionSAK = 34956;
+        public const long InterventionSkillOwnerBuff = 34956;
         public const long AchievementEligibilityDownDownDowned = 34958;
         public const long ChaoticHaze = 34963;
         public const long AchievementEligibilityLoveIsBunny = 34944;
@@ -1600,7 +1602,7 @@
         public const long Unbreakable = 34979;
         public const long RadiantAttunementPhantasm = 34992;
         public const long HerosDeparture = 34997;
-        public const long Intervention = 35000;
+        public const long InterventionInvulnerabilityBuff = 35000;
         public const long Madness = 35006;
         public const long ConfoundingFrenzy = 35009;
         public const long CrimsonAttunementPhantasm = 35014;
@@ -1610,6 +1612,7 @@
         public const long MagicBlastCharge = 35048;
         public const long GlennaCap = 35057;
         public const long EscortToxicSpores = 35059;
+        public const long InterventionSAK = 35061;
         public const long PhantasmalBlades1 = 35064;
         public const long EscortHealingCleanse = 35073;
         public const long GainingPower = 35075;
@@ -1741,6 +1744,7 @@
         public const long ClaimBuff = 37779;
         public const long Impact = 37784;
         public const long JadeSoldierExplosion = 37788;
+        public const long POV_CelestialDashBuff = 37791;
         public const long TramplingRush = 37797;
         public const long ProtectBuff = 37813;
         public const long EnragedCairn2 = 37824;
@@ -1754,7 +1758,7 @@
         public const long EffigyPulse = 37901;
         public const long DispelSAK = 37904;
         public const long GravityWave = 37910;
-        public const long CelestialDash = 37924;
+        public const long CelestialDashSAK = 37924;
         public const long Annihilate1 = 37929;
         public const long PunishementAura = 37952;
         public const long InevitableBetrayalBig = 37966;
@@ -1785,6 +1789,7 @@
         public const long Annihilate2 = 38208;
         public const long SharedAgony75 = 38209;
         public const long SharedAgony3 = 38210;
+        public const long CelestialDashBuff = 38217;
         public const long FixatedGuldhem = 38223;
         public const long UnnaturalSignet = 38224;
         public const long FanaticalResilience = 38226;
@@ -1813,6 +1818,7 @@
         public const long CorporealReassignmentBuff = 38880;
         public const long PunishingKickSkorvald = 38896;
         public const long RadiantFury = 38926;
+        public const long NovaLaunchBuff = 38929;
         public const long VaultArtsariiv = 38977;
         public const long FixatedBloom4 = 38985;
         public const long StarbustCascade1 = 38982;
@@ -1828,6 +1834,7 @@
         public const long DiaphanousShielding = 39111;
         public const long FixatedBloom1 = 39131;
         public const long WaveOfMutilation = 39133;
+        public const long HypernovaLaunchSAK = 39157;
         public const long CranialCascadeSkorvald = 39220;
         public const long SupernovaSkorvaldCM = 39225;
         public const long SolarCyclone = 39228;
@@ -1877,10 +1884,12 @@
         public const long SolarFury = 39728;
         public const long DiffractiveEdge2 = 39755;
         public const long SolarBolt2 = 39760;
+        public const long HypernovaLaunchBuff = 39762;
         public const long HorizonStrikeSkorvald4 = 39770;
         public const long SupernovaArkk = 39782;
         public const long DiffractiveEdge1 = 39787;
         public const long SolarBlastArkk1 = 39823;
+        public const long NovaLaunchSAK = 39843;
         public const long SolarBlastArkk2 = 39857;
         public const long RadiantFurySkorvald = 39845;
         public const long CrimsonDawn = 39846;
@@ -2175,6 +2184,7 @@
         public const long MistlockInstabilityVengeance = 46865;
         public const long WatchfulEyePvP = 46910;
         public const long CorsairSharpeningStone = 46925;
+        public const long IssueChallengeSAK = 46947;
         public const long FracturedSpirit = 46950;
         public const long SuperiorSigilOfTheStars = 46953;
         public const long MushroomKingsBlessing = 46970;
@@ -2224,6 +2234,7 @@
         public const long FrozenWind = 47776;
         public const long ChillingAura = 47837;
         public const long Hamstrung = 47856;
+        public const long ExpelEnergySAK = 47880;
         public const long SourcePureOblivionBuff = 47903;
         public const long QuadSlashSecondSet = 47915;
         public const long OneTrackMind = 47929;
@@ -2250,12 +2261,12 @@
         public const long CorruptTheLiving = 48327;
         public const long SpiritForm = 48331;
         public const long CorsairTuningCrystal = 48348;
-        public const long ExilesEmbrace = 48349;
         public const long QuadSlashFirstSet = 48363;
         public const long ThrowLight = 48380;
         public const long CataclysmicCycle = 48398;
         public const long FractalChampion = 48414;
         public const long OuterVortexSlash = 48432;
+        public const long ExilesEmbrace = 48439;
         public const long EmpoweredLightThief = 48477;
         public const long DeathBloom = 48500;
         public const long RendingSwipe = 48531;
@@ -3397,6 +3408,7 @@
         public const long MaiTrinCMBeamsTargetRed = 67868;
         public const long MaiTrinCMBeamsTargetGreen = 67871;
         public const long PhotonSaturation = 67872;
+        public const long ReverseThePolaritySAK = 67880;
         public const long AchievementEligibilityLeapsAbound = 67882;
         public const long ImminentDeathBuff = 67931;
         public const long FailSafeActivated = 67936;


### PR DESCRIPTION
Added all the casts listed in #823 

- Clarified Intervention for Xera between SAK owner buff and the invulnerability buff
- Added buffs for Celestial Dash, Nova Launch, Hypernova Launch
- Fixed ID for Exile's Embrace
- Moved Ride the Lightning and Ancestral Grace to generic DashCastEvents method
- Added mechanic to Escort for "Over Here!" casts
- Added decoration for Xera's Intervention

The logs i've used

[logs.zip](https://github.com/baaron4/GW2-Elite-Insights-Parser/files/13255424/logs.zip)