### PR TITLE
Updated achievement checks for various encounters

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
@@ -6,6 +6,7 @@ using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.ArcDPSEnums;
+using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
@@ -422,5 +423,29 @@ namespace GW2EIEvtcParser.EncounterLogic
             ComputeFightTargets(agentData, combatData, extensions);
         }
 
+        /// <summary>
+        /// Create a <see cref="List{}"/> containing a <paramref name="buff"/> and its <paramref name="stack"/>.<br></br>
+        /// The buff must be present on any player at the end of the encounter.<br></br>
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="buff">The buff ID to add.</param>
+        /// <param name="stack">Amount of buff stacks (0-99).</param>
+        /// <returns>
+        /// A <see cref="List{T}"/> containing a <paramref name="buff"/> and its <paramref name="stack"/> if present, otherwise empty.<br></br>
+        /// To be used to add as range to <see cref="InstanceBuffs"/>.
+        /// </returns>
+        internal static List<(Buff, int)> SetOnPlayerCustomInstanceBuff(ParsedEvtcLog log, long buff, int stack = 1)
+        {
+            var buffs = new List<(Buff, int)>();
+            foreach (Player p in log.PlayerList)
+            {
+                if (p.HasBuff(log, buff, log.FightData.FightEnd - ServerDelayConstant))
+                {
+                    buffs.Add((log.Buffs.BuffsByIds[buff], stack));
+                    break;
+                }
+            }
+            return buffs;
+        }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/FightLogic.cs
@@ -431,10 +431,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         /// <param name="buff">The buff ID to add.</param>
         /// <param name="stack">Amount of buff stacks (0-99).</param>
         /// <returns>
-        /// A <see cref="List{T}"/> containing a <paramref name="buff"/> and its <paramref name="stack"/> if present, otherwise empty.<br></br>
+        /// A <see cref="IReadOnlyList{T}"/> containing a <paramref name="buff"/> and its <paramref name="stack"/> if present, otherwise empty.<br></br>
         /// To be used to add as range to <see cref="InstanceBuffs"/>.
         /// </returns>
-        internal static List<(Buff, int)> SetOnPlayerCustomInstanceBuff(ParsedEvtcLog log, long buff, int stack = 1)
+        protected static IReadOnlyList<(Buff, int)> GetOnPlayerCustomInstanceBuff(ParsedEvtcLog log, long buff, int stack = 1)
         {
             var buffs = new List<(Buff, int)>();
             foreach (Player p in log.PlayerList)

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
@@ -378,9 +378,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success && _hasDarkMode && _hasElementalMode)
             {
-                IReadOnlyList<AbstractBuffEvent> dwd = log.CombatData.GetBuffData(AchievementEligibilityDancingWithDemons);
-                IReadOnlyList<AbstractBuffEvent> energyDispersal = log.CombatData.GetBuffData(AchievementEligibilityEnergyDispersal);
-                if (dwd.Any())
+                if (log.CombatData.GetBuffData(AchievementEligibilityDancingWithDemons).Any())
                 {
                     int counter = 0;
                     foreach (Player p in log.PlayerList)
@@ -396,16 +394,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                         InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityDancingWithDemons], 1));
                     }
                 }
