### PR TITLE
Updated dhuum encounter

### DIFF
--- a/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
@@ -537,7 +537,7 @@ namespace GW2EIEvtcParser.EIData
             CastEvents.AddRange(log.CombatData.GetInstantCastData(AgentItem));
             foreach (WeaponSwapEvent wepSwap in log.CombatData.GetWeaponSwapData(AgentItem))
             {
-                if (CastEvents.Count > 0 && (wepSwap.Time - CastEvents.Last().Time) < ServerDelayConstant && CastEvents.Last().SkillId == SkillIDs.WeaponSwap)
+                if (CastEvents.Count > 0 && (wepSwap.Time - CastEvents.Last().Time) < ServerDelayConstant && CastEvents.Last().SkillId == WeaponSwap)
                 {
                     CastEvents[CastEvents.Count - 1] = wepSwap;
                 }
@@ -861,55 +861,6 @@ namespace GW2EIEvtcParser.EIData
                 return rotations.FirstOrDefault(x => x.Time >= time && x.Time <= time + forwardWindow) ?? rotations.LastOrDefault(x => x.Time <= time); 
             }
             return rotations.LastOrDefault(x => x.Time <= time);
-        }
-
-        /// <summary>
-        /// Compute the cast duration while the target has <see cref="Quickness"/>.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="startCastTime">Starting time of the cast.</param>
-        /// <param name="castDuration">Duration of the cast.</param>
-        /// <returns>The duration of the cast.</returns>
-        public double ComputeCastTimeWithQuickness(ParsedEvtcLog log, long startCastTime, long castDuration)
-        {
-            long expectedEndCastTime = startCastTime + castDuration;
-            Segment quickness = GetBuffStatus(log, Quickness, startCastTime, expectedEndCastTime).FirstOrDefault(x => x.Value == 1);
-            if (quickness != null)
-            {
-                long quicknessTimeDuringCast = Math.Min(expectedEndCastTime, quickness.End) - Math.Max(startCastTime, quickness.Start);
-                return castDuration - quicknessTimeDuringCast + (quicknessTimeDuringCast * 0.66);
-            }
-            return 0;
-        }
-
-        /// <summary>
-        /// Compute the cast duration while the target has <see cref="MistlockInstabilitySugarRush"/>.
-        /// </summary>
-        /// <param name="castDuration">Duration of the cast.</param>
-        /// <returns>The duration of the cast.</returns>
-        public static double ComputeCastTimeWithSugarRush(long castDuration)
-        {
-            return castDuration * 0.8;
-        }
-
-        /// <summary>
-        /// Compute the cast duration while the target has <see cref="Quickness"/> and <see cref="MistlockInstabilitySugarRush"/>.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="startCastTime">Starting time of the cast.</param>
-        /// <param name="castDuration">Duration of the cast.</param>
-        /// <returns>The duration of the cast.</returns>
-        public double ComputeCastTimeWithQuicknessAndSugarRush(ParsedEvtcLog log, long startCastTime, long castDuration)
-        {
-            long expectedEndCastTime = startCastTime + castDuration;
-            Segment quickness = GetBuffStatus(log, Quickness, startCastTime, expectedEndCastTime).FirstOrDefault(x => x.Value == 1);
-            if (quickness != null)
-            {
-                long quicknessTimeDuringCast = Math.Min(expectedEndCastTime, quickness.End) - Math.Max(startCastTime, quickness.Start);
-                double castTimeWithSugarRush = ComputeCastTimeWithSugarRush(castDuration);
-                return castTimeWithSugarRush - quicknessTimeDuringCast + (quicknessTimeDuringCast * 0.66 / 0.8);
-            }
-            return 0;
         }
     }
 }

--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -298,6 +298,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Energy Threshold", EnergyThreshold, Source.FightSpecific, BuffStackType.Stacking, 5, BuffClassification.Other, BuffImages.SpiritForm), // Dhuum & Eater of Souls
             new Buff("Source: Pure Oblivion", SourcePureOblivionBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.CounterMagicSkill),
             new Buff("Messenger Fixation", DhuumsMessengerFixationBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.Fixated),
+            new Buff("Player to Soul Split Buff", DhuumPlayerToSoulTrackBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.Unknown),
             //////////////////////////////////////////////
             // CA
             new Buff("Greatsword Power", GreatswordPower, Source.FightSpecific, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.GreatswordPower),

