### PR TITLE
Bandit Trio improvements

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -137,6 +137,7 @@ namespace GW2EIEvtcParser.EIData
             // Sabetha    
             new Buff("Shell-Shocked", ShellShocked, Source.FightSpecific, BuffClassification.Other, BuffImages.ShellShocked),
             new Buff("Sapper Bomb", SapperBombBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.SapperBomb),
+            new Buff("Sapper Bomb Damage", SapperBombDamageBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.SapperBomb),
             new Buff("Time Bomb", TimeBomb, Source.FightSpecific, BuffClassification.Other, BuffImages.TimeBomb),
             //////////////////////////////////////////////
             // Slothasor

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -187,6 +187,8 @@ namespace GW2EIEvtcParser.ParsedData
             { NarcolepsySkill, "Sleeping" },
             { FearMeSlothasor, "Fear Me!" },
             { PurgeSlothasor, "Purge" },
+            // Bandit Trio
+            { ThrowOilKeg, "Throw (Oil Keg)" },
             // Matthias
             { ShieldHuman, "Shield (Human)" },
             { AbominationTransformation, "Abomination Transformation" },
@@ -818,6 +820,9 @@ namespace GW2EIEvtcParser.ParsedData
             // - Slothasor
             { PurgeSlothasor, "https://wiki.guildwars2.com/images/a/aa/Purge.png" },
             { Eat, "https://wiki.guildwars2.com/images/7/7b/Eat.png" },
+            // - Bandit Trio
+            { Beehive, BuffImages.ThrowJar },
+            { ThrowOilKeg, "https://wiki.guildwars2.com/images/5/5f/Throw_Keg.png" },
             // - Matthias
             { UnstableBloodMagic, "https://wiki.guildwars2.com/images/a/aa/Purge.png" },
             // - Escort Glenna

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -525,6 +525,8 @@ namespace GW2EIEvtcParser
         private const int UnknownAnomaly = -43;
         private const int ChestOfPrisonCamp = -44;
         private const int SnowPile = -45;
+        private const int Cage = -46;
+        private const int Bombs = -47;
         public const int NonIdentifiedSpecies = 0;
 
         //
@@ -571,6 +573,8 @@ namespace GW2EIEvtcParser
             Slubling4 = 16104,
             PoisonMushroom = ArcDPSEnums.PoisonMushroom,
             // Trio
+            Cage = ArcDPSEnums.Cage,
+            Bombs = ArcDPSEnums.Bombs,
             BanditSaboteur = 16117,
             Warg = 7481,
             VeteranTorturedWarg = 16129,

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -359,6 +359,8 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashTheTormented = "https://i.imgur.com/kEytVae.png";
         private const string TrashSoulFeast = "https://i.imgur.com/iNp5Rnx.png";
         private const string TrashSnowPile = "https://i.imgur.com/uku1klD.png";
+        private const string TrashCage = "https://i.imgur.com/W9Z0roU.png";
+        private const string TrashBombs = "https://i.imgur.com/fV8psEZ.png";
 
         // Minion NPC Icons
         private const string MinionHoundOfBalthazar = "https://i.imgur.com/FFSYrzL.png";
@@ -884,6 +886,8 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.IcePatch, TrashIcePatch },
             { ArcDPSEnums.TrashID.BanditSaboteur, TrashBanditSaboteur },
             { ArcDPSEnums.TrashID.NarellaTornado, TrashTornado },
+            { ArcDPSEnums.TrashID.Cage, TrashCage },
+            { ArcDPSEnums.TrashID.Bombs, TrashBombs },
             { ArcDPSEnums.TrashID.Tornado, TrashTornado },
             { ArcDPSEnums.TrashID.Jade, TrashJade },
             { ArcDPSEnums.TrashID.AngryZommoros, TrashAngryChillZommoros },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1537,6 +1537,7 @@
         public const long GlyphOfEqualityCA = 31401;
         public const long SeedOfLife = 31406;
         public const long BanditKick = 31408;
+        public const long SapperBombDamageBuff = 31409;
         public const long ExitCelestialAvatar = 31411;
         public const long BluePylonPower = 31413;
         public const long MagicStorm = 31419;
@@ -1805,6 +1806,7 @@
         public const long ShardsOfRageAbomination = 34411;
         public const long Surrender = 34413;
         public const long Corruption1 = 34416;
+        public const long FlakShotNarella = 34417;
         public const long BloodFueledPlayer = 34422;
         public const long AbominationTransformation = 34427;
         public const long BloodFueledMatthias = 34428;
@@ -1821,6 +1823,7 @@
         public const long FieryVortex = 34466;
         public const long NarcolepsyBuff = 34467;
         public const long ShieldHuman = 34468;
+        public const long ThrowOilKeg = 34471;
         public const long DownpourBuff = 34472;
         public const long Corruption2 = 34473;
         public const long TantrumDamage = 34479;
@@ -1837,6 +1840,7 @@
         public const long BloodShield = 34518;
         public const long POV_MushroomKingsBlessingBuff = 34523;
         public const long HeatWave = 34526;
+        public const long Beehive = 34533;
         public const long ToxicCloud2 = 34537;
         public const long Thunder = 34543;
         public const long TantrumSkill = 34547;


### PR DESCRIPTION
# Mechanics
- Received Blind from Zane
- Received Burning from Narella
- Received Slow Burn
- Applied Targeted to Berg
- Applied Targeted to anyone
- Hit cage with Sapper Bomb
- Threw Beehive
- Threw Oil Keg
- Hit Berg with Beehive
- Hit anything with Beehive
- Hit by Narella's Flak Shot

# NPCs
- Added Cage as friendly NPC
- Added Bombs and Cage as Trash IDs

# Decorations
- Added Overhead Smash for Berg

# Buffs
- Added Sapper Bomb damage buff