-                if (energyDispersal.Any())
+                if (log.CombatData.GetBuffData(AchievementEligibilityEnergyDispersal).Any())
                 {
-                    foreach (Player p in log.PlayerList)
-                    {
-                        if (p.HasBuff(log, AchievementEligibilityEnergyDispersal, log.FightData.FightEnd - ServerDelayConstant))
-                        {
-                            InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityEnergyDispersal], 1));
-                            break;
-                        }
-                    }
+                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityEnergyDispersal));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
@@ -396,7 +396,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
                 if (log.CombatData.GetBuffData(AchievementEligibilityEnergyDispersal).Any())
                 {
-                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityEnergyDispersal));
+                    InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityEnergyDispersal));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
@@ -319,17 +319,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         protected override void SetInstanceBuffs(ParsedEvtcLog log)
         {
             base.SetInstanceBuffs(log);
-            IReadOnlyList<AbstractBuffEvent> environmentallyFriendly = log.CombatData.GetBuffData(EnvironmentallyFriendly);
-            if (environmentallyFriendly.Any() && log.FightData.Success)
+
+            if (log.FightData.Success && log.CombatData.GetBuffData(EnvironmentallyFriendly).Any())
             {
-                foreach (Player p in log.PlayerList)
-                {
-                    if (p.HasBuff(log, EnvironmentallyFriendly, log.FightData.FightEnd - ServerDelayConstant))
-                    {
-                        InstanceBuffs.Add((log.Buffs.BuffsByIds[EnvironmentallyFriendly], 1));
-                        break;
-                    }
-                }
+                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, EnvironmentallyFriendly));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
@@ -322,7 +322,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success && log.CombatData.GetBuffData(EnvironmentallyFriendly).Any())
             {
-                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, EnvironmentallyFriendly));
+                InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, EnvironmentallyFriendly));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -57,7 +57,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success && log.CombatData.GetBuffData(SlipperySlubling).Any())
             {
-                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, SlipperySlubling));
+                InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, SlipperySlubling));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -54,17 +54,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         protected override void SetInstanceBuffs(ParsedEvtcLog log)
         {
             base.SetInstanceBuffs(log);
-            IReadOnlyList<AbstractBuffEvent> slipperySlublings = log.CombatData.GetBuffData(SlipperySlubling);
-            if (slipperySlublings.Any() && log.FightData.Success)
+
+            if (log.FightData.Success && log.CombatData.GetBuffData(SlipperySlubling).Any())
             {
-                foreach (Player p in log.PlayerList)
-                {
-                    if (p.HasBuff(log, SlipperySlubling, log.FightData.FightEnd - ServerDelayConstant))
-                    {
-                        InstanceBuffs.Add((log.Buffs.BuffsByIds[SlipperySlubling], 1));
-                        break;
-                    }
-                }
+                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, SlipperySlubling));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
@@ -287,8 +287,8 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success)
             {
-                if (log.CombatData.GetBuffData(AchievementEligibilityLoveIsBunny).Any()) { InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityLoveIsBunny)); }
-                if (log.CombatData.GetBuffData(AchievementEligibilityFastSiege).Any()) { InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityFastSiege)); }
+                if (log.CombatData.GetBuffData(AchievementEligibilityLoveIsBunny).Any()) { InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityLoveIsBunny)); }
+                if (log.CombatData.GetBuffData(AchievementEligibilityFastSiege).Any()) { InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityFastSiege)); }
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
@@ -287,20 +287,8 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success)
             {
-                if (log.CombatData.GetBuffData(AchievementEligibilityLoveIsBunny).Any()) { CheckAchievementBuff(log, AchievementEligibilityLoveIsBunny); }
-                if (log.CombatData.GetBuffData(AchievementEligibilityFastSiege).Any()) { CheckAchievementBuff(log, AchievementEligibilityFastSiege); }
-            }
-        }
-
-        private void CheckAchievementBuff(ParsedEvtcLog log, long achievement)
-        {
-            foreach (Player p in log.PlayerList)
-            {
-                if (p.HasBuff(log, achievement, log.FightData.FightEnd - ServerDelayConstant))
-                {
-                    InstanceBuffs.Add((log.Buffs.BuffsByIds[achievement], 1));
-                    break;
-                }
+                if (log.CombatData.GetBuffData(AchievementEligibilityLoveIsBunny).Any()) { InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityLoveIsBunny)); }
+                if (log.CombatData.GetBuffData(AchievementEligibilityFastSiege).Any()) { InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityFastSiege)); }
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
@@ -152,7 +152,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 if (log.CombatData.GetBuffData(AchievementEligibilityMildlyInsane).Any())
                 {
-                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityMildlyInsane));
+                    InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityMildlyInsane));
                 }
                 else if(CustomCheckMildlyInsaneEligibility(log))
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/TwistedCastle.cs
@@ -150,21 +150,11 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success)
             {
-                IReadOnlyList<AbstractBuffEvent> mildlyInsane = log.CombatData.GetBuffData(AchievementEligibilityMildlyInsane);
-                bool hasBeenAdded = false;
-                if (mildlyInsane.Any())
+                if (log.CombatData.GetBuffData(AchievementEligibilityMildlyInsane).Any())
                 {
-                    foreach (Player p in log.PlayerList)
-                    {
-                        if (p.HasBuff(log, AchievementEligibilityMildlyInsane, log.FightData.FightEnd - ServerDelayConstant))
-                        {
-                            InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityMildlyInsane], 1));
-                            hasBeenAdded = true;
-                            break;
-                        }
-                    }
+                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityMildlyInsane));
                 }
