### PR TITLE
Fix request URL for DPS.Report upload

### DIFF
--- a/GW2EIDPSReport/DPSReportController.cs
+++ b/GW2EIDPSReport/DPSReportController.cs
@@ -114,7 +114,7 @@ namespace GW2EIDPSReport
                 return multiPartContent;
             };
 
-            DPSReportUploadObject response = GetDPSReportResponse<DPSReportUploadObject>("UploadUsingEI", GetUploadContentURL(BaseUploadContentURL, userToken, anonymous, detailedWvW) + " & generator=ei", traceHandler, contentCreator);
+            DPSReportUploadObject response = GetDPSReportResponse<DPSReportUploadObject>("UploadUsingEI", GetUploadContentURL(BaseUploadContentURL, userToken, anonymous, detailedWvW) + "&generator=ei", traceHandler, contentCreator);
             if (response != null && response.Error != null)
             {
                 traceHandler("DPSReport: UploadUsingEI failed - " + response.Error);


### PR DESCRIPTION
Spaces in the get string cause DPS.Report to return a malformed (Non-JSON) response, which crashes the application.