--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
@@ -6,6 +6,7 @@ using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.ParserHelper;
+using static GW2EIEvtcParser.SkillIDs;
 
 namespace GW2EIEvtcParser.EncounterLogic
 {
@@ -235,6 +236,55 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// Compute the cast duration while the target has <see cref="Quickness"/>.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="startCastTime">Starting time of the cast.</param>
+        /// <param name="castDuration">Duration of the cast.</param>
+        /// <returns>The duration of the cast.</returns>
+        internal static double ComputeCastTimeWithQuickness(ParsedEvtcLog log, AbstractSingleActor actor, long startCastTime, long castDuration)
+        {
+            long expectedEndCastTime = startCastTime + castDuration;
+            Segment quickness = actor.GetBuffStatus(log, Quickness, startCastTime, expectedEndCastTime).FirstOrDefault(x => x.Value == 1);
+            if (quickness != null)
+            {
+                long quicknessTimeDuringCast = Math.Min(expectedEndCastTime, quickness.End) - Math.Max(startCastTime, quickness.Start);
+                return castDuration - quicknessTimeDuringCast + (quicknessTimeDuringCast * 0.66);
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Compute the cast duration while the target has <see cref="MistlockInstabilitySugarRush"/>.
+        /// </summary>
+        /// <param name="castDuration">Duration of the cast.</param>
+        /// <returns>The duration of the cast.</returns>
+        internal static double ComputeCastTimeWithSugarRush(long castDuration)
+        {
+            return castDuration * 0.8;
+        }
+
+        /// <summary>
+        /// Compute the cast duration while the target has <see cref="Quickness"/> and <see cref="MistlockInstabilitySugarRush"/>.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="startCastTime">Starting time of the cast.</param>
+        /// <param name="castDuration">Duration of the cast.</param>
+        /// <returns>The duration of the cast.</returns>
+        internal static double ComputeCastTimeWithQuicknessAndSugarRush(ParsedEvtcLog log, AbstractSingleActor actor, long startCastTime, long castDuration)
+        {
+            long expectedEndCastTime = startCastTime + castDuration;
+            Segment quickness = actor.GetBuffStatus(log, Quickness, startCastTime, expectedEndCastTime).FirstOrDefault(x => x.Value == 1);
+            if (quickness != null)
+            {
+                long quicknessTimeDuringCast = Math.Min(expectedEndCastTime, quickness.End) - Math.Max(startCastTime, quickness.Start);
+                double castTimeWithSugarRush = ComputeCastTimeWithSugarRush(castDuration);
+                return castTimeWithSugarRush - quicknessTimeDuringCast + (quicknessTimeDuringCast * 0.66 / 0.8);
+            }
+            return 0;
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
@@ -345,7 +345,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     {
                         int castDuration = 5400;
                         int expectedEndCastTime = (int)c.Time + castDuration;
-                        double actualDuration = target.ComputeCastTimeWithQuickness(log, c.Time, castDuration);
+                        double actualDuration = ComputeCastTimeWithQuickness(log, target, c.Time, castDuration);
                         if (actualDuration > 0)
                         {
                             replay.AddOverheadIcon(new Segment((int)c.Time, (int)c.Time + (int)Math.Ceiling(actualDuration), 1), target, ParserIcons.EyeOverhead, 30);
@@ -384,7 +384,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         // If the aspect has Sugar Rush AND Quickness
                         if (hasSugarRush && quickness != null)
                         {
-                            double actualDuration = target.ComputeCastTimeWithQuicknessAndSugarRush(log, c.Time, castDuration);
+                            double actualDuration = ComputeCastTimeWithQuicknessAndSugarRush(log, target, c.Time, castDuration);
                             var duration = new Segment(c.Time, c.Time + (int)Math.Ceiling(actualDuration), 1);
                             replay.AddOverheadIcon(duration, target, ParserIcons.EyeOverhead, 30);
                         }
@@ -392,7 +392,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         // If the aspect has Sugar rush AND NOT Quickness
                         if (hasSugarRush && quickness == null)
                         {
-                            var actualDuration = AbstractSingleActor.ComputeCastTimeWithSugarRush(castDuration);
+                            var actualDuration = ComputeCastTimeWithSugarRush(castDuration);
                             var duration = new Segment(c.Time, c.Time + (int)Math.Ceiling(actualDuration), 1);
                             replay.AddOverheadIcon(duration, target, ParserIcons.EyeOverhead, 30);
                         }
@@ -400,7 +400,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         // If the aspect DOESN'T have Sugar rush but HAS Quickness
                         if (!hasSugarRush && quickness != null)
                         {
-                            double actualDuration = target.ComputeCastTimeWithQuickness(log, c.Time, castDuration);
+                            double actualDuration = ComputeCastTimeWithQuickness(log, target, c.Time, castDuration);
                             var duration = new Segment(c.Time, c.Time + (int)Math.Ceiling(actualDuration), 1);
                             replay.AddOverheadIcon(duration, target, ParserIcons.EyeOverhead, 30);
                         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
@@ -345,11 +345,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                     {
                         int castDuration = 5400;
                         int expectedEndCastTime = (int)c.Time + castDuration;
-                        Segment quickness = target.GetBuffStatus(log, Quickness, c.Time, expectedEndCastTime).Where(x => x.Value == 1).FirstOrDefault();
-                        if (quickness != null)
+                        double actualDuration = target.ComputeCastTimeWithQuickness(log, c.Time, castDuration);
+                        if (actualDuration > 0)
                         {
-                            long quicknessTimeDuringCast = Math.Min(expectedEndCastTime, quickness.End) - Math.Max((int)c.Time, quickness.Start);
-                            double actualDuration = castDuration - quicknessTimeDuringCast + (quicknessTimeDuringCast * 0.66);
                             replay.AddOverheadIcon(new Segment((int)c.Time, (int)c.Time + (int)Math.Ceiling(actualDuration), 1), target, ParserIcons.EyeOverhead, 30);
                         }
                         else
@@ -386,24 +384,25 @@ namespace GW2EIEvtcParser.EncounterLogic
                         // If the aspect has Sugar Rush AND Quickness
                         if (hasSugarRush && quickness != null)
                         {
-                            long quicknessTimeDuringCast = Math.Min(expectedEndCastTime, quickness.End) - Math.Max((int)c.Time, quickness.Start);
-                            double castTimeWithSugarRush = castDuration * 0.8;
-                            double actualFinalDuration = castTimeWithSugarRush - quicknessTimeDuringCast + (quicknessTimeDuringCast * 0.66 / 0.8);
-                            replay.AddOverheadIcon(new Segment((int)c.Time, (int)c.Time + (int)Math.Ceiling(actualFinalDuration), 1), target, ParserIcons.EyeOverhead, 30);
+                            double actualDuration = target.ComputeCastTimeWithQuicknessAndSugarRush(log, c.Time, castDuration);
+                            var duration = new Segment(c.Time, c.Time + (int)Math.Ceiling(actualDuration), 1);
+                            replay.AddOverheadIcon(duration, target, ParserIcons.EyeOverhead, 30);
                         }
 
                         // If the aspect has Sugar rush AND NOT Quickness
                         if (hasSugarRush && quickness == null)
                         {
-                            replay.AddOverheadIcon(new Segment((int)c.Time, (int)Math.Ceiling((int)c.Time + castDuration * 0.8), 1), target, ParserIcons.EyeOverhead, 30);
+                            var actualDuration = AbstractSingleActor.ComputeCastTimeWithSugarRush(castDuration);
+                            var duration = new Segment(c.Time, c.Time + (int)Math.Ceiling(actualDuration), 1);
+                            replay.AddOverheadIcon(duration, target, ParserIcons.EyeOverhead, 30);
                         }
 
                         // If the aspect DOESN'T have Sugar rush but HAS Quickness
                         if (!hasSugarRush && quickness != null)
                         {
-                            long quicknessTimeDuringCast = Math.Min(expectedEndCastTime, quickness.End) - Math.Max((int)c.Time, quickness.Start);
-                            double actualDuration = castDuration - quicknessTimeDuringCast + (quicknessTimeDuringCast * 0.66);
-                            replay.AddOverheadIcon(new Segment((int)c.Time, (int)c.Time + (int)Math.Ceiling(actualDuration), 1), target, ParserIcons.EyeOverhead, 30);
+                            double actualDuration = target.ComputeCastTimeWithQuickness(log, c.Time, castDuration);
+                            var duration = new Segment(c.Time, c.Time + (int)Math.Ceiling(actualDuration), 1);
+                            replay.AddOverheadIcon(duration, target, ParserIcons.EyeOverhead, 30);
                         }
 
                         // If the aspect DOESN'T have Sugar Rush and Quickness

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -347,7 +347,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                             long defaultCastDuration = 1550;
 
                             // Compute cast time of the Death Mark with Quickness
-                            double computedDuration = target.ComputeCastTimeWithQuickness(log, start, defaultCastDuration);
+                            double computedDuration = ComputeCastTimeWithQuickness(log, target, start, defaultCastDuration);
                             if (computedDuration > 0)
                             {
                                 defaultCastDuration = Math.Min(defaultCastDuration, (int)Math.Ceiling(computedDuration));
@@ -429,7 +429,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                                 int expectedEndCastTime = (int)effect.Time + castDuration;
 
                                 // Find if Dhuum has stolen quickness
-                                double actualDuration = target.ComputeCastTimeWithQuickness(log, effect.Time, castDuration);
+                                double actualDuration = ComputeCastTimeWithQuickness(log, target, effect.Time, castDuration);
 
                                 // Dhuum can interrupt his own cast with other skills and the effect duration logged of 10000 isn't correct.
                                 (long, long) lifespan = effect.ComputeDynamicLifespan(log, castDuration);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -443,15 +443,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                                     supposedLifespan.Item2 = effect.Time + Math.Min(castDuration, (long)Math.Ceiling(actualDuration));
                                 }
 
-                                // Get Dhuum's rotation with 200 ms delay and a 200ms forward time window.
-                                Point3D facing = target.GetCurrentRotation(log, effect.Time + 200, 200);
-                                if (facing == null)
-                                {
-                                    continue;
-                                }
-
                                 var position = new PositionConnector(effect.Position);
-                                var rotation = new AngleConnector(facing);
+                                var rotation = new AngleConnector(effect.Rotation.Z + 90);
 
                                 var coneDec = (PieDecoration)new PieDecoration(850, 60, lifespan, "rgba(250, 120, 0, 0.2)", position).UsingRotationConnector(rotation);
                                 var coneGrowing = (PieDecoration)new PieDecoration(850, 60, lifespan, "rgba(250, 120, 0, 0.2)", position).UsingGrowingEnd(supposedLifespan.Item2).UsingRotationConnector(rotation);
@@ -465,14 +458,14 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var scytheSwing = cls.Where(x => x.SkillId == ScytheSwing).ToList();
                     for (int i = 0; i < scytheSwing.Count; i++)
                     {
-                        var endNextSwing = i < scytheSwing.Count -1 ? scytheSwing[i + 1].Time : log.FightData.FightEnd;
+                        var nextSwing = i < scytheSwing.Count -1 ? scytheSwing[i + 1].Time : log.FightData.FightEnd;
 
                         // AoE Indicator
                         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.DhuumScytheSwingIndicator, out IReadOnlyList<EffectEvent> scytheSwingIndicators))
                         {
                             int radius = 45;
                             int radiusIncrease = 5;
-                            foreach (EffectEvent indicator in scytheSwingIndicators.Where(x => x.Time >= scytheSwing[i].Time && x.Time < endNextSwing))
+                            foreach (EffectEvent indicator in scytheSwingIndicators.Where(x => x.Time >= scytheSwing[i].Time && x.Time < nextSwing))
                             {
                                 // Computing lifespan through secondary effect and position.
                                 (long start, long end) lifespan = indicator.ComputeLifespanWithSecondaryEffectAndPosition(log, EffectGUIDs.DhuumScytheSwingDamage);
@@ -487,7 +480,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         {
                             int radius = 45;
                             int radiusIncrease = 5;
-                            foreach (EffectEvent damage in scytheSwingDamage.Where(x => x.Time >= scytheSwing[i].Time && x.Time < endNextSwing))
+                            foreach (EffectEvent damage in scytheSwingDamage.Where(x => x.Time >= scytheSwing[i].Time && x.Time < nextSwing))
                             {
                                 // The effect has 0 duration, setting it to 250
                                 (long start, long end) lifespan = (damage.Time, damage.Time + 250);

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvent.cs
@@ -107,5 +107,51 @@ namespace GW2EIEvtcParser.ParsedData
             long end = ComputeEndTime(log, durationToUse, agent, associatedBuff);
             return (start, end);
         }
+
+        /// <summary>
+        /// Computes the lifespan of an effect.<br></br>
+        /// Takes the <see cref="Time"/> of the main effect as start and the <see cref="Time"/> of the <paramref name="secondaryEffectGUID"/> as end.<br></br>
+        /// Checks the matcching effects Src.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="secondaryEffectGUID"><see cref="EffectGUIDs"/> of the secondary effect.</param>
+        /// <returns>The computed start and end times.</returns>
+        public (long start, long end) ComputeLifespanWithSecondaryEffect(ParsedEvtcLog log, string secondaryEffectGUID)
+        {
+            long start = Time;
+            long end = start + Duration;
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(Src, secondaryEffectGUID, out IReadOnlyList<EffectEvent> effects))
+            {
+                EffectEvent firstEffect = effects.FirstOrDefault(x => x.Time >= Time && !IsAroundDst);
+                if (firstEffect != null)
+                {
+                    end = firstEffect.Time;
+                }
+            }
+            return (start, end);
+        }
+
+        /// <summary>
+        /// Computes the lifespan of an effect.<br></br>
+        /// Takes the <see cref="Time"/> of the main effect as start and the <see cref="Time"/> of the <paramref name="secondaryEffectGUID"/> as end.<br></br>
+        /// Checks the matching effects Src and Position.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="secondaryEffectGUID"><see cref="EffectGUIDs"/> of the secondary effect.</param>
+        /// <returns>The computed start and end times.</returns>
+        public (long start, long end) ComputeLifespanWithSecondaryEffectAndPosition(ParsedEvtcLog log, string secondaryEffectGUID)
+        {
+            long start = Time;
+            long end = start + Duration;
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(Src, secondaryEffectGUID, out IReadOnlyList<EffectEvent> effects))
+            {
+                EffectEvent firstEffect = effects.FirstOrDefault(x => x.Time >= Time && !x.IsAroundDst && x.Position.DistanceToPoint(Position) < 1e-6);
+                if (firstEffect != null)
+                {
+                    end = firstEffect.Time;
+                }
+            }
+            return (start, end);
+        }
     }
 }

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -528,7 +528,6 @@ namespace GW2EIEvtcParser
         private const int Cage = -46;
         private const int Bombs = -47;
         private const int YourSoul = -48;
-        private const int TheVortexOfSouls = -49;
         public const int NonIdentifiedSpecies = 0;
 
         //
@@ -707,7 +706,6 @@ namespace GW2EIEvtcParser
             UnderworldReaper = 19831,
             DhuumDesmina = 19481,
             YourSoul = ArcDPSEnums.YourSoul,
-            TheVortexOfSouls = ArcDPSEnums.TheVortexOfSouls,
             // CA
             ConjuredGreatsword = 21255,
             ConjuredShield = 21170,

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -527,6 +527,8 @@ namespace GW2EIEvtcParser
         private const int SnowPile = -45;
         private const int Cage = -46;
         private const int Bombs = -47;
+        private const int YourSoul = -48;
+        private const int TheVortexOfSouls = -49;
         public const int NonIdentifiedSpecies = 0;
 
         //
@@ -704,6 +706,8 @@ namespace GW2EIEvtcParser
             Deathling = 19759,
             UnderworldReaper = 19831,
             DhuumDesmina = 19481,
+            YourSoul = ArcDPSEnums.YourSoul,
+            TheVortexOfSouls = ArcDPSEnums.TheVortexOfSouls,
             // CA
             ConjuredGreatsword = 21255,
             ConjuredShield = 21170,

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -367,6 +367,17 @@ namespace GW2EIEvtcParser
         public const string BrokenKingIceBreakerGreenExplosion = "957ADB83D139704F8CB865E86E389228";
         public const string BrokenKingKingsWrathConeAoEIndicator = "FA4B726574C96E489D73529CFE390D3D"; // Currently unused, we don't know how to determinate the aoe size
         public const string BrokenKingKingsWrathConeAoEDamage = "22AC6bFC0B06C1459DFEF1E380F50165"; // Currently unused, we don't know how to determinate the aoe size
+        // Dhuum
+        public const string DhuumScytheSwingIndicator = "91A23D51294E80458BE9C3C89A2ED138"; // 1200 duration
+        public const string DhuumScytheSwingDamage = "C79F5D95E11070448A39ACD7F6C5D0D3"; // 0 duration
+        public const string DhuumCullAoEIndicator = "1BB71ED45AF4354AB65BBEB976E8CFEE"; // 0 duration
+        public const string DhuumCullCracksIndicator = "F28528CBE08E0D43B3227A157CD1CCF2"; // dynamic duration, earlier cracks have longer duration than last ones.
+        public const string DhuumCullCracksDamage = "13B5022FBF7D884C9AA9ED667FEEC22F"; // 0 duration
+        public const string DhuumDeathMarkFirstIndicator = "6A0D725CD03D8D48BEA939CD1BBA7A9A"; // 2000 duration - Soul split warning indicator
+        public const string DhuumDeathMarkSecondIndicator = "4BA74BA044B7BD4BB1E3392641078D97"; // 1000 duration - Hit indicator (black smoke)
+        public const string DhuumDeathMarkDeathZone = "B8F90FE6AF4F2A4C84D349861A098392"; // 120000 duration
+        public const string DhuumSuperspeedOrb = "8F89945581099142B598977188BAC8E1"; // max duration - has end effect
+        public const string DhuumConeSlash = "21BA95CC014CC944A71E2A6FB28D9A86";
         // CA
         public const string CAArmSmash = "B1AAD873DB07E04E9D69627156CA8918";
         // Sabir

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -22,9 +22,24 @@ namespace GW2EIEvtcParser.ParserHelpers
         public const string GenericEnemyIcon = "https://i.imgur.com/ZnFcOIA.png";
 
         /// <summary>
-        /// Generic blue arrow up.
+        /// Generic blue arrow pointing upwards.
         /// </summary>
         public const string GenericBlueArrowUp = "https://i.imgur.com/0EnjyQX.png";
+
+        /// <summary>
+        /// Generic Green arrow pointing upwards.
+        /// </summary>
+        public const string GenericGreenArrowUp = "https://i.imgur.com/Nlu3u04.png";
+
+        /// <summary>
+        /// Generic Red arrow pointing upwards.
+        /// </summary>
+        public const string GenericRedArrowUp = "https://i.imgur.com/hCrbYA6.png";
+
+        /// <summary>
+        /// Generic Purple arrow pointing upwards.
+        /// </summary>
+        public const string GenericPurpleArrowUp = "https://i.imgur.com/DBq6i0R.png";
 
         // High Resolution Icons 200px
         private const string HighResUntamed = "https://wiki.guildwars2.com/images/3/33/Untamed_tango_icon_200px.png";
@@ -361,6 +376,7 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashSnowPile = "https://i.imgur.com/uku1klD.png";
         private const string TrashCage = "https://i.imgur.com/W9Z0roU.png";
         private const string TrashBombs = "https://i.imgur.com/fV8psEZ.png";
+        private const string TrashDhuumSoul = "https://i.imgur.com/rAyuxqS.png";
 
         // Minion NPC Icons
         private const string MinionHoundOfBalthazar = "https://i.imgur.com/FFSYrzL.png";
@@ -867,6 +883,7 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.Messenger, TrashTormentedDeadMessenger },
             { ArcDPSEnums.TrashID.Enforcer, TrashEnforcer },
             { ArcDPSEnums.TrashID.Echo, TrashEcho },
+            { ArcDPSEnums.TrashID.YourSoul, TrashDhuumSoul },
             { ArcDPSEnums.TrashID.KeepConstructCore, TrashKeepConstructCoreExquisiteConjunction },
             { ArcDPSEnums.TrashID.ExquisiteConjunction, TrashKeepConstructCoreExquisiteConjunction },
             { ArcDPSEnums.TrashID.Jessica, TrashKeepConstructGhosts },

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -376,7 +376,6 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashSnowPile = "https://i.imgur.com/uku1klD.png";
         private const string TrashCage = "https://i.imgur.com/W9Z0roU.png";
         private const string TrashBombs = "https://i.imgur.com/fV8psEZ.png";
-        private const string TrashDhuumSoul = "https://i.imgur.com/rAyuxqS.png";
 
         // Minion NPC Icons
         private const string MinionHoundOfBalthazar = "https://i.imgur.com/FFSYrzL.png";
@@ -662,6 +661,9 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string TargetOrder4Overhead = "https://wiki.guildwars2.com/images/c/c6/Target_Order-4_%28overhead_icon%29.png";
         internal const string TargetOrder5Overhead = "https://wiki.guildwars2.com/images/4/47/Target_Order-5_%28overhead_icon%29.png";
 
+        // NPC / Gadgets Icons not private
+        internal const string DhuumPlayerSoul = "https://i.imgur.com/rAyuxqS.png";
+
         /// <summary>
         /// Dictionary matching a <see cref="Spec"/> to their high resolution profession icon.
         /// </summary>
@@ -883,7 +885,7 @@ namespace GW2EIEvtcParser.ParserHelpers
             { ArcDPSEnums.TrashID.Messenger, TrashTormentedDeadMessenger },
             { ArcDPSEnums.TrashID.Enforcer, TrashEnforcer },
             { ArcDPSEnums.TrashID.Echo, TrashEcho },
-            { ArcDPSEnums.TrashID.YourSoul, TrashDhuumSoul },
+            { ArcDPSEnums.TrashID.YourSoul, DhuumPlayerSoul },
             { ArcDPSEnums.TrashID.KeepConstructCore, TrashKeepConstructCoreExquisiteConjunction },
             { ArcDPSEnums.TrashID.ExquisiteConjunction, TrashKeepConstructCoreExquisiteConjunction },
             { ArcDPSEnums.TrashID.Jessica, TrashKeepConstructGhosts },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -2541,6 +2541,7 @@
         public const long EndersEchoDamage = 47076;
         public const long ReclaimedEnergyBuff = 47090;
         public const long FollowersAsylum = 47122;
+        public const long ScytheSwing = 47123;
         public const long GreensEaterofSouls = 47153;
         public const long DhuumShacklesHit = 47164;
         public const long ImminentDemise = 47181;
@@ -2625,7 +2626,9 @@
         public const long MortalCoilStatueOfDeath = 48583;
         public const long DhuumShacklesBuff2 = 48591;
         public const long HowlingDeath = 48662;
-        public const long Cull = 48752;
+        public const long DhuumPlayerToSoulTrackBuff = 48670; // Buff applied from the player to the soul gadget
+        public const long CullDamage = 48752;
+        public const long CullSkill = 48758;
         public const long PutridBomb = 48760;
         public const long HastenedDemise = 48773;
         public const long LightCarrier = 48779;


### PR DESCRIPTION
# Dhuum
## General
- Added Enforcers to phases, targets and renamed them with counter number
- Added Ender's Echo to targets for breakbar phases
- Cleaned up some unused code and ArcDPSEnums, removed commented mechanics that weren't used
## Decorations
- Fixed Cone Slash rotating point
- Added Cone Slash using effect event and quickness check
- Reworked Death Mark for older logs
- - Fixed cast time if Dhuum gains quickness
- - Added a quickness cast time check
- - Added warning hit decoration
- - Updated colors
- Added Death Mark using effects
- - Same behaviour as the above
- Added Scythe Swing AoEs (indicator + damage)
- Added Cull cracks (spawn circle, cracks indicators, cracks explosion)
- Added superspeed orbs
- Added Rending Swipe autoattack for Enforcers (old and new logs)
- Added Soul Split
- - Players split from their soul have a tether to it
- - Soul has an icon and a growing red circle indicating the death timer
- - Soul will despawn on its last aware
- - Logs that don't have a gadget master utilize player-to-soul buff application as tracker
- Added green arrow icon for players up to a green
## Mechanics
- Added superspeed orbs counter
- Hit by Enforcer's Rending Swipe

# General
- Added EffectEvent APIs
- - ComputeLifespanWithSecondaryEffect - Computes the effect life span using the secondary effect start time as end time
- - ComputeLifespanWithSecondaryEffectAndPosition - Computes the effect life span using the secondary effect start time as end time, also checking for position of the effects
- Added EncounterLogicUtils APIs
- ComputeCastTimeWithQuickness - Computes the cast duration while an agent has quickness
- ComputeCastTimeWithSugarRush - Computes the cast duration if the instability is active
- ComputeCastTimeWithQuicknessAndSugarRush - Computes the cast duration if the instability is active and the target gains quickness
- Updated Kanaxai to be using the above APIs
- Added generic arrow colors pointing upwards to ParserIcons