-                if (!hasBeenAdded && CustomCheckMildlyInsaneEligibility(log))
+                else if(CustomCheckMildlyInsaneEligibility(log))
                 {
                     InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityMildlyInsane], 1));
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -1035,7 +1035,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 if (log.CombatData.GetBuffData(AchievementEligibilityManipulateTheManipulator).Any())
                 {
-                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityManipulateTheManipulator));
+                    InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityManipulateTheManipulator));
                 }
                 else if (CustomCheckManipulateTheManipulator(log))
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -61,6 +61,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             new PlayerDstHitMechanic(Claw, "Claw", new MechanicPlotlySetting(Symbols.TriangleLeftOpen,Colors.DarkTeal,10), "Claw","Claw (Reaper of Flesh attack)", "Reaper Claw",0),
             new PlayerDstHitMechanic(SwapQadim, "Swap", new MechanicPlotlySetting(Symbols.CircleCrossOpen,Colors.Magenta), "Port","Swap (Ported from below Legendary Creature to Qadim)", "Port to Qadim",0),
             new PlayerDstBuffApplyMechanic(PowerOfTheLamp, "Power of the Lamp", new MechanicPlotlySetting(Symbols.TriangleUp,Colors.LightPurple,10), "Lamp","Power of the Lamp (Returned from the Lamp)", "Lamp Return",0),
+            new PlayerStatusMechanic<DeadEvent>("Taking Turns", new MechanicPlotlySetting(Symbols.Bowtie, Colors.Black), "Taking Turns", "Achievement Eligibility: Taking Turns", "Taking Turns", 0, (log, a) => log.CombatData.GetDeadEvents(a)).UsingEnable((log) => CustomCheckTakingTurns(log)).UsingAchievementEligibility(true),
             new EnemyStatusMechanic<DeadEvent>("Pyre Guardian", new MechanicPlotlySetting(Symbols.Bowtie,Colors.Red), "Pyre.K","Pyre Killed", "Pyre Killed",0, (log, a) => a.IsSpecies(TrashID.PyreGuardian) ? log.CombatData.GetDeadEvents(a) : new List<DeadEvent>()),
             new EnemyStatusMechanic<DeadEvent>("Stab Pyre Guardian", new MechanicPlotlySetting(Symbols.Bowtie,Colors.LightOrange), "Pyre.S.K","Stab Pyre Killed", "Stab Pyre Killed",0, (log, a) => a.IsSpecies(TrashID.PyreGuardianStab) ? log.CombatData.GetDeadEvents(a) : new List<DeadEvent>()),
             new EnemyStatusMechanic<DeadEvent>("Protect Pyre Guardian", new MechanicPlotlySetting(Symbols.Bowtie,Colors.Orange), "Pyre.P.K","Protect Pyre Killed", "Protect Pyre Killed",0, (log, a) => a.IsSpecies(TrashID.PyreGuardianProtect) ? log.CombatData.GetDeadEvents(a) : new List<DeadEvent>()),
@@ -183,7 +184,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<InstantCastFinder>()
             {
-                new DamageCastFinder(BurningCrucible, BurningCrucible), // Burning Crucible
+                new DamageCastFinder(BurningCrucible, BurningCrucible),
             };
         }
 
@@ -241,7 +242,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 {
                     phase.Name = "Qadim P" + (i) / 2;
                     var pyresFirstAware = new List<long>();
-                    var pyres = new List<ArcDPSEnums.TrashID>
+                    var pyres = new List<TrashID>
                         {
                             TrashID.PyreGuardian,
                             TrashID.PyreGuardianProtect,
@@ -296,9 +297,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             return phases;
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            return new List<ArcDPSEnums.TrashID>()
+            return new List<TrashID>()
             {
                 TrashID.LavaElemental1,
                 TrashID.LavaElemental2,
@@ -1032,21 +1033,122 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success)
             {
-                if (log.CombatData.GetBuffData(AchievementEligibilityTakingTurns).Any()) { CheckAchievementBuff(log, AchievementEligibilityTakingTurns); }
-                if (log.CombatData.GetBuffData(AchievementEligibilityManipulateTheManipulator).Any()) { CheckAchievementBuff(log, AchievementEligibilityManipulateTheManipulator); }
+                if (log.CombatData.GetBuffData(AchievementEligibilityManipulateTheManipulator).Any())
+                {
+                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityManipulateTheManipulator));
+                }
+                else if (CustomCheckManipulateTheManipulator(log))
+                {
+                    InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityManipulateTheManipulator], 1));
+                }
             }
         }
 
-        private void CheckAchievementBuff(ParsedEvtcLog log, long achievement)
+        /// <summary>
+        /// Check the player positions for the achievement eligiblity.<br></br>
+        /// </summary>
+        /// <param name="log"></param>
+        /// <returns><see langword="true"/> if eligible, otherwise <see langword="false"/>.</returns>
+        private static bool CustomCheckTakingTurns(ParsedEvtcLog log)
         {
+            // Z coordinates info:
+            // The player in the lamp is roughly at -81
+            // The death zone from falling off the platform is roughly at -2950
+            // The main fight platform is at roughly at -4700
+
+            var lamps = log.AgentData.GetNPCsByID(TrashID.QadimLamp).ToList();
+            int lampLabyrinthZ = -250; // Height Threshold
+
             foreach (Player p in log.PlayerList)
             {
-                if (p.HasBuff(log, achievement, log.FightData.FightEnd - ServerDelayConstant))
+                IReadOnlyList<ParametricPoint3D> positions = p.GetCombatReplayPolledPositions(log);
+                var exitBuffs = log.CombatData.GetBuffData(PowerOfTheLamp).OfType<BuffApplyEvent>().Where(x => x.To == p.AgentItem).ToList();
+
+                // Count the times the player has entered and exited the lamp.
+                // A player that has entered the lamp but never exites and remains alive is elible for the achievement.
+
+                int entered = 0;
+                int exited = 0;
+
+                for (int i = 0; i < lamps.Count; i++)
                 {
-                    InstanceBuffs.Add((log.Buffs.BuffsByIds[achievement], 1));
-                    break;
+                    if (positions.Any(x => x.Z > lampLabyrinthZ && x.Time >= lamps[i].FirstAware && x.Time <= lamps[i].LastAware) && entered == exited)
+                    {
+                        entered++;
+                    }
+
+                    var end = i < lamps.Count - 1 ? lamps[i + 1].FirstAware : log.FightData.FightEnd;
+                    var segment = new Segment(lamps[i].LastAware, end, 1);
+
+                    if (exitBuffs.Any(x => segment.ContainsPoint(x.Time)))
+                    {
+                        exited++;
+                    }
+
+                    if (entered > 1) { return false; } // Failed achievement
                 }
             }
+
+            return true; // Successful achievement
+        }
+
+        /// <summary>
+        /// Check the NPC positions for the achievement eligiblity.<br></br>
+        /// </summary>
+        /// <param name="log"></param>
+        /// <returns><see langword="true"/> if eligible, otherwise <see langword="false"/>.</returns>
+        private static bool CustomCheckManipulateTheManipulator(ParsedEvtcLog log)
+        {
+            AbstractSingleActor qadim = log.FightData.Logic.Targets.Where(x => x.IsSpecies(TargetID.Qadim)).FirstOrDefault();
+            AbstractSingleActor hydra = log.FightData.Logic.Targets.Where(x => x.IsSpecies(TrashID.AncientInvokedHydra)).FirstOrDefault();
+            AbstractSingleActor bringer = log.FightData.Logic.Targets.Where(x => x.IsSpecies(TrashID.ApocalypseBringer)).FirstOrDefault();
+            AbstractSingleActor matriarch = log.FightData.Logic.Targets.Where(x => x.IsSpecies(TrashID.WyvernMatriarch)).FirstOrDefault();
+            AbstractSingleActor patriarch = log.FightData.Logic.Targets.Where(x => x.IsSpecies(TrashID.WyvernPatriarch)).FirstOrDefault();
+
+            if (qadim != null && hydra != null && bringer != null && matriarch != null && patriarch != null)
+            {
+                return !DistanceCheck(log, qadim, hydra) &&
+                    !DistanceCheck(log, qadim, bringer) &&
+                    !DistanceCheck(log, qadim, matriarch) &&
+                    !DistanceCheck(log, qadim, patriarch);
+            }
+            
+            return false;
+        }
+
+        /// <summary>
+        /// Find out if the distance points between <paramref name="qadim"/> and an <paramref name="add"/> goes under 2000 range.
+        /// </summary>
+        /// <param name="log"></param>
+        /// <param name="qadim"></param>
+        /// <param name="add"></param>
+        /// <returns><see langword="true"/> if distance goes under 2000, otherwise <see langword="false"/>.</returns>
+        private static bool DistanceCheck(ParsedEvtcLog log, AbstractSingleActor qadim, AbstractSingleActor add)
+        {
+            // Get positions of Ancient Invoked Hydra, Apocalypse Bringer, Wyvern Matriarch and Patriarch
+            var addPositions = add.GetCombatReplayPolledPositions(log).ToList();
+            if (addPositions.Count == 0)
+            {
+                return true;
+            }
+            // Get positions of Qadim during the times of the adds being present
+            var qadimPositions = qadim.GetCombatReplayPolledPositions(log).Where(x => x.Time >= addPositions.First().Time && x.Time <= addPositions.Last().Time).ToList();
+            if (qadimPositions.Count == 0)
+            {
+                return true;
+            }
+
+            // For each matching position polled, check if the distance between points is under 2000
+            for (int i = 0; i < Math.Min(addPositions.Count, qadimPositions.Count); i++)
+            {
+                if (qadimPositions[i].DistanceToPoint(addPositions[i]) < 2000)
+                {
+                    return true;
+                }
+            }
+
+            // Never went under 2000 range
+            return false;
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
@@ -360,17 +360,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         protected override void SetInstanceBuffs(ParsedEvtcLog log)
         {
             base.SetInstanceBuffs(log);
-            IReadOnlyList<AbstractBuffEvent> conserveTheLand = log.CombatData.GetBuffData(AchievementEligibilityConserveTheLand);
-            if (conserveTheLand.Any() && log.FightData.Success)
+
+            if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityConserveTheLand).Any())
             {
-                foreach (Player p in log.PlayerList)
-                {
-                    if (p.HasBuff(log, AchievementEligibilityConserveTheLand, log.FightData.FightEnd - ServerDelayConstant))
-                    {
-                        InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityConserveTheLand], 1));
-                        break;
-                    }
-                }
+                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityConserveTheLand));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
@@ -363,7 +363,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityConserveTheLand).Any())
             {
-                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityConserveTheLand));
+                    InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityConserveTheLand));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
@@ -308,7 +308,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 if (log.CombatData.GetBuffData(AchievementEligibilityTriangulation).Any())
                 {
-                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityTriangulation));
+                    InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityTriangulation));
                 }
                 else if (CustomCheckTriangulationEligibility(log))
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/AetherbladeHideout.cs
@@ -304,23 +304,13 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             base.SetInstanceBuffs(log);
             
-            if(log.FightData.Success)
+            if (log.FightData.Success)
             {
-                IReadOnlyList<AbstractBuffEvent> triangulation = log.CombatData.GetBuffData(AchievementEligibilityTriangulation);
-                bool hasTriangulationBeenAdded = false;
-                if (triangulation.Any())
+                if (log.CombatData.GetBuffData(AchievementEligibilityTriangulation).Any())
                 {
-                    foreach (Player p in log.PlayerList)
-                    {
-                        if (p.HasBuff(log, AchievementEligibilityTriangulation, log.FightData.FightEnd - ServerDelayConstant))
-                        {
-                            InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityTriangulation], 1));
-                            hasTriangulationBeenAdded = true;
-                            break;
-                        }
-                    }
+                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityTriangulation));
                 }
-                if (!hasTriangulationBeenAdded && CustomCheckTriangulationEligibility(log))
+                else if (CustomCheckTriangulationEligibility(log))
                 {
                     InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityTriangulation], 1));
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -1147,7 +1147,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 if (log.CombatData.GetBuffData(AchievementEligibilityVoidwalker).Any())
                 {
-                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityVoidwalker));
+                    InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityVoidwalker));
                 }
                 else if (CustomCheckVoidwalkerEligibility(log)) // In case all 10 players already have voidwalker
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -1142,24 +1142,14 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             base.SetInstanceBuffs(log);
 
+            // Added a CM mode check because the eligibility had been bugged for some time and showed up in normal mode.
             if (log.FightData.Success && log.FightData.IsCM)
             {
-                IReadOnlyList<AbstractBuffEvent> voidwalker = log.CombatData.GetBuffData(AchievementEligibilityVoidwalker);
-                bool hasVoidwalkerBeenAdded = false;
-                // Added a CM mode check because the eligibility has been bugged for a while and showed up in normal mode.
-                if (voidwalker.Any())
+                if (log.CombatData.GetBuffData(AchievementEligibilityVoidwalker).Any())
                 {
-                    foreach (Player p in log.PlayerList)
-                    {
-                        if (p.HasBuff(log, AchievementEligibilityVoidwalker, log.FightData.FightEnd - ServerDelayConstant))
-                        {
-                            InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityVoidwalker], 1));
-                            hasVoidwalkerBeenAdded = true;
-                            break;
-                        }
-                    }
+                    InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityVoidwalker));
                 }
-                if (!hasVoidwalkerBeenAdded && CustomCheckVoidwalkerEligibility(log)) // In case all 10 players already have voidwalker
+                else if (CustomCheckVoidwalkerEligibility(log)) // In case all 10 players already have voidwalker
                 {
                     InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityVoidwalker], 1));
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
@@ -293,7 +293,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityFearNotThisKnight).Any())
             {
-                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityFearNotThisKnight));
+                InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityFearNotThisKnight));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
@@ -290,18 +290,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         protected override void SetInstanceBuffs(ParsedEvtcLog log)
         {
             base.SetInstanceBuffs(log);
-            IReadOnlyList<AbstractBuffEvent> fearNotThisKnight = log.CombatData.GetBuffData(AchievementEligibilityFearNotThisKnight);
-            
-            if (fearNotThisKnight.Any() && log.FightData.Success)
+
+            if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityFearNotThisKnight).Any())
             {
-                foreach (Player p in log.PlayerList)
-                {
-                    if (p.HasBuff(log, AchievementEligibilityFearNotThisKnight, log.FightData.FightEnd - ServerDelayConstant))
-                    {
-                        InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityFearNotThisKnight], 1));
-                        break;
-                    }
-                }
+                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityFearNotThisKnight));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
@@ -89,7 +89,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityHoldOntoTheLight).Any())
             {
-                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityHoldOntoTheLight));
+                InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityHoldOntoTheLight));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
@@ -86,18 +86,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         protected override void SetInstanceBuffs(ParsedEvtcLog log)
         {
             base.SetInstanceBuffs(log);
-            IReadOnlyList<AbstractBuffEvent> holdOntoTheLight = log.CombatData.GetBuffData(AchievementEligibilityHoldOntoTheLight);
 
-            if (holdOntoTheLight.Any() && log.FightData.Success)
+            if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityHoldOntoTheLight).Any())
             {
-                foreach (Player p in log.PlayerList)
-                {
-                    if (p.HasBuff(log, AchievementEligibilityHoldOntoTheLight, log.FightData.FightEnd - ServerDelayConstant))
-                    {
-                        InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityHoldOntoTheLight], 1));
-                        break;
-                    }
-                }
+                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityHoldOntoTheLight));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/FraenirOfJormag.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/FraenirOfJormag.cs
@@ -197,7 +197,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityElementalElegy).Any())
             {
-                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityElementalElegy));
+                InstanceBuffs.AddRange(GetOnPlayerCustomInstanceBuff(log, AchievementEligibilityElementalElegy));
             }
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/FraenirOfJormag.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/FraenirOfJormag.cs
@@ -194,18 +194,10 @@ namespace GW2EIEvtcParser.EncounterLogic
         protected override void SetInstanceBuffs(ParsedEvtcLog log)
         {
             base.SetInstanceBuffs(log);
-            IReadOnlyList<AbstractBuffEvent> elementalElegy = log.CombatData.GetBuffData(AchievementEligibilityElementalElegy);
 
-            if (elementalElegy.Any() && log.FightData.Success)
+            if (log.FightData.Success && log.CombatData.GetBuffData(AchievementEligibilityElementalElegy).Any())
             {
-                foreach (Player p in log.PlayerList)
-                {
-                    if (p.HasBuff(log, AchievementEligibilityElementalElegy, log.FightData.FightEnd - ServerDelayConstant))
-                    {
-                        InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityElementalElegy], 1));
-                        break;
-                    }
-                }
+                InstanceBuffs.AddRange(SetOnPlayerCustomInstanceBuff(log, AchievementEligibilityElementalElegy));
             }
         }
     }


### PR DESCRIPTION
- Created SetOnPlayerCustomInstanceBuff and streamlined the usage within SetInstanceBuffs to reduce code repetition
- Created CustomCheckTakingTurns and removed its instance buff, instead moved it to PlayerStatusMechanic<DeadEvent>
- Created CustomCheckManipulateTheManipulator for logs that don't have any present achievement buff
- Small cleanups for Qadim