### PR TITLE
Fractal encounters & general cleanup

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -51,6 +51,8 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Mistlock Instability: Vengeance", MistlockInstabilityVengeance, Source.FractalInstability, BuffClassification.Other, BuffImages.InstabilityVengeance),
             new Buff("Mistlock Instability: We Bleed Fire", MistlockInstabilityWeBleedFire, Source.FractalInstability, BuffClassification.Other, BuffImages.InstabilityWeBleedFire),
             new Buff("Mistlock Instability: Toxic Sickness", MistlockInstabilityToxicSickness, Source.FractalInstability, BuffClassification.Other, BuffImages.InstabilityToxicSickness),
+            // Related buffs
+            new Buff("Flux Bomb Target", FluxBombBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.InstabilityFluxBomb),
         };
 
         internal static readonly List<Buff> FightSpecific = new List<Buff>

--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -54,7 +54,9 @@ namespace GW2EIEvtcParser.EIData
         public static Color Orange = new Color(255, 100, 0);
         public static Color LightOrange = new Color(250, 120, 0);
         public static Color Yellow = new Color(255, 220, 0);
+        public static Color LightBrown = new Color(196, 164, 132);
         public static Color Brown = new Color(120, 100, 0);
+        public static Color Chocolate = new Color(123, 63, 0);
         public static Color Green = new Color(0, 255, 0);
         public static Color GreenishYellow = new Color(220, 255, 0);
         public static Color MilitaryGreen = new Color(69, 75, 27);

--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -51,6 +51,7 @@ namespace GW2EIEvtcParser.EIData
         public static Color Red = new Color(255, 0, 0);
         public static Color LightRed = new Color(255, 128, 128);
         public static Color DarkRed = new Color(128, 0, 0);
+        public static Color RedBrownish = new Color(71, 35, 32);
         public static Color Orange = new Color(255, 100, 0);
         public static Color LightOrange = new Color(250, 120, 0);
         public static Color Yellow = new Color(255, 220, 0);

--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicUtils.cs
@@ -242,6 +242,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         /// Compute the cast duration while the target has <see cref="Quickness"/>.
         /// </summary>
         /// <param name="log">The log.</param>
+        /// <param name="actor">Actor casting.</param>
         /// <param name="startCastTime">Starting time of the cast.</param>
         /// <param name="castDuration">Duration of the cast.</param>
         /// <returns>The duration of the cast.</returns>
@@ -271,6 +272,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         /// Compute the cast duration while the target has <see cref="Quickness"/> and <see cref="MistlockInstabilitySugarRush"/>.
         /// </summary>
         /// <param name="log">The log.</param>
+        /// <param name="actor">Actor casting.</param>
         /// <param name="startCastTime">Starting time of the cast.</param>
         /// <param name="castDuration">Duration of the cast.</param>
         /// <returns>The duration of the cast.</returns>
@@ -287,15 +289,25 @@ namespace GW2EIEvtcParser.EncounterLogic
             return 0;
         }
 
-        internal static long ComputeEndCastTimeByStun(ParsedEvtcLog log, AbstractSingleActor actor, long startCastTime, long castDuration)
+        /// <summary>
+        /// Compute the end time of a cast.<br></br>
+        /// If <paramref name="buffId"/> is present before the end of the cast, return the <paramref name="buffId"/> application time.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="actor">Actor casting.</param>
+        /// <param name="buffId">Buff application that ends the cast earlier than the expected duration.</param>
+        /// <param name="startCastTime">Starting time of the cast.</param>
+        /// <param name="castDuration">Duration of the cast.</param>
+        /// <returns>The end time of the cast.</returns>
+        internal static long ComputeEndCastTimeByBuffApplication(ParsedEvtcLog log, AbstractSingleActor actor, long buffId, long startCastTime, long castDuration)
         {
-            long standardEndCastTime = startCastTime + castDuration;
-            Segment stunSegment = actor.GetBuffStatus(log, Stun, startCastTime, standardEndCastTime).FirstOrDefault(x => x.Value > 0);
-            if (stunSegment != null)
+            long end = startCastTime + castDuration;
+            Segment segment = actor.GetBuffStatus(log, buffId, startCastTime, end).FirstOrDefault(x => x.Value > 0);
+            if (segment != null)
             {
-                return stunSegment.Start;
+                return segment.Start;
             }
-            return standardEndCastTime;
+            return end;
         }
 
 

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/FractalLogic.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/FractalLogic.cs
@@ -4,8 +4,9 @@ using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
-using static GW2EIEvtcParser.EncounterLogic.EncounterCategory;
+using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.SkillIDs;
+using static GW2EIEvtcParser.EncounterLogic.EncounterCategory;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
@@ -22,7 +23,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
             new PlayerDstBuffApplyMechanic(FluxBombBuff, "Flux Bomb", new MechanicPlotlySetting(Symbols.Circle,Colors.Purple,10), "Flux","Flux Bomb application", "Flux Bomb",0),
             new PlayerDstHitMechanic(FluxBombSkill, "Flux Bomb", new MechanicPlotlySetting(Symbols.CircleOpen,Colors.Purple,10), "Flux dmg","Flux Bomb hit", "Flux Bomb dmg",0), // No longer tracking damage
-            new SpawnMechanic((int)ArcDPSEnums.TrashID.FractalVindicator, "Fractal Vindicator", new MechanicPlotlySetting(Symbols.StarDiamondOpen,Colors.Black,10), "Vindicator","Fractal Vindicator spawned", "Vindicator spawn",0),
+            new SpawnMechanic((int)TrashID.FractalVindicator, "Fractal Vindicator", new MechanicPlotlySetting(Symbols.StarDiamondOpen,Colors.Black,10), "Vindicator","Fractal Vindicator spawned", "Vindicator spawn",0),
             new PlayerDstBuffApplyMechanic(DebilitatedToxicSickness, "Debilitated", new MechanicPlotlySetting(Symbols.TriangleUp, Colors.Pink, 10), "Debil.A", "Debilitated Application (Toxic Sickness)", "Received Debilitated", 0),
             new PlayerSrcEffectMechanic(new [] { EffectGUIDs.ToxicSicknessOldIndicator, EffectGUIDs.ToxicSicknessNewIndicator }, "Toxic Sickness", new MechanicPlotlySetting(Symbols.TriangleUpOpen, Colors.LightOrange, 10), "ToxSick.A", "Toxic Sickness Application", "Toxic Sickness Application", 0),
             /* Not trackable due to health % damage for now
@@ -68,17 +69,17 @@ namespace GW2EIEvtcParser.EncounterLogic
             };
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            return new List<ArcDPSEnums.TrashID>()
+            return new List<TrashID>()
             {
-                ArcDPSEnums.TrashID.FractalAvenger,
-                ArcDPSEnums.TrashID.FractalVindicator,
-                ArcDPSEnums.TrashID.TheMossman,
-                ArcDPSEnums.TrashID.InspectorEllenKiel,
-                ArcDPSEnums.TrashID.ChampionRabbit,
-                ArcDPSEnums.TrashID.JadeMawTentacle,
-                ArcDPSEnums.TrashID.AwakenedAbomination,
+                TrashID.FractalAvenger,
+                TrashID.FractalVindicator,
+                TrashID.TheMossman,
+                TrashID.InspectorEllenKiel,
+                TrashID.ChampionRabbit,
+                TrashID.JadeMawTentacle,
+                TrashID.AwakenedAbomination,
             };
         }
 
@@ -107,7 +108,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         protected static long GetFightOffsetByFirstInvulFilter(FightData fightData, AgentData agentData, List<CombatItem> combatData, int targetID, long invulID)
         {         
             long startToUse = GetGenericFightOffset(fightData);
-            CombatItem logStartNPCUpdate = combatData.FirstOrDefault(x => x.IsStateChange == ArcDPSEnums.StateChange.LogStartNPCUpdate);
+            CombatItem logStartNPCUpdate = combatData.FirstOrDefault(x => x.IsStateChange == StateChange.LogStartNPCUpdate);
             AgentItem target;
             if (logStartNPCUpdate != null)
             {
@@ -125,16 +126,16 @@ namespace GW2EIEvtcParser.EncounterLogic
             // check first invul gain
             CombatItem invulGain = combatData.FirstOrDefault(x => x.DstMatchesAgent(target) && x.IsBuffApply() && x.SkillID == invulID && x.Time >= startToUse);
             // get invul lost
-            CombatItem invulLost = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target) && x.IsBuffRemove == ArcDPSEnums.BuffRemove.All && x.SkillID == invulID && x.Time >= startToUse);
+            CombatItem invulLost = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target) && x.IsBuffRemove == BuffRemove.All && x.SkillID == invulID && x.Time >= startToUse);
             // invul gain at the start and invul loss matches the gained invul
-            if (invulGain != null && (invulGain.IsStateChange == ArcDPSEnums.StateChange.BuffInitial || invulGain.Time - target.FirstAware < 200) && invulLost != null && invulLost.Time >= invulGain.Time)
+            if (invulGain != null && (invulGain.IsStateChange == StateChange.BuffInitial || invulGain.Time - target.FirstAware < 200) && invulLost != null && invulLost.Time >= invulGain.Time)
             {
                 return invulLost.Time + 1;
             }
             else if (invulLost != null && (invulGain == null || invulLost.Time < invulGain.Time))
             {
                 // only invul lost, missing buff apply event
-                CombatItem enterCombat = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target) && x.IsStateChange == ArcDPSEnums.StateChange.EnterCombat && x.Time >= startToUse);
+                CombatItem enterCombat = combatData.FirstOrDefault(x => x.SrcMatchesAgent(target) && x.IsStateChange == StateChange.EnterCombat && x.Time >= startToUse);
                 // no buff apply -> target was invul the whole time
                 if (enterCombat != null && enterCombat.Time >= invulLost.Time)
                 {
@@ -148,31 +149,21 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             base.ComputePlayerCombatReplayActors(p, log, replay);
 
-            // Toxic Sickness - Old Indicator
-            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(p.AgentItem, EffectGUIDs.ToxicSicknessOldIndicator, out IReadOnlyList<EffectEvent> toxicSicknessOld))
+            // Toxic Sickness
+            var toxicSicknessGUIDs = new List<string>() { EffectGUIDs.ToxicSicknessOldIndicator, EffectGUIDs.ToxicSicknessNewIndicator };
+            foreach (string guid in toxicSicknessGUIDs)
             {
-                foreach (EffectEvent effect in toxicSicknessOld)
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(p.AgentItem, guid, out IReadOnlyList<EffectEvent> toxicSickenss))
                 {
-                    (long start, long end) lifespan = (effect.Time, effect.Time + 4000);
-                    (long start, long end) lifespanPuke = (lifespan.end, lifespan.end + 200);
-                    var rotation = new AgentFacingConnector(p);
-                    var connector = new AgentConnector(p);
-                    replay.Decorations.Add(new PieDecoration(600, 36, lifespan, Colors.DarkGreen, 0.2, connector).UsingRotationConnector(rotation));
-                    replay.Decorations.Add(new PieDecoration(600, 36, lifespanPuke, Colors.DarkGreen, 0.4, connector).UsingRotationConnector(rotation));                   
-                }
-            }
-
-            // Toxic Sickness - New Indicator
-            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(p.AgentItem, EffectGUIDs.ToxicSicknessNewIndicator, out IReadOnlyList<EffectEvent> toxicSicknessNew))
-            {
-                foreach (EffectEvent effect in toxicSicknessNew)
-                {
-                    (long start, long end) lifespan = (effect.Time, effect.Time + 4000);
-                    (long start, long end) lifespanPuke = (lifespan.end, lifespan.end + 200);
-                    var rotation = new AgentFacingConnector(p);
-                    var connector = new AgentConnector(p);
-                    replay.Decorations.Add(new PieDecoration(600, 36, lifespan, Colors.DarkGreen, 0.2, connector).UsingRotationConnector(rotation));
-                    replay.Decorations.Add(new PieDecoration(600, 36, lifespanPuke, Colors.DarkGreen, 0.4, connector).UsingRotationConnector(rotation));
+                    foreach (EffectEvent effect in toxicSickenss)
+                    {
+                        (long start, long end) lifespan = (effect.Time, effect.Time + 4000);
+                        (long start, long end) lifespanPuke = (lifespan.end, lifespan.end + 200);
+                        var rotation = new AgentFacingConnector(p);
+                        var connector = new AgentConnector(p);
+                        replay.Decorations.Add(new PieDecoration(600, 36, lifespan, Colors.DarkGreen, 0.2, connector).UsingRotationConnector(rotation));
+                        replay.Decorations.Add(new PieDecoration(600, 36, lifespanPuke, Colors.DarkGreen, 0.4, connector).UsingRotationConnector(rotation));
+                    }
                 }
             }
 
@@ -186,7 +177,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         protected static void AddFractalScaleEvent(ulong gw2Build, List<CombatItem> combatData, IReadOnlyList<(ulong build, byte scale)> scales)
         {
-            if (combatData.Any(x => x.IsStateChange == ArcDPSEnums.StateChange.FractalScale))
+            if (combatData.Any(x => x.IsStateChange == StateChange.FractalScale))
             {
                 return;
             }
@@ -195,7 +186,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 if (gw2Build >= build)
                 {
-                    combatData.Add(new CombatItem(0, scale, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte)ArcDPSEnums.StateChange.FractalScale, 0, 0, 0, 0));
+                    combatData.Add(new CombatItem(0, scale, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, (byte)StateChange.FractalScale, 0, 0, 0, 0));
                     break;
                 }
             }
@@ -214,6 +205,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             base.ComputeEnvironmentCombatReplayDecorations(log);
 
+            // Flux bomb on the ground
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SmallFluxBomb, out IReadOnlyList<EffectEvent> fluxBombs))
             {
                 foreach (EffectEvent effect in fluxBombs)
@@ -236,5 +228,44 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
         }
 
+        /// <summary>
+        /// Add AoE decorations based on the distance to the caster. <br></br>
+        /// Used for Caustic Barrage (Siax, Ensolyss) and Solar Bolt (Skorvald).
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="environmentDecorations">The decorations list.</param>
+        /// <param name="effectGUID">The <see cref="EffectGUIDs"/>.</param>
+        /// <param name="target">The target casting.</param>
+        /// <param name="distanceThreshold">Threshold distance of the effect from the caster.</param>
+        /// <param name="onDistanceSuccessDuration">Duration of the AoE effects closer to the caster.</param>
+        /// <param name="onDistanceFailDuration">Duration of the AoE effects farther away from the caster.</param>
+        protected static void AddDistanceCorrectedOrbDecorations(ParsedEvtcLog log, List<GenericDecoration> environmentDecorations, string effectGUID, TargetID target, double distanceThreshold, long onDistanceSuccessDuration, long onDistanceFailDuration)
+        {
+            if (log.CombatData.TryGetEffectEventsByGUID(effectGUID, out IReadOnlyList<EffectEvent> effects))
+            {
+                foreach (EffectEvent effect in effects)
+                {
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    // Correcting the duration of the effects for CTBS 45, based on the distance from the target casting the mechanic.
+                    if (effect is EffectEventCBTS45)
+                    {
+                        AgentItem agent = log.AgentData.GetNPCsByID(target).FirstOrDefault();
+                        if (agent != null)
+                        {
+                            var distance = effect.Position.DistanceToPoint(agent.GetCurrentPosition(log, effect.Time));
+                            if (distance < distanceThreshold)
+                            {
+                                lifespan.end = effect.Time + onDistanceSuccessDuration;
+                            }
+                            else
+                            {
+                                lifespan.end = effect.Time + onDistanceFailDuration;
+                            }
+                        }
+                    }
+                    environmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position)));
+                }
+            }
+        }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
@@ -442,34 +442,6 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             base.ComputeEnvironmentCombatReplayDecorations(log);
 
-            // Caustic Barrage
-            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.CausticBarrageIndicator, out IReadOnlyList<EffectEvent> barrageEffects))
-            {
-                foreach (EffectEvent effect in barrageEffects)
-                {
-                    int duration;
-                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
-                    if (effect is EffectEventCBTS45)
-                    {
-                        AgentItem ensolyss = log.AgentData.GetNPCsByID(TargetID.Ensolyss).FirstOrDefault();
-                        if (ensolyss != null)
-                        {
-                            var distance = effect.Position.DistanceToPoint(ensolyss.GetCurrentPosition(log, effect.Time));
-                            if (distance < 210)
-                            {
-                                duration = 1000;
-                            }
-                            else
-                            {
-                                duration = 1300;
-                            }
-                            lifespan.end = effect.Time + duration;
-                        }
-                    }
-                    EnvironmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position)));
-                }
-            }
-
             // Nightmare Altar Orb AoE 1
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EnsolyssNightmareAltarOrangeAoE, out IReadOnlyList<EffectEvent> indicators1))
             {
@@ -499,6 +471,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                     EnvironmentDecorations.Add(new CircleDecoration(1200, lifespan, Colors.Yellow, 0.4, new PositionConnector(effect.Position)).UsingFilled(false).UsingGrowingEnd(lifespan.end));
                 }
             }
+
+            // Caustic Barrage
+            AddDistanceCorrectedOrbDecorations(log, EnvironmentDecorations, EffectGUIDs.CausticBarrageIndicator, TargetID.Ensolyss, 210, 1000, 1300);
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
@@ -61,17 +61,17 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<int>
             {
                 (int)TargetID.Ensolyss,
-                //(int)ArcDPSEnums.TrashID.NightmareAltar,
+                //(int)TrashID.NightmareAltar,
             };
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            var trashIDs = new List<ArcDPSEnums.TrashID>
+            var trashIDs = new List<TrashID>
             {
                 TrashID.NightmareHallucination1,
                 TrashID.NightmareHallucination2,
-                //ArcDPSEnums.TrashID.NightmareAltar,
+                //TrashID.NightmareAltar,
             };
             trashIDs.AddRange(base.GetTrashMobsIDs());
             return trashIDs;
@@ -104,16 +104,16 @@ namespace GW2EIEvtcParser.EncounterLogic
             return phases;
         }
 
-        private static void AddTormentingBlastDecoration(CombatReplay replay, AbstractSingleActor target, int start, int attackEnd, Point3D point, int quarterAoE, int quarterHit)
+        private static void AddTormentingBlastDecoration(CombatReplay replay, AbstractSingleActor target, (long start, long end) lifespan, Point3D point, int quarterAoE, int quarterHit)
         {
-            int startQuarter = start + quarterAoE;
-            int endQuarter = start + quarterHit;
-            int growingQuarter = start + quarterHit;
-            if (attackEnd >= endQuarter) // If the attack started
+            long startQuarter = lifespan.start + quarterAoE;
+            long endQuarter = lifespan.start + quarterHit;
+            long growingQuarter = lifespan.start + quarterHit;
+            if (lifespan.end >= endQuarter) // If the attack started
             {
                 var connector = new AgentConnector(target);
                 var rotationConnector = new AngleConnector(point);
-                replay.AddDecorationWithGrowing((PieDecoration)new PieDecoration(700, 90, (startQuarter, endQuarter), Colors.Orange, 0.2, connector).UsingRotationConnector(rotationConnector), growingQuarter);
+                replay.AddDecorationWithGrowing((PieDecoration)new PieDecoration(700, 90, (startQuarter, endQuarter), Colors.LightOrange, 0.2, connector).UsingRotationConnector(rotationConnector), growingQuarter);
                 if (endQuarter == growingQuarter) // If the attack went off
                 {
                     replay.Decorations.Add(new PieDecoration(700, 90, (endQuarter, endQuarter + 1000), Colors.LightPink, 0.2,connector).UsingRotationConnector(rotationConnector)); // Lingering
@@ -121,25 +121,22 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
         }
 
-        private static void AddCausticExplosionDecoration(CombatReplay replay, AbstractSingleActor target, Point3D point, int attackEnd, int start, int end, int growing)
+        private static void AddCausticExplosionDecoration(CombatReplay replay, AbstractSingleActor target, Point3D point, long attackEnd, (long start, long end) lifespan, long growing)
         {
-            if (attackEnd >= end) // If the attack started
+            if (attackEnd >= lifespan.end) // If the attack started
             {
                 Point3D flipPoint = -1 * point;
                 var connector = new AgentConnector(target);
                 var rotationConnector = new AngleConnector(point);
-                // Frontal
-                replay.AddDecorationWithGrowing((PieDecoration)new PieDecoration(1200, 90, (start, end), Colors.Orange, 0.2, connector).UsingRotationConnector(rotationConnector), growing);
-                if (end == growing) // If the attack went off
-                {
-                    replay.Decorations.Add(new PieDecoration(1200, 90, (end, end + 1000), Colors.LightPink, 0.2, connector).UsingRotationConnector(rotationConnector)); // Lingering
-                }
-                // Retro
                 var flippedRotationConnector = new AngleConnector(flipPoint);
-                replay.AddDecorationWithGrowing((PieDecoration)new PieDecoration(1200, 90, (start, end), Colors.Orange, 0.2, connector).UsingRotationConnector(flippedRotationConnector), growing);
-                if (end == growing) // If the attack went off
+                (long start, long end) lifespanLingering = (lifespan.end, lifespan.end + 1000);
+                
+                replay.AddDecorationWithGrowing((PieDecoration)new PieDecoration(1200, 90, lifespan, Colors.LightOrange, 0.2, connector).UsingRotationConnector(rotationConnector), growing); // Frontal
+                replay.AddDecorationWithGrowing((PieDecoration)new PieDecoration(1200, 90, lifespan, Colors.LightOrange, 0.2, connector).UsingRotationConnector(flippedRotationConnector), growing); // Retro
+                if (lifespan.end == growing) // If the attack went off
                 {
-                    replay.Decorations.Add(new PieDecoration(1200, 90, (end, end + 1000), Colors.LightPink, 0.2, connector).UsingRotationConnector(flippedRotationConnector)); // Lingering
+                    replay.Decorations.Add(new PieDecoration(1200, 90, lifespanLingering, Colors.LightPink, 0.2, connector).UsingRotationConnector(rotationConnector)); // Frontal Lingering
+                    replay.Decorations.Add(new PieDecoration(1200, 90, lifespanLingering, Colors.LightPink, 0.2, connector).UsingRotationConnector(flippedRotationConnector)); // Retro Lingering
                 }
             }
         }
@@ -254,19 +251,15 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var tailLash = casts.Where(x => x.SkillId == TailLashEnsolyss).ToList();
                     foreach (AbstractCastEvent c in tailLash)
                     {
-                        int duration = 1550;
-                        int openingAngle = 144;
-                        uint radius = 600;
-                        int start = (int)c.Time;
-                        int attackEnd = (int)c.Time + duration;
-                        Segment stunSegment = target.GetBuffStatus(log, Stun, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (stunSegment != null)
+                        int castDuration = 1550;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        Point3D facing = target.GetCurrentRotation(log, c.Time + castDuration);
+                        if (facing != null)
                         {
-                            attackEnd = Math.Min((int)stunSegment.Start, attackEnd); // Start of Stun
-                        }
-                        if (replay.Rotations.Any())
-                        {
-                            replay.Decorations.Add(new PieDecoration(radius, openingAngle, (start, attackEnd), Colors.Orange, 0.2,new AgentConnector(target)).UsingRotationConnector(new AgentFacingConnector(target)));
+                            var rotation = new AngleConnector(facing);
+                            var cone = (PieDecoration)new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation);
+                            replay.AddDecorationWithGrowing(cone, expectedEndCast);
                         }
                     }
 
@@ -278,26 +271,19 @@ namespace GW2EIEvtcParser.EncounterLogic
                         int secondQuarterAoe = 900;
                         int firstQuarterHit = 1635;
                         int secondQuarterHit = 1900;
-                        int duration = 1900;
-                        int start = (int)c.Time;
-                        int attackEnd = start + duration;
-
-                        Segment stunSegment = target.GetBuffStatus(log, Stun, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (stunSegment != null)
-                        {
-                            attackEnd = Math.Min((int)stunSegment.Start, attackEnd); // Start of Stun
-                        }
+                        int castDuration = 1900;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
 
                         // Facing point
-                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time, duration);
+                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time, castDuration);
                         if (facingDirection != null)
                         {
                             // Calculated points
                             var frontalPoint = new Point3D(facingDirection.X, facingDirection.Y);
                             var leftPoint = new Point3D(facingDirection.Y * -1, facingDirection.X);
 
-                            AddTormentingBlastDecoration(replay, target, start, attackEnd, frontalPoint, firstQuarterAoe, firstQuarterHit); // Frontal
-                            AddTormentingBlastDecoration(replay, target, start, attackEnd, leftPoint, secondQuarterAoe, secondQuarterHit); // Left of frontal
+                            AddTormentingBlastDecoration(replay, target, lifespan, frontalPoint, firstQuarterAoe, firstQuarterHit); // Frontal
+                            AddTormentingBlastDecoration(replay, target, lifespan, leftPoint, secondQuarterAoe, secondQuarterHit); // Left of frontal
                         }
                     }
 
@@ -305,85 +291,69 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var causticGrasp = casts.Where(x => x.SkillId == CausticGrasp).ToList();
                     foreach (AbstractCastEvent c in causticGrasp)
                     {
-                        int duration = 1500;
-                        int start = (int)c.Time;
-                        int expectedHitEnd = start + duration;
-                        int attackEnd = start + duration;
-                        Segment stunSegment = target.GetBuffStatus(log, Stun, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (stunSegment != null)
-                        {
-                            attackEnd = Math.Min((int)stunSegment.Start, attackEnd); // Start of Stun
-                        }
-                        replay.AddDecorationWithGrowing(new CircleDecoration(1300, (start, attackEnd), Colors.Orange, 0.2, new AgentConnector(target)), expectedHitEnd);
+                        int castDuration = 1500;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        replay.AddDecorationWithGrowing(new CircleDecoration(1300, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)), expectedEndCast);
                     }
 
                     // Upswing
                     var upswingEnso = casts.Where(x => x.SkillId == UpswingEnsolyss).ToList();
                     foreach (AbstractCastEvent c in upswingEnso)
                     {
-                        int duration = 1333;
-                        int start = (int)c.Time;
-                        int expectedHitEnd = start + duration;
-                        int attackEnd = start + duration;
-                        int endTimeWave = start + 3100;
-                        Segment stunSegment = target.GetBuffStatus(log, Stun, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (stunSegment != null)
-                        {
-                            attackEnd = Math.Min((int)stunSegment.Start, attackEnd); // Start of Stun
-                        }
-                        replay.AddDecorationWithGrowing(new CircleDecoration(600, (start, attackEnd), Colors.Orange, 0.2, new AgentConnector(target)), expectedHitEnd);
+                        int castDuration = 1333;
+                        long expectedEndCast = c.Time + castDuration;
+                        long endTimeWave = c.Time + 3100;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        (long start, long end) lifespanShockwave = (lifespan.end, c.Time + 3100);
+                        replay.AddDecorationWithGrowing(new CircleDecoration(600, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)), expectedEndCast);
                         // Shockwave
-                        replay.Decorations.Add(new CircleDecoration( 1500, (attackEnd, endTimeWave), Colors.Yellow, 0.4, new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(endTimeWave));
+                        replay.Decorations.Add(new CircleDecoration(1500, lifespanShockwave, Colors.Yellow, 0.4, new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(endTimeWave));
                     }
 
                     // 66% & 33% Breakbars
                     var causticExplosion = casts.Where(x => x.SkillId == CausticExplosionEnsolyss).ToList();
                     foreach (AbstractCastEvent c in causticExplosion)
                     {
-                        int duration = 15000;
-                        int start = (int)c.Time;
-                        int expectedHitEnd = start + duration;
-                        int attackEnd = start + duration;
+                        int castDuration = 15000;
+                        long expectedEndCast = c.Time + castDuration;
                         int durationQuarter = 3000;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
 
-                        Segment stunSegment = target.GetBuffStatus(log, Stun, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (stunSegment != null)
-                        {
-                            attackEnd = Math.Min((int)stunSegment.Start, attackEnd); // Start of Stun
-                        }
                         // Circle going in
-                        replay.AddDecorationWithGrowing(new DoughnutDecoration(0, 2000, (start, attackEnd), Colors.Red, 0.2, new AgentConnector(target)), expectedHitEnd, true);
-                        if (attackEnd == expectedHitEnd)
+                        replay.AddDecorationWithGrowing(new DoughnutDecoration(0, 2000, lifespan, Colors.Red, 0.2, new AgentConnector(target)), expectedEndCast, true);
+
+                        if (lifespan.end == expectedEndCast)
                         {
-                            replay.Decorations.Add(new CircleDecoration(2000, (attackEnd, attackEnd + 300), Colors.Red, 0.4, new AgentConnector(target)));
+                            // Explosion
+                            replay.Decorations.Add(new CircleDecoration(2000, (lifespan.end, lifespan.end + 300), Colors.Red, 0.4, new AgentConnector(target)));
                         }
+
                         // Initial facing point
-                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time, duration);
+                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time, castDuration);
                         if (facingDirection != null)
                         {
                             // Calculated other quarters from initial point
                             var frontalPoint = new Point3D(facingDirection.X, facingDirection.Y);
                             var leftPoint = new Point3D(facingDirection.Y * -1, facingDirection.X);
+                            int initialDelay = 1500;
+
                             // First quarters
-                            int startFirstQuarter = start + 1500;
-                            int endFirstQuarter = Math.Min(startFirstQuarter + durationQuarter, attackEnd);
-                            int growingFirstQuarter = startFirstQuarter + durationQuarter;
-                            AddCausticExplosionDecoration(replay, target, frontalPoint, attackEnd, startFirstQuarter, endFirstQuarter, growingFirstQuarter);
+                            (long start, long end) lifespanFirst = (c.Time + initialDelay, Math.Min(c.Time + initialDelay + durationQuarter, lifespan.end));
+                            long growingFirst = lifespanFirst.start + durationQuarter;
+                            AddCausticExplosionDecoration(replay, target, frontalPoint, lifespan.end, lifespanFirst, growingFirst);
                             // Second quarters
-                            int startSecondQuarter = endFirstQuarter;
-                            int endSecondQuarter = Math.Min(startSecondQuarter + durationQuarter, attackEnd);
-                            int growingSecondQuarter = startSecondQuarter + durationQuarter;
-                            AddCausticExplosionDecoration(replay, target, leftPoint, attackEnd, startSecondQuarter, endSecondQuarter, growingSecondQuarter);
+                            (long start, long end) lifespanSecond = (lifespanFirst.end, Math.Min(lifespanFirst.end + durationQuarter, lifespan.end));
+                            long growingSecond = lifespanSecond.start + durationQuarter;
+                            AddCausticExplosionDecoration(replay, target, leftPoint, lifespan.end, lifespanSecond, growingSecond);
                             // Third quarters
-                            int startThirdQuarter = endSecondQuarter;
-                            int endThirdQuarter = Math.Min(startThirdQuarter + durationQuarter, attackEnd);
-                            int growingThirdQuarter = startThirdQuarter + durationQuarter;
-                            AddCausticExplosionDecoration(replay, target, frontalPoint, attackEnd, startThirdQuarter, endThirdQuarter, growingThirdQuarter);
+                            (long start, long end) lifespanThird = (lifespanSecond.end, Math.Min(lifespanSecond.end + durationQuarter, lifespan.end));
+                            long growingThird = lifespanThird.start + durationQuarter;
+                            AddCausticExplosionDecoration(replay, target, frontalPoint, lifespan.end, lifespanThird, growingThird);
                             // Fourth quarters
-                            int startFourthQuarter = endThirdQuarter;
-                            int endFourthQuarter = Math.Min(startFourthQuarter + durationQuarter, attackEnd);
-                            int growingFourthQuarter = startFourthQuarter + durationQuarter;
-                            AddCausticExplosionDecoration(replay, target, leftPoint, attackEnd, startFourthQuarter, endFourthQuarter, growingFourthQuarter);
+                            (long start, long end) lifespanFourth = (lifespanThird.end, Math.Min(lifespanThird.end + durationQuarter, lifespan.end));
+                            long growingFourth = lifespanFourth.start + durationQuarter;
+                            AddCausticExplosionDecoration(replay, target, leftPoint, lifespan.end, lifespanFourth, growingFourth);
                         }
                     }
 
@@ -391,25 +361,64 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var lungeEnso = casts.Where(x => x.SkillId == LungeEnsolyss).ToList();
                     foreach (AbstractCastEvent c in lungeEnso)
                     {
-                        int startLine = (int)c.Time;
-                        int lineEffectEnd = (int)c.Time + 1000;
-                        if (replay.Rotations.Any())
+                        int castDuration = 1000;
+                        Point3D facing = target.GetCurrentRotation(log, c.Time + castDuration);
+                        if (facing != null)
                         {
-                            replay.Decorations.Add(new RectangleDecoration(1700, target.HitboxWidth, (startLine, lineEffectEnd), Colors.Orange, 0.2, new AgentConnector(target).WithOffset(new Point3D(850, 0), true)).UsingRotationConnector(new AgentFacingConnector(target)));
+                            var rotation = new AngleConnector(facing);
+                            (long start, long end) lifespan = (c.Time, c.Time + castDuration);
+                            replay.Decorations.Add(new RectangleDecoration(1700, target.HitboxWidth, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target).WithOffset(new Point3D(850, 0), true)).UsingRotationConnector(rotation));
                         }
                     }
 
+                    // Rampage - 8 Arrows attack
+                    var rampage = casts.Where(x => x.SkillId == RampageEnsolyss).ToList();
+                    foreach (AbstractCastEvent c in rampage)
+                    {
+                        // Cast duration is 4050 but visually fits better 4450
+                        int castDuration = 4050;
+                        int visualDuration = 4450;
+                        int warningDuration = 1800;
+                        (long start, long end) lifespan = (c.Time, c.Time + visualDuration);
+                        (long start, long end) lifespanWarning = (c.Time, c.Time + warningDuration);
+                        (long start, long end) lifespanShockwave = (c.Time, c.Time + castDuration);
+                        // Red outline
+                        var outline = (CircleDecoration)new CircleDecoration(380, lifespan, Colors.Red, 0.4, new AgentConnector(target)).UsingFilled(false);
+                        replay.Decorations.Add(outline);
+                        // Orange warning circle
+                        var warning = new CircleDecoration(380, lifespanWarning, Colors.LightOrange, 0.2, new AgentConnector(target));
+                        replay.AddDecorationWithGrowing(warning, lifespanWarning.end);
+                        // Growing inwards shockwave
+                        var shockwave = (CircleDecoration)new CircleDecoration(1200, lifespanShockwave, Colors.Yellow, 0.4, new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(lifespanShockwave.end, true);
+                        replay.Decorations.Add(shockwave);
+                        // 8 Arrows
+                        if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.EnsolyssArrow, out IReadOnlyList<EffectEvent> arrows))
+                        {
+                            foreach (EffectEvent effect in arrows.Where(x => x.Time >= c.Time && x.Time < c.Time + visualDuration))
+                            {
+                                if (effect is EffectEventCBTS51)
+                                {
+                                    (long start, long end) lifespanArrow = (effect.Time, effect.Time + effect.Duration);
+                                    var rotation = new AngleConnector(effect.Rotation.Z);
+                                    var arrow = (RectangleDecoration)new RectangleDecoration(30, 600, lifespanArrow, Colors.LightOrange, 0.2, new PositionConnector(effect.Position).WithOffset(new Point3D(0, 300), true)).UsingRotationConnector(rotation);
+                                    replay.Decorations.Add(arrow);
+                                }
+                            }
+                        }
+                    }
                     break;
                 case (int)TrashID.NightmareHallucination1:
                     // Lunge (Dash)
                     var lungeHallu = casts.Where(x => x.SkillId == LungeNightmareHallucination).ToList();
                     foreach (AbstractCastEvent c in lungeHallu)
                     {
-                        int startLine = (int)c.Time;
-                        int lineEffectEnd = (int)c.Time + 1000;
-                        if (replay.Rotations.Any())
+                        int castDuration = 1000;
+                        Point3D facing = target.GetCurrentRotation(log, c.Time + castDuration);
+                        if (facing != null)
                         {
-                            replay.Decorations.Add(new RectangleDecoration(1700, target.HitboxWidth, (startLine, lineEffectEnd), Colors.Orange, 0.2, new AgentConnector(target).WithOffset(new Point3D(850, 0), true)).UsingRotationConnector(new AgentFacingConnector(target)));
+                            var rotation = new AngleConnector(facing);
+                            (long start, long end) lifespan = (c.Time, c.Time + castDuration);
+                            replay.Decorations.Add(new RectangleDecoration(1700, target.HitboxWidth, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target).WithOffset(new Point3D(850, 0), true)).UsingRotationConnector(rotation));
                         }
                     }
 
@@ -417,9 +426,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var upswingHallu = casts.Where(x => x.SkillId == UpswingHallucination).ToList();
                     foreach (AbstractCastEvent c in upswingHallu)
                     {
-                        int start = (int)c.Time;
-                        int endTime = (int)c.Time + 1333;
-                        replay.AddDecorationWithGrowing(new CircleDecoration( 300, (start, endTime), Colors.LightOrange, 0.1, new AgentConnector(target)), endTime);
+                        int castDuration = 1333;
+                        (long start, long end) lifespan = (c.Time, c.Time + castDuration);
+                        replay.AddDecorationWithGrowing(new CircleDecoration(300, lifespan, Colors.LightOrange, 0.1, new AgentConnector(target)), lifespan.end);
                     }
                     break;
                 case (int)TrashID.NightmareHallucination2:
@@ -434,28 +443,60 @@ namespace GW2EIEvtcParser.EncounterLogic
             base.ComputeEnvironmentCombatReplayDecorations(log);
 
             // Caustic Barrage
-            //EffectGUIDEvent causticBarrage = log.CombatData.GetEffectGUIDEvent(EffectGUIDs.CausticBarrageHitEffect);
-            //if (causticBarrage != null)
-            //{
-            //    var barrageEffects = log.CombatData.GetEffectEventsByEffectID(causticBarrage.ContentID).ToList();
-            //    foreach (EffectEvent barrageEffect in barrageEffects)
-            //    {
-            //        int duration = 500;
-            //        int start = (int)barrageEffect.Time;
-            //        int effectEnd = start + duration;
-            //        EnvironmentDecorations.Add(new CircleDecoration(true, 0, 100, (start, effectEnd), Colors.Orange, 0.2, new PositionConnector(barrageEffect.Position)));
-            //    }
-            //}
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.CausticBarrageIndicator, out IReadOnlyList<EffectEvent> barrageEffects))
+            {
+                foreach (EffectEvent effect in barrageEffects)
+                {
+                    int duration;
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    if (effect is EffectEventCBTS45)
+                    {
+                        AgentItem ensolyss = log.AgentData.GetNPCsByID(TargetID.Ensolyss).FirstOrDefault();
+                        if (ensolyss != null)
+                        {
+                            var distance = effect.Position.DistanceToPoint(ensolyss.GetCurrentPosition(log, effect.Time));
+                            if (distance < 210)
+                            {
+                                duration = 1000;
+                            }
+                            else
+                            {
+                                duration = 1300;
+                            }
+                            lifespan.end = effect.Time + duration;
+                        }
+                    }
+                    EnvironmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Nightmare Altar Orb AoE 1
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EnsolyssNightmareAltarOrangeAoE, out IReadOnlyList<EffectEvent> indicators1))
+            {
+                foreach (EffectEvent effect in indicators1)
+                {
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    EnvironmentDecorations.Add(new CircleDecoration(120, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Nightmare Altar Orb AoE 2
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EnsolyssNightmareAltarLightOrangeAoE, out IReadOnlyList<EffectEvent> indicators2))
+            {
+                foreach (EffectEvent effect in indicators2)
+                {
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    EnvironmentDecorations.Add(new CircleDecoration(180, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position)));
+                }
+            }
 
             // Altar Shockwave
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EnsolyssNightmareAltarShockwave, out IReadOnlyList<EffectEvent> waveEffects))
             {
-                foreach (EffectEvent waveEffect in waveEffects)
+                foreach (EffectEvent effect in waveEffects)
                 {
-                    int duration = 2000;
-                    int start = (int)waveEffect.Time;
-                    int effectEnd = start + duration;
-                    EnvironmentDecorations.Add(new CircleDecoration(1150, (start, effectEnd), Colors.Yellow, 0.4, new PositionConnector(waveEffect.Position)).UsingFilled(false).UsingGrowingEnd(effectEnd));
+                    (long start, long end) lifespan = (effect.Time, effect.Time + 2000);
+                    EnvironmentDecorations.Add(new CircleDecoration(1200, lifespan, Colors.Yellow, 0.4, new PositionConnector(effect.Position)).UsingFilled(false).UsingGrowingEnd(lifespan.end));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -278,12 +278,13 @@ namespace GW2EIEvtcParser.EncounterLogic
             // Arkk's Shield
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ArkkShieldIndicator, out IReadOnlyList<EffectEvent> shieldEffects))
             {
-                foreach (EffectEvent shieldEffect in shieldEffects)
+                foreach (EffectEvent effect in shieldEffects)
                 {
                     int duration = 6400;
-                    (long start, long end) lifespan = (shieldEffect.Time, shieldEffect.Time + duration);
-                    var arkkShield = new CircleDecoration(300, lifespan, Colors.Blue, 0.4, new PositionConnector(shieldEffect.Position));
-                    var doughnutHit = (DoughnutDecoration)new DoughnutDecoration(300, 5000, lifespan, Colors.Red, 0.2, new PositionConnector(shieldEffect.Position)).UsingGrowingEnd(lifespan.end, true);
+                    (long start, long end) lifespan = (effect.Time, effect.Time + duration);
+                    var positionConnector = new PositionConnector(effect.Position);
+                    var arkkShield = new CircleDecoration(300, lifespan, Colors.Blue, 0.4, positionConnector);
+                    var doughnutHit = (DoughnutDecoration)new DoughnutDecoration(300, 5000, lifespan, Colors.Red, 0.2, positionConnector).UsingGrowingEnd(lifespan.end, true);
                     EnvironmentDecorations.Add(arkkShield);
                     EnvironmentDecorations.Add(doughnutHit);
                 }
@@ -294,13 +295,10 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 foreach (EffectEvent effect in effects)
                 {
-                    int duration = (int)effect.Duration;
-                    int start = (int)effect.Time;
-                    int end = start + duration;
-                    uint radius = 140;
-                    var connector = new PositionConnector(effect.Position);
-                    var circleIndicator = (CircleDecoration)new CircleDecoration(radius, (start, end), Colors.Orange, 0.2, connector).UsingFilled(false);
-                    var circleFiller = (CircleDecoration)new CircleDecoration(radius, (start, end), Colors.Orange, 0.2, connector).UsingGrowingEnd(end);
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    var positionConnector = new PositionConnector(effect.Position);
+                    var circleIndicator = (CircleDecoration)new CircleDecoration(140, lifespan, Colors.Orange, 0.2, positionConnector).UsingFilled(false);
+                    var circleFiller = (CircleDecoration)new CircleDecoration(140, lifespan, Colors.Orange, 0.2, positionConnector).UsingGrowingEnd(lifespan.end);
                     EnvironmentDecorations.Add(circleIndicator);
                     EnvironmentDecorations.Add(circleFiller);
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -140,9 +140,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             };
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            var trashIDs = new List<ArcDPSEnums.TrashID>
+            var trashIDs = new List<TrashID>
             {
                 TrashID.TwistedHorror
             };
@@ -164,131 +164,155 @@ namespace GW2EIEvtcParser.EncounterLogic
             switch (target.ID)
             {
                 case (int)TargetID.MAMA:
-                    // AoE Knockback
+                    // Blastwave - AoE Knockback
                     var blastwave = casts.Where(x => x.SkillId == Blastwave1 || x.SkillId == Blastwave2).ToList();
                     foreach (AbstractCastEvent c in blastwave)
                     {
-                        int hitTime = (int)c.ExpectedEndTime;
-                        int endTime = Math.Min((int)c.GetInterruptedByStunTime(log), hitTime);
-                        replay.AddDecorationWithBorder(new CircleDecoration(550, (c.Time, endTime), Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(hitTime), 0, Colors.Red, 0.2, false);
+                        int castDuration = 2750;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+
+                        if (c.SkillId == Blastwave1)
+                        {
+                            replay.AddDecorationWithBorder(new CircleDecoration(530, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(expectedEndCast), 0, Colors.Red, 0.2, false);
+                        }
+                        else if (c.SkillId == Blastwave2)
+                        {
+                            replay.AddDecorationWithBorder(new CircleDecoration(480, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(expectedEndCast), 0, Colors.Red, 0.2, false);
+                        }
                     }
 
                     // Leap with shockwaves
                     var leap = casts.Where(x => x.SkillId == Leap).ToList();
                     foreach (AbstractCastEvent c in leap)
                     {
-                        int attackStart = (int)c.Time;
-                        int hitTime = (int)c.ExpectedEndTime;
+                        int castDuration = 2400;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+
                         // Find position at the end of the leap time
-                        Point3D targetPosition = target.GetCurrentPosition(log, hitTime + 1000);
-                        if (targetPosition == null)
+                        Point3D targetPosition = target.GetCurrentPosition(log, expectedEndCast + 1000);
+                        if (targetPosition != null)
                         {
-                            continue;
-                        }
-                        int attackEnd = Math.Min((int)c.GetInterruptedByStunTime(log), hitTime);
-                        uint impactRadius = target.HitboxWidth / 2 + 100;
-                        replay.AddDecorationWithGrowing(new CircleDecoration(impactRadius, (attackStart, attackEnd), Colors.Orange, 0.2, new PositionConnector(targetPosition)), hitTime);
-                        // 3 rounds of decorations for the 3 waves
-                        if (c.Status != AbstractCastEvent.AnimationStatus.Interrupted && attackEnd >= hitTime)
-                        {
-                            uint shockwaveRadius = 1300;
-                            int duration = 2680;
-                            for (int i = 0; i < 3; i++)
+                            replay.AddDecorationWithGrowing(new CircleDecoration(350, lifespan, Colors.Orange, 0.2, new PositionConnector(targetPosition)), expectedEndCast);
+                        
+                            // 3 rounds of decorations for the 3 waves
+                            if (lifespan.end == expectedEndCast)
                             {
-                                int shockWaveStart = hitTime + i * 120;
-                                replay.Decorations.Add(new CircleDecoration(shockwaveRadius, (shockWaveStart, shockWaveStart + duration), Colors.Yellow, 0.3, new PositionConnector(targetPosition)).UsingFilled(false).UsingGrowingEnd(shockWaveStart + duration));
+                                uint shockwaveRadius = 1300;
+                                int duration = 2680;
+                                for (int i = 0; i < 3; i++)
+                                {
+                                    long shockWaveStart = expectedEndCast + i * 120;
+                                    replay.Decorations.Add(new CircleDecoration(shockwaveRadius, (shockWaveStart, shockWaveStart + duration), Colors.Yellow, 0.3, new PositionConnector(targetPosition)).UsingFilled(false).UsingGrowingEnd(shockWaveStart + duration));
+                                }
                             }
                         }
                     }
-
-                    // Nightmare Miasma AoE
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.NightmareMiasmaIndicator, out IReadOnlyList<EffectEvent> miasmaEffects))
-                    {
-                        foreach (EffectEvent miasmaEffect in miasmaEffects)
-                        {
-                            int durationFirstAoe = 300;
-                            int durationSecondAoe = 2000;
-                            int growingFirstAoe = (int)miasmaEffect.Time + durationFirstAoe;
-                            int growingSecondAoe = (int)miasmaEffect.Time + durationSecondAoe;
-                            int startFirstAoe = (int)miasmaEffect.Time;
-                            int startSecondAoe = (int)miasmaEffect.Time + durationFirstAoe;
-                            int endFirstAndSecondAoe = startFirstAoe + durationFirstAoe + durationSecondAoe;
-                            int safeTime = endFirstAndSecondAoe + 1000;
-                            int dangerTime = 77000;
-
-                            replay.Decorations.Add(new CircleDecoration(540, (startFirstAoe, endFirstAndSecondAoe), Colors.LightOrange, 0.1, new PositionConnector(miasmaEffect.Position)).UsingGrowingEnd(growingFirstAoe));
-                            replay.Decorations.Add(new CircleDecoration(540, (startSecondAoe, endFirstAndSecondAoe), Colors.LightOrange, 0.1, new PositionConnector(miasmaEffect.Position)).UsingGrowingEnd(growingSecondAoe));
-                            replay.AddDecorationWithGrowing(new CircleDecoration(540, (endFirstAndSecondAoe, safeTime), "rgba(83, 30, 25, 0.1)", new PositionConnector(miasmaEffect.Position)), safeTime);
-                            replay.Decorations.Add(new CircleDecoration(540, (safeTime, endFirstAndSecondAoe + dangerTime), "rgba(83, 30, 25, 0.2)", new PositionConnector(miasmaEffect.Position)));
-                        }
-                    }
-
-                    // Arkk's Shield
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ArkkShieldIndicator, out IReadOnlyList<EffectEvent> shieldEffects))
-                    {
-                        foreach (EffectEvent shieldEffect in shieldEffects)
-                        {
-                            int duration = 6200;
-                            int start = (int)shieldEffect.Time;
-                            int effectEnd = start + duration;
-                            replay.Decorations.Add(new CircleDecoration(300, (start, effectEnd), Colors.Blue, 0.4, new PositionConnector(shieldEffect.Position)));
-                            replay.AddDecorationWithGrowing(new DoughnutDecoration(300, 5000, (start, effectEnd), Colors.Red, 0.2, new PositionConnector(shieldEffect.Position)), effectEnd, true);
-                        }
-                    }
-
-                    // Grenade Barrage
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.MAMAGrenadeBarrageIndicator, out IReadOnlyList<EffectEvent> effects)) {
-                        foreach (EffectEvent effect in effects) {
-                            int duration = (int)effect.Duration;
-                            int start = (int)effect.Time;
-                            int end = start + duration;
-                            uint radius = 140;
-                            var connector = new PositionConnector(effect.Position);
-                            replay.AddDecorationWithFilledWithGrowing(new CircleDecoration(radius, (start, end), Colors.Orange, 0.2, connector).UsingFilled(false), true, end);
-                        }
-                    }
-
-                    // Cascade Of Torment
-                    int cotDuration = 1000;
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing0, cotDuration, 0, 150);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing1, cotDuration, 150, 250);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing2, cotDuration, 250, 350);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing3, cotDuration, 350, 450);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing4, cotDuration, 450, 550);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing5, cotDuration, 550, 650);
                     break;
                 case (int)TrashID.BlueKnight:
                 case (int)TrashID.RedKnight:
                 case (int)TrashID.GreenKnight:
-                    // Knockback AoE
+                    // Explosive Launch - Knight Jump in air
+                    var explosiveLaunch = casts.Where(x => x.SkillId == ExplosiveLaunch).ToList();
+                    foreach (AbstractCastEvent c in explosiveLaunch)
+                    {
+                        int castDuration = 1714;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        replay.AddDecorationWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), expectedEndCast, true);
+                    }
+
+                    // Explosive Impact - Knight fall and knockback AoE
                     var explosiveImpact = casts.Where(x => x.SkillId == ExplosiveImpact).ToList();
                     foreach (AbstractCastEvent c in explosiveImpact)
                     {
-                        int duration = 3000;
-                        int hitTime = (int)c.ExpectedEndTime;
-                        int attackEnd = Math.Min((int)c.GetInterruptedByStunTime(log), hitTime);
-                        int windUpDuration = (int)c.Time - (attackEnd - duration);
-                        int windUpStart = (int)c.Time - windUpDuration;
-
-                        // Wind Up - Knight in air
-                        replay.AddDecorationWithGrowing(new CircleDecoration( 600, (windUpStart, c.Time), Colors.Orange, 0.2, new AgentConnector(target)), c.Time, true);
-                        // Hit - Knight falling
-                        replay.AddDecorationWithGrowing(new CircleDecoration(600, (c.Time, attackEnd), Colors.Orange, 0.2, new AgentConnector(target)), hitTime);
+                        int castDuration = 533;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        replay.AddDecorationWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), expectedEndCast);
                     }
 
                     // Pull AoE
                     var extraction = casts.Where(x => x.SkillId == Extraction).ToList();
                     foreach (AbstractCastEvent c in extraction)
                     {
-                        int hitTime = (int)c.ExpectedEndTime;
-                        int attackEnd = Math.Min((int)c.GetInterruptedByStunTime(log), hitTime);
-
-                        replay.AddDecorationWithGrowing(new DoughnutDecoration(300, 2000, ((int)c.Time, attackEnd), Colors.Orange, 0.2, new AgentConnector(target)), hitTime);
+                        int castDuration = 3835;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        replay.AddDecorationWithGrowing(new DoughnutDecoration(300, 2000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), expectedEndCast);
                     }
                     break;
                 default:
                     break;
             }
+        }
+
+        internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
+        {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
+            // Nightmare Miasma AoE Indicator
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.NightmareMiasmaIndicator, out IReadOnlyList<EffectEvent> miasmaIndicators))
+            {
+                foreach (EffectEvent effect in miasmaIndicators)
+                {
+                    // Effect duration is slightly too long, reducing it from 3300 to 3000
+                    (long start, long end) lifespan = (effect.Time, effect.Time + 3000);
+                    var circle = new CircleDecoration(540, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position));
+                    EnvironmentDecorations.Add(circle);
+                    EnvironmentDecorations.Add(circle.Copy().UsingGrowingEnd(lifespan.end));
+                }
+            }
+
+            // Nightmare Miasma AoE Damage
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.NightmareMiasmaDamage, out IReadOnlyList<EffectEvent> miasmaDamage))
+            {
+                foreach (EffectEvent effect in miasmaDamage)
+                {
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 76800);
+                    EnvironmentDecorations.Add(new CircleDecoration(540, lifespan, Colors.Chocolate, 0.2, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Arkk's Shield
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ArkkShieldIndicator, out IReadOnlyList<EffectEvent> shieldEffects))
+            {
+                foreach (EffectEvent shieldEffect in shieldEffects)
+                {
+                    int duration = 6400;
+                    (long start, long end) lifespan = (shieldEffect.Time, shieldEffect.Time + duration);
+                    var arkkShield = new CircleDecoration(300, lifespan, Colors.Blue, 0.4, new PositionConnector(shieldEffect.Position));
+                    var doughnutHit = (DoughnutDecoration)new DoughnutDecoration(300, 5000, lifespan, Colors.Red, 0.2, new PositionConnector(shieldEffect.Position)).UsingGrowingEnd(lifespan.end, true);
+                    EnvironmentDecorations.Add(arkkShield);
+                    EnvironmentDecorations.Add(doughnutHit);
+                }
+            }
+
+            // Grenade Barrage
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.MAMAGrenadeBarrageIndicator, out IReadOnlyList<EffectEvent> effects))
+            {
+                foreach (EffectEvent effect in effects)
+                {
+                    int duration = (int)effect.Duration;
+                    int start = (int)effect.Time;
+                    int end = start + duration;
+                    uint radius = 140;
+                    var connector = new PositionConnector(effect.Position);
+                    var circleIndicator = (CircleDecoration)new CircleDecoration(radius, (start, end), Colors.Orange, 0.2, connector).UsingFilled(false);
+                    var circleFiller = (CircleDecoration)new CircleDecoration(radius, (start, end), Colors.Orange, 0.2, connector).UsingGrowingEnd(end);
+                    EnvironmentDecorations.Add(circleIndicator);
+                    EnvironmentDecorations.Add(circleFiller);
+                }
+            }
+
+            // Cascade Of Torment
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing0, 0, 150);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing1, 150, 250);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing2, 250, 350);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing3, 350, 450);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing4, 450, 550);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing5, 550, 650);
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Nightmare.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Nightmare.cs
@@ -20,22 +20,24 @@ namespace GW2EIEvtcParser.EncounterLogic
             EncounterID |= EncounterIDs.FractalMasks.NightmareMask;
         }
 
-        protected static void AddCascadeOfTormentDecoration(ParsedEvtcLog log, CombatReplay replay, string cascadeOfTormentEffectGUID, int cotDuration, uint innerRadius, uint outerRadius)
+        protected static void AddCascadeOfTormentDecoration(ParsedEvtcLog log, List<GenericDecoration> environmentDecorations, string guid, uint innerRadius, uint outerRadius)
         {
-            if (log.CombatData.TryGetEffectEventsByGUID(cascadeOfTormentEffectGUID, out IReadOnlyList<EffectEvent> expulsionEffects))
+            int duration = 1000;
+            if (log.CombatData.TryGetEffectEventsByGUID(guid, out IReadOnlyList<EffectEvent> cascadeOfTorment))
             {
-                foreach (EffectEvent effect in expulsionEffects)
+                foreach (EffectEvent effect in cascadeOfTorment)
                 {
-                    long endTime = effect.Time + cotDuration;
+                    (long start, long end) lifespanIndicator = (effect.Time, effect.Time + duration);
+                    (long start, long end) lifespanDamage = (lifespanIndicator.end, lifespanIndicator.end + 150);
                     if (innerRadius == 0)
                     {
-                        replay.Decorations.Add(new CircleDecoration(outerRadius, (effect.Time, endTime), Colors.Orange, 0.2, new PositionConnector(effect.Position)));
-                        replay.Decorations.Add(new CircleDecoration(outerRadius, (endTime, endTime + 150), Colors.Orange, 0.4, new PositionConnector(effect.Position)));
+                        environmentDecorations.Add(new CircleDecoration(outerRadius, lifespanIndicator, Colors.Orange, 0.2, new PositionConnector(effect.Position)));
+                        environmentDecorations.Add(new CircleDecoration(outerRadius, lifespanDamage, Colors.Orange, 0.4, new PositionConnector(effect.Position)));
                     }
                     else
                     {
-                        replay.Decorations.Add(new DoughnutDecoration(innerRadius, outerRadius, (effect.Time, endTime), Colors.Orange, 0.2, new PositionConnector(effect.Position)));
-                        replay.Decorations.Add(new DoughnutDecoration(innerRadius, outerRadius, (endTime, endTime + 150), Colors.Orange, 0.4, new PositionConnector(effect.Position)));
+                        environmentDecorations.Add(new DoughnutDecoration(innerRadius, outerRadius, lifespanIndicator, Colors.Orange, 0.2, new PositionConnector(effect.Position)));
+                        environmentDecorations.Add(new DoughnutDecoration(innerRadius, outerRadius, lifespanDamage, Colors.Orange, 0.4, new PositionConnector(effect.Position)));
                     }
                 }
             }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -47,9 +47,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                             (11804, 4414, 12444, 5054)*/);
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            var trashIDs = new List<ArcDPSEnums.TrashID>
+            var trashIDs = new List<TrashID>
             {
                 TrashID.VolatileHallucinationSiax,
                 TrashID.NightmareHallucinationSiax
@@ -144,115 +144,59 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var causticExplosionBreakbar = casts.Where(x => x.SkillId == CausticExplosionSiaxBreakbar).ToList();
                     foreach (AbstractCastEvent c in causticExplosionBreakbar)
                     {
-                        int duration = 15000;
-                        int start = (int)c.Time;
-                        int expectedHitTime = (int)c.Time + duration;
-                        int attackEnd = (int)c.Time + duration;
-
-                        Segment stunSegment = target.GetBuffStatus(log, Stun, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (stunSegment != null)
-                        {
-                            attackEnd = Math.Min((int)stunSegment.Start, attackEnd); // Start of stun
-                        }
-                        Segment detSegment = target.GetBuffStatus(log, Determined762, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (detSegment != null)
-                        {
-                            attackEnd = Math.Min((int)detSegment.Start, attackEnd); // Start of determinated
-                        }
-                        var doughnut = new DoughnutDecoration(0, 1500, (start, attackEnd), Colors.Red, 0.2, new AgentConnector(target));
-                        replay.AddDecorationWithGrowing(doughnut, expectedHitTime, true);
+                        int castDuration = 15000;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                        var doughnut = new DoughnutDecoration(0, 1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
+                        replay.AddDecorationWithGrowing(doughnut, expectedEndCast, true);
                     }
                     // Tail Swipe
                     var tailLash = casts.Where(x => x.SkillId == TailLashSiax).ToList();
                     foreach (AbstractCastEvent c in tailLash)
                     {
-                        int duration = 1500;
-                        int openingAngle = 144;
-                        uint radius = 600;
-                        int start = (int)c.Time;
-                        int end = start + duration;
-                        if (replay.Rotations.Any())
+                        int castDuration = 1550;
+                        (long start, long end) lifespan = (c.Time, c.Time + castDuration);
+                        Point3D facing = target.GetCurrentRotation(log, c.Time + castDuration);
+                        if (facing != null)
                         {
-                            replay.Decorations.Add(new PieDecoration(radius, openingAngle, (start, end), Colors.Orange, 0.2, new AgentConnector(target)).UsingRotationConnector(new AgentFacingConnector(target)));
+                            var rotation = new AngleConnector(facing);
+                            replay.Decorations.Add(new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation));
                         }
                     }
                     // 66% and 33% phases
                     var causticExplosionPhases = casts.Where(x => x.SkillId == CausticExplosionSiaxPhase66 || x.SkillId == CausticExplosionSiaxPhase33).ToList();
                     foreach (AbstractCastEvent c in causticExplosionPhases)
                     {
-                        int duration = 20000;
-                        int start = (int)c.Time;
-                        int expectedHitTime = (int)c.Time + duration;
-                        int attackEnd = (int)c.Time + duration;
-
-                        Segment detSegment = target.GetBuffStatus(log, Determined762, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-                        if (detSegment != null)
-                        {
-                            attackEnd = Math.Min((int)detSegment.End, attackEnd); // End of determinated
-                        }
-                        var circle = new CircleDecoration(1500, (start, attackEnd), Colors.Red, 0.2, new AgentConnector(target));
-                        replay.AddDecorationWithGrowing(circle, expectedHitTime);
+                        int castDuration = 20000;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                        var circle = new CircleDecoration(1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
+                        replay.AddDecorationWithGrowing(circle, expectedEndCast);
                     }
-                    // Poison AoE
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.VileSpitSiax, out IReadOnlyList<EffectEvent> poisonEffects))
-                    {
-                        int duration = 16000;
-                        foreach (EffectEvent effect in poisonEffects)
-                        {
-                            replay.Decorations.Add(new CircleDecoration(240, ((int)effect.Time, (int)effect.Time + duration), Colors.Green, 0.2, new PositionConnector(effect.Position)));
-                        }
-                    }
-                    // Nightmare Hallucinations Spawn Event
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.NightmareHallucinationsSpawn, out IReadOnlyList<EffectEvent> spawnEffects))
-                    {
-                        int duration = 3000;
-                        foreach (EffectEvent effect in spawnEffects)
-                        {
-                            var circle = new CircleDecoration(360, (effect.Time, effect.Time + duration), Colors.Orange, 0.2, new PositionConnector(effect.Position));
-                            replay.AddDecorationWithGrowing(circle, effect.Time + duration);
-                        }
-                    }
-                    // Caustic Barrage
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.CausticBarrageIndicator, out IReadOnlyList<EffectEvent> barrageEffects))
-                    {
-                        int duration = 500;
-                        foreach (EffectEvent effect in barrageEffects)
-                        {
-                            var circle = new CircleDecoration(100, (effect.Time, effect.Time + duration), Colors.Orange, 0.2, new PositionConnector(effect.Position));
-                            replay.AddDecorationWithGrowing(circle, effect.Time + duration);
-                        }
-                    }
-                    // Volatile Hallucinations Explosions
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.VolatileExpulsionIndicator, out IReadOnlyList<EffectEvent> expulsionEffects))
-                    {
-                        int duration = 200;
-                        foreach (EffectEvent effect in expulsionEffects)
-                        {
-                            var circle = new CircleDecoration(240, (effect.Time, effect.Time + duration), Colors.Orange, 0.2, new PositionConnector(effect.Position));
-                            replay.AddDecorationWithGrowing(circle, effect.Time + duration);
-                        }
-                    }
-                    // Cascade Of Torment
-                    int cotDuration = 1000;
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing0, cotDuration, 0, 150);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing1, cotDuration, 150, 250);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing2, cotDuration, 250, 350);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing3, cotDuration, 350, 450);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing4, cotDuration, 450, 550);
-                    AddCascadeOfTormentDecoration(log, replay, EffectGUIDs.CascadeOfTormentRing5, cotDuration, 550, 650);
+                    
                     break;
                 case (int)TrashID.EchoOfTheUnclean:
                     var causticExplosionEcho = casts.Where(x => x.SkillId == CausticExplosionSiaxEcho).ToList();
                     foreach (AbstractCastEvent c in causticExplosionEcho)
                     {
                         // Duration is the same as Siax's explosion but starts 2 seconds later
-                        int duration = 20000;
-                        int start = (int)c.Time + 18000;
-                        int attackEnd = (int)c.Time + duration;
-                        replay.Decorations.Add(new CircleDecoration(3000, (start, attackEnd), Colors.Orange, 0.2, new AgentConnector(target)));
+                        // Display the explosion for a brief time
+                        (long start, long end) lifespan = (c.Time + 18000, c.Time + 20000);
+                        replay.Decorations.Add(new CircleDecoration(3000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)));
                     }
                     break;
                 case (int)TrashID.VolatileHallucinationSiax:
+                    // Volatile Hallucinations Explosions
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.VolatileExpulsionIndicator, out IReadOnlyList<EffectEvent> expulsionEffects))
+                    {
+                        foreach (EffectEvent effect in expulsionEffects)
+                        {
+                            (long start, long end) lifespan = effect.ComputeLifespan(log, 300);
+                            var circle = new CircleDecoration(240, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target));
+                            replay.AddDecorationWithGrowing(circle, lifespan.end);
+                        }
+                    }
                     break;
                 case (int)TrashID.NightmareHallucinationSiax:
                     break;
@@ -268,6 +212,81 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<AbstractBuffEvent> fixationEvents = GetFilteredList(log.CombatData, FixatedNightmare, p, true, true);
             replay.AddOverheadIcons(fixations, p, ParserIcons.FixationPurpleOverhead);
             replay.AddTether(fixationEvents, Colors.Magenta, 0.5);
+        }
+
+        internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
+        {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
+            // Vile Spit - Indicators
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SiaxVileSpitIndicator, out IReadOnlyList<EffectEvent> vileSpitIndicators))
+            {
+                foreach (EffectEvent effect in vileSpitIndicators)
+                {
+                    // Indicator effect has variable duration
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    EnvironmentDecorations.Add(new CircleDecoration(240, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Vile Spit - Poison
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SiaxVileSpitPoison, out IReadOnlyList<EffectEvent> vileSpitPoisons))
+            {
+                foreach (EffectEvent effect in vileSpitPoisons)
+                {
+                    (long start, long end) lifespan = effect.ComputeDynamicLifespan(log, 15600);
+                    EnvironmentDecorations.Add(new CircleDecoration(240, lifespan, Colors.GreenishYellow, 0.2, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Nightmare Hallucinations Spawn Event
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SiaxNightmareHallucinationsSpawnIndicator, out IReadOnlyList<EffectEvent> spawnEffects))
+            {
+                int duration = 3000;
+                foreach (EffectEvent effect in spawnEffects)
+                {
+                    var circle = new CircleDecoration(360, (effect.Time, effect.Time + duration), Colors.Orange, 0.2, new PositionConnector(effect.Position));
+                    EnvironmentDecorations.Add(circle);
+                    EnvironmentDecorations.Add(circle.Copy().UsingGrowingEnd(effect.Time + duration));
+                }
+            }
+
+            // Caustic Barrage
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.CausticBarrageIndicator, out IReadOnlyList<EffectEvent> barrageEffects))
+            {
+                foreach (EffectEvent effect in barrageEffects)
+                {
+                    int duration;
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    if (effect is EffectEventCBTS45)
+                    {
+                        AgentItem siax = log.AgentData.GetNPCsByID(TargetID.Siax).FirstOrDefault();
+                        if (siax != null)
+                        {
+                            var distance = effect.Position.DistanceToPoint(siax.GetCurrentPosition(log, effect.Time));
+                            if (distance < 210)
+                            {
+                                duration = 1000;
+                            }
+                            else
+                            {
+                                duration = 966;
+                            }
+                            lifespan.end = effect.Time + duration;
+                        }
+                    }
+                    var circle = new CircleDecoration(100, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position));
+                    EnvironmentDecorations.Add(circle);
+                }
+            }
+
+            // Cascade Of Torment
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing0, 0, 150);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing1, 150, 250);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing2, 250, 350);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing3, 350, 450);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing4, 450, 550);
+            AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing5, 550, 650);
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -252,33 +252,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
 
             // Caustic Barrage
-            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.CausticBarrageIndicator, out IReadOnlyList<EffectEvent> barrageEffects))
-            {
-                foreach (EffectEvent effect in barrageEffects)
-                {
-                    int duration;
-                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
-                    if (effect is EffectEventCBTS45)
-                    {
-                        AgentItem siax = log.AgentData.GetNPCsByID(TargetID.Siax).FirstOrDefault();
-                        if (siax != null)
-                        {
-                            var distance = effect.Position.DistanceToPoint(siax.GetCurrentPosition(log, effect.Time));
-                            if (distance < 210)
-                            {
-                                duration = 1000;
-                            }
-                            else
-                            {
-                                duration = 966;
-                            }
-                            lifespan.end = effect.Time + duration;
-                        }
-                    }
-                    var circle = new CircleDecoration(100, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position));
-                    EnvironmentDecorations.Add(circle);
-                }
-            }
+            AddDistanceCorrectedOrbDecorations(log, EnvironmentDecorations, EffectGUIDs.CausticBarrageIndicator, TargetID.Siax, 210, 1000, 966);
 
             // Cascade Of Torment
             AddCascadeOfTormentDecoration(log, EnvironmentDecorations, EffectGUIDs.CascadeOfTormentRing0, 0, 150);

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -60,9 +60,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             };
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            var trashIDs = new List<ArcDPSEnums.TrashID>
+            var trashIDs = new List<TrashID>
             {
                 TrashID.TemporalAnomalyArtsariiv,
                 TrashID.Spark,

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/ShatteredObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/ShatteredObservatory.cs
@@ -80,18 +80,16 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 foreach (EffectEvent effect in domeExplosions)
                 {
-                    int start = (int)effect.Time - 500;
-                    int end = (int)effect.Time;
-                    EnvironmentDecorations.Add(new CircleDecoration(220, (start, end), Colors.LightBlue, 0.4, new PositionConnector(effect.Position)).UsingGrowingEnd(end));
+                    (long start, long end) lifespan = (effect.Time - 500, effect.Time);
+                    EnvironmentDecorations.Add(new CircleDecoration(220, lifespan, Colors.LightBlue, 0.4, new PositionConnector(effect.Position)).UsingGrowingEnd(lifespan.end));
                 }
             }
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.CorporealReassignmentExplosion1, out IReadOnlyList<EffectEvent> explosions))
             {
                 foreach (EffectEvent effect in explosions)
                 {
-                    int start = (int)effect.Time;
-                    int end = start + 500;
-                    EnvironmentDecorations.Add(new CircleDecoration(2000, (start, end), Colors.Red, 0.2, new PositionConnector(effect.Position)).UsingGrowingEnd(end));
+                    (long start, long end) lifespan = (effect.Time, effect.Time + 500);
+                    EnvironmentDecorations.Add(new CircleDecoration(2000, lifespan, Colors.Red, 0.2, new PositionConnector(effect.Position)).UsingGrowingEnd(lifespan.end));
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -543,32 +543,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
 
             // Solar Bolt - Indicator
-            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SolarBoltIndicators, out IReadOnlyList<EffectEvent> solarBoltIndicators))
-            {
-                foreach (EffectEvent effect in solarBoltIndicators)
-                {
-                    int duration;
-                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
-                    if (effect is EffectEventCBTS45)
-                    {
-                        AgentItem skorvald = log.AgentData.GetNPCsByID(TargetID.Skorvald).FirstOrDefault();
-                        if (skorvald != null)
-                        {
-                            var distance = effect.Position.DistanceToPoint(skorvald.GetCurrentPosition(log, effect.Time));
-                            if (distance < 310)
-                            {
-                                duration = 1800;
-                            }
-                            else
-                            {
-                                duration = 1300;
-                            }
-                            lifespan.end = effect.Time + duration;
-                        }
-                    }
-                    EnvironmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position)));
-                }
-            }
+            AddDistanceCorrectedOrbDecorations(log, EnvironmentDecorations, EffectGUIDs.SolarBoltIndicators, TargetID.Skorvald, 310, 1800, 1300);
 
             // Solar Bolt - Damage
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SkorvaldSolarBoltDamage, out IReadOnlyList<EffectEvent> solarBolts))

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -599,6 +599,13 @@ namespace GW2EIEvtcParser.EncounterLogic
             replay.AddOverheadIcons(fixations, p, ParserIcons.FixationPurpleOverhead);
         }
 
+        /// <summary>
+        /// Add Horizon Strike decoration.
+        /// </summary>
+        /// <param name="replay">Combat Replay.</param>
+        /// <param name="target">Actor.</param>
+        /// <param name="lifespan">Start and End of cast.</param>
+        /// <param name="degree">Degree of the strike.</param>
         private static void AddHorizonStrikeDecoration(CombatReplay replay, AbstractSingleActor target, (long start, long end) lifespan, float degree)
         {
             var connector = new AgentConnector(target);
@@ -615,11 +622,25 @@ namespace GW2EIEvtcParser.EncounterLogic
             replay.Decorations.Add(pieHit.Copy().UsingRotationConnector(flipRotationConnector));
         }
 
+        /// <summary>
+        /// Add Solar Discharge decoration.
+        /// </summary>
+        /// <param name="replay">Combat Replay.</param>
+        /// <param name="target">Actor.</param>
+        /// <param name="lifespan">Start and End of cast.</param>
         private static void AddSolarDischargeDecoration(CombatReplay replay, AbstractSingleActor target, (long start, long end) lifespan)
         {
             replay.Decorations.Add(new CircleDecoration(1200, lifespan, Colors.Red, 0.6, new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(lifespan.end));
         }
 
+        /// <summary>
+        /// Add Kick decoration.
+        /// </summary>
+        /// <param name="replay">Combat Replay.</param>
+        /// <param name="target">Actor.</param>
+        /// <param name="lifespan">Start and End of cast.</param>
+        /// <param name="expectedEndCast">Expected end of the cast.</param>
+        /// <param name="rotation">Rotation degree.</param>
         private static void AddKickIndicatorDecoration(CombatReplay replay, AbstractSingleActor target, (long start, long end) lifespan, long expectedEndCast, float rotation)
         {
             int translation = 150;

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -270,9 +270,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             }
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            var trashIDs = new List<ArcDPSEnums.TrashID>
+            var trashIDs = new List<TrashID>
             {
                 TrashID.SolarBloom
             };
@@ -291,44 +291,39 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var horizonStrike = casts.Where(x => x.SkillId == HorizonStrikeSkorvald2 || x.SkillId == HorizonStrikeSkorvald4).ToList();
                     foreach (AbstractCastEvent c in horizonStrike)
                     {
-                        int start = (int)c.Time + 100;
-                        int duration = 3900;
-                        uint radius = 1200;
-                        int angle = 70;
+                        int castDuration = 3900;
                         int shiftingAngle = 45;
                         int sliceSpawnInterval = 750;
-                        int attackEnd = start + duration;
-                        attackEnd = GetAttackEndByStunTime(log, target, c, duration, attackEnd);
-                        attackEnd = GetAttackEndByDeterminedTime(log, target, c, duration, attackEnd);
+                        (long start, long end) lifespan = (c.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
 
-                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time + 100, duration);
-                        if (facingDirection == null)
+                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time + 100, castDuration);
+                        if (facingDirection != null)
                         {
-                            continue;
-                        }
-                        float degree = Point3D.GetZRotationFromFacing(facingDirection);
+                            float degree = Point3D.GetZRotationFromFacing(facingDirection);
 
-                        // Horizon Strike starting at Skorvald's facing point
-                        if (c.SkillId == HorizonStrikeSkorvald4)
-                        {
-                            for (int i = 0; i < 4; i++)
+                            // Horizon Strike starting at Skorvald's facing point
+                            if (c.SkillId == HorizonStrikeSkorvald4)
                             {
-                                AddHorizonStrikeDecoration(replay, target, start, attackEnd, degree, radius, angle);
-                                start += sliceSpawnInterval;
-                                attackEnd += sliceSpawnInterval;
-                                degree -= shiftingAngle;
+                                for (int i = 0; i < 4; i++)
+                                {
+                                    AddHorizonStrikeDecoration(replay, target, lifespan, degree);
+                                    lifespan.start += sliceSpawnInterval;
+                                    lifespan.end += sliceSpawnInterval;
+                                    degree -= shiftingAngle;
+                                }
                             }
-                        }
-                        // Starting at Skorvald's 90° of facing point
-                        if (c.SkillId == HorizonStrikeSkorvald2)
-                        {
-                            degree -= 90;
-                            for (int i = 0; i < 4; i++)
+                            // Starting at Skorvald's 90° of facing point
+                            if (c.SkillId == HorizonStrikeSkorvald2)
                             {
-                                AddHorizonStrikeDecoration(replay, target, start, attackEnd, degree, radius, angle);
-                                start += sliceSpawnInterval;
-                                attackEnd += sliceSpawnInterval;
-                                degree += shiftingAngle;
+                                degree -= 90;
+                                for (int i = 0; i < 4; i++)
+                                {
+                                    AddHorizonStrikeDecoration(replay, target, lifespan, degree);
+                                    lifespan.start += sliceSpawnInterval;
+                                    lifespan.end += sliceSpawnInterval;
+                                    degree += shiftingAngle;
+                                }
                             }
                         }
                     }
@@ -340,66 +335,45 @@ namespace GW2EIEvtcParser.EncounterLogic
                     {
                         uint radius = 1200;
                         int angle = 295;
-                        int start = (int)c.Time;
-                        int duration = 3000;
-                        int attackEnd = start + duration;
-                        attackEnd = GetAttackEndByStunTime(log, target, c, duration, attackEnd);
-                        attackEnd = GetAttackEndByDeterminedTime(log, target, c, duration, attackEnd);
+                        int castDuration = 3000;
+                        (long start, long end) lifespan = (c.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
 
-                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time + 100, duration);
-                        if (facingDirection == null)
+                        Point3D facingDirection = target.GetCurrentRotation(log, c.Time + 100, castDuration);
+                        if (facingDirection != null)
                         {
-                            continue;
-                        }
-                        float degree = Point3D.GetZRotationFromFacing(facingDirection);
+                            float degree = Point3D.GetZRotationFromFacing(facingDirection);
 
-                        if (c.SkillId == CrimsonDawnSkorvaldCM2)
-                        {
-                            degree += 90;
+                            if (c.SkillId == CrimsonDawnSkorvaldCM2)
+                            {
+                                degree += 90;
+                            }
+                            if (c.SkillId == CrimsonDawnSkorvaldCM1)
+                            {
+                                degree += 270;
+                            }
+                            var connector = new AgentConnector(target);
+                            var rotationConnector = new AngleConnector(degree);
+                            replay.Decorations.Add(new PieDecoration(radius, angle, lifespan, Colors.Orange, 0.2, connector).UsingRotationConnector(rotationConnector));
+                            replay.Decorations.Add(new PieDecoration(radius, angle, (lifespan.end, lifespan.end + 500), Colors.Red, 0.2, connector).UsingRotationConnector(rotationConnector));
                         }
-                        if (c.SkillId == CrimsonDawnSkorvaldCM1)
-                        {
-                            degree += 270;
-                        }
-                        var connector = new AgentConnector(target);
-                        var rotationConnector = new AngleConnector(degree);
-                        replay.Decorations.Add(new PieDecoration(radius, angle, (start, attackEnd), Colors.Orange, 0.2, connector).UsingRotationConnector(rotationConnector));
-                        replay.Decorations.Add(new PieDecoration(radius, angle, (attackEnd, attackEnd + 500), Colors.Red, 0.2, connector).UsingRotationConnector(rotationConnector));
                     }
 
                     // Punishing Kick
                     var punishingKick = casts.Where(x => x.SkillId == PunishingKickSkorvald).ToList();
                     foreach (AbstractCastEvent c in punishingKick)
                     {
-                        int start = (int)c.Time;
-                        int duration = 1850;
-                        int translation = 150;
-                        int cascadeCount = 4;
-                        int attackEnd = start + duration;
-                        attackEnd = GetAttackEndByStunTime(log, target, c, duration, attackEnd);
-                        attackEnd = GetAttackEndByDeterminedTime(log, target, c, duration, attackEnd);
+                        int castDuration = 1850;
+                        (long start, long end) lifespan = (c.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                        long expectedEndCast = c.Time + castDuration;
 
-                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, duration);
-                        if (frontalPoint == null)
+                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, castDuration);
+                        if (frontalPoint != null)
                         {
-                            continue;
-                        }
-                        float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
-
-                        // Frontal
-                        AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation, translation, cascadeCount);
-                    }
-
-                    // Solar Bolt
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SolarBolt, out IReadOnlyList<EffectEvent> solarBoltEffects))
-                    {
-                        foreach (EffectEvent solarBoltEffect in solarBoltEffects)
-                        {
-                            uint aoeRadius = 100;
-                            int aoeTimeout = 12000;
-                            int start = (int)solarBoltEffect.Time;
-                            int attackEnd = start + aoeTimeout;
-                            replay.Decorations.Add(new CircleDecoration(aoeRadius, (start, attackEnd), Colors.Red, 0.2, new PositionConnector(solarBoltEffect.Position)));
+                            float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
+                            // Frontal
+                            AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, rotation);
                         }
                     }
 
@@ -407,18 +381,16 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var radiantFury = casts.Where(x => x.SkillId == RadiantFurySkorvald).ToList();
                     foreach (AbstractCastEvent c in radiantFury)
                     {
-                        int start = (int)c.Time;
                         int duration = 2700;
-                        int expectedHitTime = start + duration;
-                        int attackEnd = start + duration;
-                        int endWave = attackEnd + 900;
-                        attackEnd = GetAttackEndByStunTime(log, target, c, duration, attackEnd);
-                        attackEnd = GetAttackEndByDeterminedTime(log, target, c, duration, attackEnd);
+                        long expectedEndCast = c.Time + duration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, duration));
+                        lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, duration));
+                        (long start, long end) lifespanWave = (lifespan.end, lifespan.end + 900);
 
-                        if (expectedHitTime <= attackEnd)
+                        if (expectedEndCast <= lifespan.end)
                         {
                             // Shockwave
-                            AddSolarDischargeDecoration(replay, target, attackEnd, endWave, 1200);
+                            AddSolarDischargeDecoration(replay, target, lifespanWave);
                         }
                     }
 
@@ -426,51 +398,35 @@ namespace GW2EIEvtcParser.EncounterLogic
                     var supernova = casts.Where(x => x.SkillId == SupernovaSkorvaldCM).ToList();
                     foreach (AbstractCastEvent c in supernova)
                     {
-                        int start = (int)c.Time;
                         int duration = 75000;
-                        int expectedHitTime = start + duration;
-                        int attackEnd = start + duration;
-                        attackEnd = GetAttackEndByStunTime(log, target, c, duration, attackEnd);
-                        replay.AddDecorationWithGrowing(new CircleDecoration(1200, (start, attackEnd), Colors.Red, 0.2, new AgentConnector(target)), expectedHitTime);
-                    }
-
-                    // Solar Cyclone
-                    if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.KickGroundEffect, out IReadOnlyList<EffectEvent> kickEffects))
-                    {
-                        foreach (EffectEvent kickEffect in kickEffects)
-                        {
-                            int start = (int)kickEffect.Time;
-                            int end = start + 300;
-                            replay.Decorations.Add(new RectangleDecoration(300, target.HitboxWidth, (start, end), Colors.Red, 0.2, new PositionConnector(kickEffect.Position)).UsingRotationConnector(new AngleConnector(kickEffect.Rotation.Z - 90)));
-                        }
+                        long expectedEndCast = c.Time + duration;
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, duration));
+                        replay.AddDecorationWithGrowing(new CircleDecoration(1200, lifespan, Colors.Red, 0.2, new AgentConnector(target)), expectedEndCast);
                     }
 
                     // Cranial Cascade
                     var cranialCascadeSkorvald = casts.Where(x => x.SkillId == CranialCascadeSkorvald).ToList();
                     foreach (AbstractCastEvent c in cranialCascadeSkorvald)
                     {
-                        int start = (int)c.Time;
-                        int duration = 1750;
+                        int castDuration = 1750;
                         int angle = 35;
-                        int cascadeCount = 4;
-                        int translation = 150;
-                        int attackEnd = start + duration;
-                        attackEnd = GetAttackEndByStunTime(log, target, c, duration, attackEnd);
-                        attackEnd = GetAttackEndByDeterminedTime(log, target, c, duration, attackEnd);
+                        long expectedEndCast = c.Time + castDuration;
 
-                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, duration);
-                        if (frontalPoint == null)
+                        (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                        lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+
+                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, castDuration);
+                        if (frontalPoint != null)
                         {
-                            continue;
-                        }
-                        float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
+                            float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
 
-                        // Frontal
-                        AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation, translation, cascadeCount);
-                        // Left
-                        AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation - angle, translation, cascadeCount);
-                        // Right
-                        AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation + angle, translation, cascadeCount);
+                            // Frontal
+                            AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, rotation);
+                            // Left
+                            AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, rotation - angle);
+                            // Right
+                            AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, rotation + angle);
+                        }
                     }
                     break;
                 case (int)TrashID.FluxAnomalyCM1:
@@ -482,99 +438,86 @@ namespace GW2EIEvtcParser.EncounterLogic
                     foreach (AbstractCastEvent c in solarStomp)
                     {
                         uint radius = 280;
-                        int castTime = 2250;
-                        int start = (int)c.Time;
-                        int attackEnd = start + castTime;
-                        int endWave = attackEnd + castTime;
+                        int castDuration = 2250;
+                        (long start, long end) lifespan = (c.Time, c.Time + castDuration);
+                        (long start, long end) lifespanShockwave = (lifespan.end, lifespan.end + castDuration);
 
                         // Stomp
-                        replay.AddDecorationWithGrowing(new CircleDecoration(radius, (start, attackEnd), Colors.Orange, 0.2, new AgentConnector(target)), attackEnd);
+                        replay.AddDecorationWithGrowing(new CircleDecoration(radius, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)), lifespan.end);
                         // Shockwave
-                        AddSolarDischargeDecoration(replay, target, attackEnd, endWave, 1200);
+                        AddSolarDischargeDecoration(replay, target, lifespanShockwave);
                     }
 
                     // Punishing Kick
                     var punishingKickAnomaly = casts.Where(x => x.SkillId == PunishingKickAnomaly).ToList();
                     foreach (AbstractCastEvent c in punishingKickAnomaly)
                     {
-                        int start = (int)c.Time;
-                        int duration = 1850;
-                        int translation = 150;
-                        int cascadeCount = 4;
-                        int attackEnd = start + duration;
+                        int castDuration = 1850;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, expectedEndCast);
 
-                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, duration);
-                        if (frontalPoint == null)
+                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, castDuration);
+                        if (frontalPoint != null)
                         {
-                            continue;
+                            float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
+                            // Frontal
+                            AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, rotation);
                         }
-                        float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
-
-                        // Frontal
-                        AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation, translation, cascadeCount);
                     }
 
                     // Cranial Cascade
                     var cranialCascadeAnomaly = casts.Where(x => x.SkillId == CranialCascadeAnomaly).ToList();
                     foreach (AbstractCastEvent c in cranialCascadeAnomaly)
                     {
-                        int start = (int)c.Time;
-                        int duration = 1750;
+                        int castDuration = 1750;
                         int angle = 35;
-                        int cascadeCount = 4;
-                        int translation = 150;
-                        int attackEnd = start + duration;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, expectedEndCast);
 
-                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, duration);
-                        if (frontalPoint == null)
+                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, castDuration);
+                        if (frontalPoint != null)
                         {
-                            continue;
-                        }
-                        float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
+                            float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
 
-                        // Left
-                        AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation - angle, translation, cascadeCount);
-                        // Right
-                        AddKickIndicatorDecoration(replay, target, start, attackEnd, rotation + angle, translation, cascadeCount);
+                            // Left
+                            AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, rotation - angle);
+                            // Right
+                            AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, rotation + angle);
+                        }
                     }
 
                     // Mist Smash
                     var mistSmash = casts.Where(x => x.SkillId == MistSmash).ToList();
                     foreach (AbstractCastEvent c in mistSmash)
                     {
-                        int start = (int)c.Time;
-                        int duration = 1933;
-                        uint radius = 160;
-                        int attackEnd = start + duration;
-                        int waveEnd = attackEnd + 2250;
-                        replay.AddDecorationWithGrowing(new CircleDecoration(radius, (start, attackEnd), Colors.Orange, 0.2, new AgentConnector(target)), attackEnd);
+                        int castDuration = 1933;
+                        (long start, long end) lifespan = (c.Time, c.Time + castDuration);
+                        (long start, long end) lifespanShockwave = (lifespan.end, lifespan.end + 2250);
+                        replay.AddDecorationWithGrowing(new CircleDecoration(160, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), lifespan.end);
                         // Nightmare Discharge Shockwave
-                        replay.Decorations.Add(new CircleDecoration(1200, (attackEnd, waveEnd), Colors.Yellow, 0.3, new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(waveEnd));
+                        replay.Decorations.Add(new CircleDecoration(1200, lifespanShockwave, Colors.Yellow, 0.3, new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(lifespanShockwave.end));
                     }
 
                     // Wave of Mutilation
                     var waveOfMutilation = casts.Where(x => x.SkillId == WaveOfMutilation).ToList();
                     foreach (AbstractCastEvent c in waveOfMutilation)
                     {
-                        int start = (int)c.Time;
-                        int duration = 1850;
+                        int castDuration = 1850;
                         int angle = 18;
-                        int translation = 150;
-                        int cascadeCount = 4;
-                        int attackEnd = start + duration;
+                        long expectedEndCast = c.Time + castDuration;
+                        (long start, long end) lifespan = (c.Time, expectedEndCast);
 
-                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, duration);
-                        if (frontalPoint == null)
+                        Point3D frontalPoint = target.GetCurrentRotation(log, c.Time + 100, castDuration);
+                        if (frontalPoint != null)
                         {
-                            continue;
-                        }
-                        float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
+                            float rotation = Point3D.GetZRotationFromFacing(frontalPoint);
 
-                        float startingDegree = rotation - angle * 2;
-                        for (int i = 0; i < 5; i++)
-                        {
-                            AddKickIndicatorDecoration(replay, target, start, attackEnd, startingDegree, translation, cascadeCount);
-                            startingDegree += angle;
+                            float startingDegree = rotation - angle * 2;
+                            for (int i = 0; i < 5; i++)
+                            {
+                                AddKickIndicatorDecoration(replay, target, lifespan, expectedEndCast, startingDegree);
+                                startingDegree += angle;
+                            }
                         }
                     }
                     break;
@@ -590,15 +533,60 @@ namespace GW2EIEvtcParser.EncounterLogic
             base.ComputeEnvironmentCombatReplayDecorations(log);
 
             // Mist Bomb - Both for Skorvald and Flux Anomalies
-            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.MistBomb, out IReadOnlyList<EffectEvent> mistBombEffects))
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.MistBomb, out IReadOnlyList<EffectEvent> mistBombs))
             {
-                foreach (EffectEvent mistBombEffect in mistBombEffects)
+                foreach (EffectEvent effect in mistBombs)
                 {
-                    uint aoeRadius = 130;
-                    int aoeTimeout = 300;
-                    int start = (int)mistBombEffect.Time;
-                    int attackEnd = start + aoeTimeout;
-                    EnvironmentDecorations.Add(new CircleDecoration(aoeRadius, (start, attackEnd), Colors.Orange, 0.2, new PositionConnector(mistBombEffect.Position)));
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 1000);
+                    EnvironmentDecorations.Add(new CircleDecoration(130, lifespan, Colors.Orange, 0.2, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Solar Bolt - Indicator
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SolarBoltIndicators, out IReadOnlyList<EffectEvent> solarBoltIndicators))
+            {
+                foreach (EffectEvent effect in solarBoltIndicators)
+                {
+                    int duration;
+                    (long start, long end) lifespan = (effect.Time, effect.Time + effect.Duration);
+                    if (effect is EffectEventCBTS45)
+                    {
+                        AgentItem skorvald = log.AgentData.GetNPCsByID(TargetID.Skorvald).FirstOrDefault();
+                        if (skorvald != null)
+                        {
+                            var distance = effect.Position.DistanceToPoint(skorvald.GetCurrentPosition(log, effect.Time));
+                            if (distance < 310)
+                            {
+                                duration = 1800;
+                            }
+                            else
+                            {
+                                duration = 1300;
+                            }
+                            lifespan.end = effect.Time + duration;
+                        }
+                    }
+                    EnvironmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Orange, 0.3, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Solar Bolt - Damage
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.SkorvaldSolarBoltDamage, out IReadOnlyList<EffectEvent> solarBolts))
+            {
+                foreach (EffectEvent effect in solarBolts)
+                {
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 12000);
+                    EnvironmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Red, 0.2, new PositionConnector(effect.Position)));
+                }
+            }
+
+            // Solar Cyclone
+            if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.KickGroundEffect, out IReadOnlyList<EffectEvent> kickEffects))
+            {
+                foreach (EffectEvent effect in kickEffects)
+                {
+                    (long start, long end) lifespan = (effect.Time, effect.Time + 300);
+                    EnvironmentDecorations.Add(new RectangleDecoration(300, 180, lifespan, Colors.Red, 0.2, new PositionConnector(effect.Position)).UsingRotationConnector(new AngleConnector(effect.Rotation.Z - 90)));
                 }
             }
         }
@@ -611,48 +599,39 @@ namespace GW2EIEvtcParser.EncounterLogic
             replay.AddOverheadIcons(fixations, p, ParserIcons.FixationPurpleOverhead);
         }
 
-        private static void AddHorizonStrikeDecoration(CombatReplay replay, AbstractSingleActor target, int start, int attackEnd, float degree, uint radius, int angle)
+        private static void AddHorizonStrikeDecoration(CombatReplay replay, AbstractSingleActor target, (long start, long end) lifespan, float degree)
         {
             var connector = new AgentConnector(target);
             var frontRotationConnector = new AngleConnector(degree);
             var flipRotationConnector = new AngleConnector(degree + 180);
             // Indicator
-            var pieIndicator = new PieDecoration(radius, angle, (start, attackEnd), Colors.Orange, 0.2, connector);
+            var pieIndicator = new PieDecoration(1200, 70, lifespan, Colors.Orange, 0.2, connector);
             replay.Decorations.Add(pieIndicator.UsingRotationConnector(frontRotationConnector));
             replay.Decorations.Add(pieIndicator.Copy().UsingRotationConnector(flipRotationConnector));
             // Attack hit
-            var pieHit = (PieDecoration)new PieDecoration(radius, angle, (attackEnd, attackEnd + 300), Colors.Red, 0.2, connector).UsingGrowingEnd(attackEnd + 300);
+            (long start, long end) lifespanHit = (lifespan.end, lifespan.end + 300);
+            var pieHit = (PieDecoration)new PieDecoration(1200, 70, lifespanHit, Colors.Red, 0.2, connector).UsingGrowingEnd(lifespanHit.end);
             replay.Decorations.Add(pieHit.UsingRotationConnector(frontRotationConnector));
             replay.Decorations.Add(pieHit.Copy().UsingRotationConnector(flipRotationConnector));
         }
 
-        private static void AddSolarDischargeDecoration(CombatReplay replay, AbstractSingleActor target, int start, int attackEnd, uint radius)
+        private static void AddSolarDischargeDecoration(CombatReplay replay, AbstractSingleActor target, (long start, long end) lifespan)
         {
-            replay.Decorations.Add(new CircleDecoration(radius, (start, attackEnd), "rgba(120, 0, 0, 0.6)", new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(attackEnd));
+            replay.Decorations.Add(new CircleDecoration(1200, lifespan, Colors.Red, 0.6, new AgentConnector(target)).UsingFilled(false).UsingGrowingEnd(lifespan.end));
         }
 
-        private static int GetAttackEndByStunTime(ParsedEvtcLog log, AbstractSingleActor target, AbstractCastEvent c, int duration, int attackEnd)
+        private static void AddKickIndicatorDecoration(CombatReplay replay, AbstractSingleActor target, (long start, long end) lifespan, long expectedEndCast, float rotation)
         {
-            Segment stun = target.GetBuffStatus(log, Stun, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-            return stun != null ? (int)Math.Min(stun.Start, attackEnd) : attackEnd;
-        }
-
-        private static int GetAttackEndByDeterminedTime(ParsedEvtcLog log, AbstractSingleActor target, AbstractCastEvent c, int duration, int attackEnd)
-        {
-            Segment det = target.GetBuffStatus(log, Determined762, c.Time, c.Time + duration).FirstOrDefault(x => x.Value > 0);
-            return det != null ? (int)Math.Min(det.Start, attackEnd) : attackEnd;
-        }
-
-        private static void AddKickIndicatorDecoration(CombatReplay replay, AbstractSingleActor target, int start, int attackEnd, float rotation, int translation, int cascadeCount)
-        {
+            int translation = 150;
             var rotationConnector = new AngleConnector(rotation);
             var positionConnector = (AgentConnector)new AgentConnector(target).WithOffset(new Point3D(translation, 0), true);
-            replay.AddDecorationWithGrowing((RectangleDecoration)new RectangleDecoration(300, target.HitboxWidth, (start, attackEnd), Colors.Orange, 0.2, positionConnector).UsingRotationConnector(rotationConnector), attackEnd);
+            replay.AddDecorationWithGrowing((RectangleDecoration)new RectangleDecoration(300, target.HitboxWidth, lifespan, Colors.LightOrange, 0.2, positionConnector).UsingRotationConnector(rotationConnector), expectedEndCast);
 
-            for (int i = 0; i < cascadeCount; i++)
+            // Cascade count => 4
+            for (int i = 0; i < 4; i++)
             {
-                replay.Decorations.Add(new RectangleDecoration(300, target.HitboxWidth, (attackEnd, attackEnd + 300), Colors.Red, 0.2, positionConnector).UsingRotationConnector(rotationConnector));
-                attackEnd += 300;
+                replay.Decorations.Add(new RectangleDecoration(300, target.HitboxWidth, (lifespan.end, lifespan.end + 300), Colors.Red, 0.2, positionConnector).UsingRotationConnector(rotationConnector));
+                lifespan.end += 300;
                 translation += 300;
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
@@ -6,6 +6,7 @@ using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using GW2EIEvtcParser.ParserHelpers;
+using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.EncounterLogic.EncounterCategory;
@@ -85,7 +86,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new HashSet<int>
             {
-                (int)ArcDPSEnums.TargetID.KanaxaiScytheOfHouseAurkusCM,
+                (int)TargetID.KanaxaiScytheOfHouseAurkusCM,
             };
         }
 
@@ -93,12 +94,12 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new List<int>
             {
-                (int)ArcDPSEnums.TargetID.KanaxaiScytheOfHouseAurkusCM,
-                (int)ArcDPSEnums.TrashID.AspectOfTorment,
-                (int)ArcDPSEnums.TrashID.AspectOfLethargy,
-                (int)ArcDPSEnums.TrashID.AspectOfExposure,
-                (int)ArcDPSEnums.TrashID.AspectOfDeath,
-                (int)ArcDPSEnums.TrashID.AspectOfFear,
+                (int)TargetID.KanaxaiScytheOfHouseAurkusCM,
+                (int)TrashID.AspectOfTorment,
+                (int)TrashID.AspectOfLethargy,
+                (int)TrashID.AspectOfExposure,
+                (int)TrashID.AspectOfDeath,
+                (int)TrashID.AspectOfFear,
             };
         }
 
@@ -106,12 +107,12 @@ namespace GW2EIEvtcParser.EncounterLogic
         {
             return new Dictionary<int, int>()
             {
-                {(int)ArcDPSEnums.TargetID.KanaxaiScytheOfHouseAurkusCM, 0 },
-                {(int)ArcDPSEnums.TrashID.AspectOfTorment, 1 },
-                {(int)ArcDPSEnums.TrashID.AspectOfLethargy, 1 },
-                {(int)ArcDPSEnums.TrashID.AspectOfExposure, 1 },
-                {(int)ArcDPSEnums.TrashID.AspectOfDeath, 1 },
-                {(int)ArcDPSEnums.TrashID.AspectOfFear, 1 },
+                {(int)TargetID.KanaxaiScytheOfHouseAurkusCM, 0 },
+                {(int)TrashID.AspectOfTorment, 1 },
+                {(int)TrashID.AspectOfLethargy, 1 },
+                {(int)TrashID.AspectOfExposure, 1 },
+                {(int)TrashID.AspectOfDeath, 1 },
+                {(int)TrashID.AspectOfFear, 1 },
             };
         }
 
@@ -128,11 +129,11 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 switch (actor.ID)
                 {
-                    case (int)ArcDPSEnums.TrashID.AspectOfTorment:
-                    case (int)ArcDPSEnums.TrashID.AspectOfLethargy:
-                    case (int)ArcDPSEnums.TrashID.AspectOfExposure:
-                    case (int)ArcDPSEnums.TrashID.AspectOfDeath:
-                    case (int)ArcDPSEnums.TrashID.AspectOfFear:
+                    case (int)TrashID.AspectOfTorment:
+                    case (int)TrashID.AspectOfLethargy:
+                    case (int)TrashID.AspectOfExposure:
+                    case (int)TrashID.AspectOfDeath:
+                    case (int)TrashID.AspectOfFear:
                         if (aspectCounts.TryGetValue(actor.ID, out int count))
                         {
                             actor.OverrideName(actor.Character + " " + count);
@@ -151,7 +152,7 @@ namespace GW2EIEvtcParser.EncounterLogic
         internal override List<PhaseData> GetPhases(ParsedEvtcLog log, bool requirePhases)
         {
             List<PhaseData> phases = GetInitialPhase(log);
-            AbstractSingleActor kanaxai = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TargetID.KanaxaiScytheOfHouseAurkusCM));
+            AbstractSingleActor kanaxai = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.KanaxaiScytheOfHouseAurkusCM));
             if (kanaxai == null)
             {
                 throw new MissingKeyActorsException("Kanaxai not found");
@@ -217,11 +218,11 @@ namespace GW2EIEvtcParser.EncounterLogic
                     {
                         switch (aspect.ID)
                         {
-                            case (int)ArcDPSEnums.TrashID.AspectOfTorment:
-                            case (int)ArcDPSEnums.TrashID.AspectOfLethargy:
-                            case (int)ArcDPSEnums.TrashID.AspectOfExposure:
-                            case (int)ArcDPSEnums.TrashID.AspectOfDeath:
-                            case (int)ArcDPSEnums.TrashID.AspectOfFear:
+                            case (int)TrashID.AspectOfTorment:
+                            case (int)TrashID.AspectOfLethargy:
+                            case (int)TrashID.AspectOfExposure:
+                            case (int)TrashID.AspectOfDeath:
+                            case (int)TrashID.AspectOfFear:
                                 if (log.CombatData.GetBuffRemoveAllData(Determined762).Any(x => x.To == aspect.AgentItem && x.Time >= curPhase.Start && x.Time <= curPhase.End))
                                 {
                                     curPhase.AddTarget(aspect);
@@ -270,7 +271,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void CheckSuccess(CombatData combatData, AgentData agentData, FightData fightData, IReadOnlyCollection<AgentItem> playerAgents)
         {
-            AbstractSingleActor kanaxai = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TargetID.KanaxaiScytheOfHouseAurkusCM));
+            AbstractSingleActor kanaxai = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.KanaxaiScytheOfHouseAurkusCM));
             if (kanaxai == null)
             {
                 throw new MissingKeyActorsException("Kanaxai not found");
@@ -335,21 +336,22 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             switch (target.ID)
             {
-                case (int)ArcDPSEnums.TargetID.KanaxaiScytheOfHouseAurkusCM:
+                case (int)TargetID.KanaxaiScytheOfHouseAurkusCM:
                     // World Cleaver
                     var worldCleaver = casts.Where(x => x.SkillId == WorldCleaver).ToList();
                     foreach (AbstractCastEvent c in worldCleaver)
                     {
-                        int duration = 26320;
-                        int start = (int)c.Time;
-                        IEnumerable<AbstractHealthDamageEvent> hits = log.CombatData.GetDamageData(WorldCleaver).Where(x => x.Time > c.Time);
-                        if (hits.Any())
+                        int castDuration = 26320;
+                        var hits = log.CombatData.GetDamageData(WorldCleaver).Where(x => x.Time > c.Time).ToList();
+                        (long start, long end) lifespan = (c.Time, c.Time + castDuration);
+                        (long start, long end) lifespanHit = (c.Time, hits.FirstOrDefault(x => x.Time > c.Time).Time);
+                        if (hits.Count != 0)
                         {
-                            AddWorldCleaverDecoration(target, replay, start, (int)hits.FirstOrDefault(x => x.Time > c.Time).Time, start + duration);
+                            AddWorldCleaverDecoration(target, replay, lifespanHit, lifespan.end);
                         }
                         else
                         {
-                            AddWorldCleaverDecoration(target, replay, start, start + duration, start + duration);
+                            AddWorldCleaverDecoration(target, replay, lifespan, lifespan.end);
                         }
                     }
                     // Dread Visage
@@ -361,19 +363,19 @@ namespace GW2EIEvtcParser.EncounterLogic
                         double actualDuration = ComputeCastTimeWithQuickness(log, target, c.Time, castDuration);
                         if (actualDuration > 0)
                         {
-                            replay.AddOverheadIcon(new Segment((int)c.Time, (int)c.Time + (int)Math.Ceiling(actualDuration), 1), target, ParserIcons.EyeOverhead, 30);
+                            replay.AddOverheadIcon(new Segment(c.Time, c.Time + (long)Math.Ceiling(actualDuration), 1), target, ParserIcons.EyeOverhead, 30);
                         }
                         else
                         {
-                            replay.AddOverheadIcon(new Segment((int)c.Time, expectedEndCastTime, 1), target, ParserIcons.EyeOverhead, 30);
+                            replay.AddOverheadIcon(new Segment(c.Time, expectedEndCastTime, 1), target, ParserIcons.EyeOverhead, 30);
                         }
                     }
                     break;
-                case (int)ArcDPSEnums.TrashID.AspectOfTorment:
-                case (int)ArcDPSEnums.TrashID.AspectOfLethargy:
-                case (int)ArcDPSEnums.TrashID.AspectOfExposure:
-                case (int)ArcDPSEnums.TrashID.AspectOfDeath:
-                case (int)ArcDPSEnums.TrashID.AspectOfFear:
+                case (int)TrashID.AspectOfTorment:
+                case (int)TrashID.AspectOfLethargy:
+                case (int)TrashID.AspectOfExposure:
+                case (int)TrashID.AspectOfDeath:
+                case (int)TrashID.AspectOfFear:
                     // Tether casts performed by Aspects
                     IEnumerable<AnimatedCastEvent> tetherCasts = log.CombatData.GetAnimatedCastData(target.AgentItem).Where(x => x.SkillId == AspectTetherSkill);
                     foreach (AnimatedCastEvent cast in tetherCasts)
@@ -439,10 +441,8 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 foreach (EffectEvent aoe in frighteningSpeedRedAoEs)
                 {
-                    int duration = 1500;
-                    int start = (int)aoe.Time;
-                    int effectEnd = start + duration;
-                    var circle = new CircleDecoration( 380, (start, effectEnd), Colors.Red, 0.2, new PositionConnector(aoe.Position));
+                    (long start, long end) lifespan = (aoe.Time, aoe.Time + 1500);
+                    var circle = new CircleDecoration(380, lifespan, Colors.Red, 0.2, new PositionConnector(aoe.Position));
                     EnvironmentDecorations.Add(circle);
                     EnvironmentDecorations.Add(circle.Copy().UsingFilled(false));
                 }
@@ -452,7 +452,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.AxeGroundAoE, out IReadOnlyList<EffectEvent> axeAoEs))
             {
                 // Get World Cleaver casts
-                AbstractSingleActor kanaxai = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TargetID.KanaxaiScytheOfHouseAurkusCM));
+                AbstractSingleActor kanaxai = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.KanaxaiScytheOfHouseAurkusCM));
                 IReadOnlyList<AbstractCastEvent> casts = kanaxai.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
                 
                 // Get Axe AoE Buffs
@@ -487,12 +487,10 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 foreach (EffectEvent harrowshot in harrowshots)
                 {
-                    int duration = 3000;
-                    int start = (int)harrowshot.Time;
-                    int end = (int)harrowshot.Time + duration;
-                    var circle = new CircleDecoration(280, (start, end), Colors.Orange, 0.2, new PositionConnector(harrowshot.Position));
+                    (long start, long end) lifespan = harrowshot.ComputeLifespan(log, 3000);
+                    var circle = new CircleDecoration(280, lifespan, Colors.Orange, 0.2, new PositionConnector(harrowshot.Position));
                     EnvironmentDecorations.Add(circle);
-                    EnvironmentDecorations.Add(circle.Copy().UsingGrowingEnd(end));
+                    EnvironmentDecorations.Add(circle.Copy().UsingGrowingEnd(lifespan.end));
                 }
             }
         }
@@ -523,17 +521,16 @@ namespace GW2EIEvtcParser.EncounterLogic
             EnvironmentDecorations.Add(circle.Copy().UsingFilled(false));
         }
 
-        /// <summary>
+        /// /// <summary>
         /// Adds the World Cleaver decoration.
         /// </summary>
         /// <param name="target">Kanaxai.</param>
         /// <param name="replay">Combat Replay.</param>
-        /// <param name="start">Start of the cast.</param>
-        /// <param name="end">End of the cast.</param>
+        /// <param name="lifespan">Start and End of the cast.</param>
         /// <param name="growing">Duration of the channel.</param>
-        private static void AddWorldCleaverDecoration(NPC target, CombatReplay replay, int start, int end, int growing)
+        private static void AddWorldCleaverDecoration(NPC target, CombatReplay replay, (long start, long end) lifespan, long growing)
         {
-            replay.AddDecorationWithGrowing(new CircleDecoration(1100, (start, end), Colors.Red, 0.2, new AgentConnector(target)), growing);
+            replay.AddDecorationWithGrowing(new CircleDecoration(1100, lifespan, Colors.Red, 0.2, new AgentConnector(target)), growing);
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
@@ -521,7 +521,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             EnvironmentDecorations.Add(circle.Copy().UsingFilled(false));
         }
 
-        /// /// <summary>
+        /// <summary>
         /// Adds the World Cleaver decoration.
         /// </summary>
         /// <param name="target">Kanaxai.</param>

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -145,6 +145,8 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
         {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ValeGuardianDistributedMagic, out IReadOnlyList<EffectEvent> distributedMagicEvents))
             {
                 int distributedMagicDuration = 6700;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Cairn.cs
@@ -99,6 +99,8 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
         {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.CairnDisplacement, out IReadOnlyList<EffectEvent> displacementEffects))
             {
                 foreach (EffectEvent displacement in displacementEffects)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -423,6 +423,8 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
         {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
             if (_manualPlatforms)
             {
                 AddManuallyAnimatedPlatformsToCombatReplay(Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Qadim)), log, EnvironmentDecorations);

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -664,6 +664,8 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
         {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.HarvestTempleGreen, out IReadOnlyList<EffectEvent> greenEffects))
             {
                 AddShareTheVoidDecoration(greenEffects, true);
@@ -1343,7 +1345,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         uint radius = 500;
                         long castDuration = 1680;
                         long supposedEndCast = c.Time + castDuration;
-                        long actualEndCast = ComputeEndCastTimeByStun(log, target, c.Time, castDuration);
+                        long actualEndCast = ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration);
                         (long start, long end) lifespan = (c.Time, actualEndCast);
                         var agentConnector = new AgentConnector(c.Caster);
                         var circle = new CircleDecoration(radius, lifespan, Colors.Orange, 0.2, agentConnector);
@@ -1523,7 +1525,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         uint width = target.HitboxWidth;
                         long castDuration = 1000;
                         long supposedEndCast = c.Time + castDuration;
-                        long actualEndCast = ComputeEndCastTimeByStun(log, target, c.Time, castDuration);
+                        long actualEndCast = ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration);
                         Point3D facing = target.GetCurrentRotation(log, c.Time + castDuration);
                         if (facing != null)
                         {
@@ -1543,7 +1545,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         int openingAngle = 60;
                         long castDuration = 3400;
                         long supposedEndCast = c.Time + castDuration;
-                        long actualEndCast = ComputeEndCastTimeByStun(log, target, c.Time, castDuration);
+                        long actualEndCast = ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration);
                         Point3D facing = target.GetCurrentRotation(log, c.Time + castDuration);
                         if (facing != null)
                         {
@@ -1623,7 +1625,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                         uint radius = 600;
                         long castDuration = 1880;
                         long supposedEndCast = c.Time + castDuration;
-                        long actualEndCast = ComputeEndCastTimeByStun(log, target, c.Time, castDuration);
+                        long actualEndCast = ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration);
                         (long start, long end) lifespan = (c.Time, actualEndCast);
                         var agentConnector = new AgentConnector(c.Caster);
                         var circle = new CircleDecoration(radius, lifespan, Colors.Orange, 0.2, agentConnector);

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -57,26 +58,26 @@ namespace GW2EIEvtcParser.EncounterLogic
             };
         }
 
-        protected override List<ArcDPSEnums.TrashID> GetTrashMobsIDs()
+        protected override List<TrashID> GetTrashMobsIDs()
         {
-            return new List<ArcDPSEnums.TrashID>
+            return new List<TrashID>
             {
-                ArcDPSEnums.TrashID.VigilTactician,
-                ArcDPSEnums.TrashID.VigilRecruit,
-                ArcDPSEnums.TrashID.PrioryExplorer,
-                ArcDPSEnums.TrashID.PrioryScholar,
-                ArcDPSEnums.TrashID.AberrantWisp,
-                ArcDPSEnums.TrashID.Torch,
+                TrashID.VigilTactician,
+                TrashID.VigilRecruit,
+                TrashID.PrioryExplorer,
+                TrashID.PrioryScholar,
+                TrashID.AberrantWisp,
+                TrashID.Torch,
             };
         }
 
         internal override void EIEvtcParse(ulong gw2Build, int evtcVersion, FightData fightData, AgentData agentData, List<CombatItem> combatData, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)
         {
-            var torches = combatData.Where(x => x.DstAgent == 14940 && x.IsStateChange == ArcDPSEnums.StateChange.MaxHealthUpdate).Select(x => agentData.GetAgent(x.SrcAgent, x.Time)).Where(x => x.Type == AgentItem.AgentType.Gadget && x.HitboxHeight == 500 && x.HitboxWidth >= 250).ToList();
+            var torches = combatData.Where(x => x.DstAgent == 14940 && x.IsStateChange == StateChange.MaxHealthUpdate).Select(x => agentData.GetAgent(x.SrcAgent, x.Time)).Where(x => x.Type == AgentItem.AgentType.Gadget && x.HitboxHeight == 500 && x.HitboxWidth >= 250).ToList();
             foreach (AgentItem torch in torches)
             {
                 torch.OverrideType(AgentItem.AgentType.NPC);
-                torch.OverrideID(ArcDPSEnums.TrashID.Torch);
+                torch.OverrideID(TrashID.Torch);
                 torch.OverrideAwareTimes(fightData.LogStart, fightData.LogEnd);
             }
             agentData.Refresh();
@@ -99,7 +100,7 @@ namespace GW2EIEvtcParser.EncounterLogic
 
             switch (target.ID)
             {
-                case (int)ArcDPSEnums.TargetID.Boneskinner:
+                case (int)TargetID.Boneskinner:
                     // Death Wind
                     var deathWind = casts.Where(x => x.SkillId == DeathWind).ToList();
                     foreach (AbstractCastEvent c in deathWind)
@@ -161,13 +162,13 @@ namespace GW2EIEvtcParser.EncounterLogic
                         replay.AddDecorationWithGrowing(landingCircle, finalTime);
                     }
                     // Cascade
-                    AddCascadeDecoration(log, target,replay, EffectGUIDs.CascadeAoEIndicator1, 200, 40);
+                    AddCascadeDecoration(log, target, replay, EffectGUIDs.CascadeAoEIndicator1, 200, 40);
                     AddCascadeDecoration(log, target, replay, EffectGUIDs.CascadeAoEIndicator2, 400, 80);
                     AddCascadeDecoration(log, target, replay, EffectGUIDs.CascadeAoEIndicator3, 600, 120);
                     AddCascadeDecoration(log, target, replay, EffectGUIDs.CascadeAoEIndicator4, 800, 160);
                     AddCascadeDecoration(log, target, replay, EffectGUIDs.CascadeAoEIndicator5, 1000, 200);
                     break;
-                case (int)ArcDPSEnums.TrashID.AberrantWisp:
+                case (int)TrashID.AberrantWisp:
                     break;
                 default:
                     break;
@@ -199,7 +200,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                     int duration = 30000;
                     int start = (int)claw.Time;
                     int end = (int)claw.Time + duration;
-                    var circle = new CircleDecoration(100, (start, end), "rgba(71, 35, 32, 0.2)", new PositionConnector(claw.Position));
+                    var circle = new CircleDecoration(100, (start, end), Colors.RedBrownish, 0.2, new PositionConnector(claw.Position));
                     EnvironmentDecorations.Add(circle);
                     EnvironmentDecorations.Add(circle.GetBorderDecoration(Colors.Red, 0.2));
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/IcebroodSaga/Bjora/Boneskinner.cs
@@ -176,6 +176,8 @@ namespace GW2EIEvtcParser.EncounterLogic
 
         internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
         {
+            base.ComputeEnvironmentCombatReplayDecorations(log);
+
             // Grasp AoE Orange Indicator
             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.GraspAoeIndicator, out IReadOnlyList<EffectEvent> indicators))
             {

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvent.cs
@@ -161,13 +161,13 @@ namespace GW2EIEvtcParser.ParsedData
         /// <param name="log">The log.</param>
         /// <param name="secondaryEffectGUID"><see cref="EffectGUIDs"/> of the secondary effect.</param>
         /// <returns>The computed start and end times.</returns>
-        public (long start, long end) ComputeLifespanWithSecondaryEffectAndPosition(ParsedEvtcLog log, string secondaryEffectGUID)
+        public (long start, long end) ComputeLifespanWithSecondaryEffectAndPosition(ParsedEvtcLog log, string secondaryEffectGUID, double minDistance = 1e-6)
         {
             long start = Time;
             long end = start + Duration;
             if (log.CombatData.TryGetEffectEventsBySrcWithGUID(Src, secondaryEffectGUID, out IReadOnlyList<EffectEvent> effects))
             {
-                EffectEvent firstEffect = effects.FirstOrDefault(x => x.Time >= Time && !x.IsAroundDst && x.Position.DistanceToPoint(Position) < 1e-6);
+                EffectEvent firstEffect = effects.FirstOrDefault(x => x.Time >= Time && !x.IsAroundDst && x.Position.DistanceToPoint(Position) < minDistance);
                 if (firstEffect != null)
                 {
                     end = firstEffect.Time;

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -318,16 +318,21 @@ namespace GW2EIEvtcParser
         // Nightmare Fractal
         public const string SmallFluxBomb = "B9CB27D38747A94F817208835C41BB35";
         public const string ToxicSicknessIndicator = "3C98B00B9E795F4B8744E186EEEA7DF7";
-        public const string ToxicSicknessPuke1 = "B7DFF8C2A8DABD4C9C7F1D4CFC31FC8C";
-        public const string ToxicSicknessPuke2 = "E09CD66E417B59409401192201CE4B6E";
+        public const string ToxicSicknessOldIndicator = "B7DFF8C2A8DABD4C9C7F1D4CFC31FC8C";
+        public const string ToxicSicknessNewIndicator = "71469269D3A1F9469D74CC96153264C0";
+        public const string ToxicSicknessPuke = "E09CD66E417B59409401192201CE4B6E";
         public const string MAMAGrenadeBarrageIndicator = "8DDED161CE26964FA5952D821AD852F7";
         public const string NightmareMiasmaIndicator = "41883B3BD532124DACF93F7C2584E63C";
-        public const string ArkkShieldIndicator = "5B1B9D29D6242F47A82743330AE4225B";
-        public const string NightmareHallucinationsSpawn = "0C284B1C201D1846B4D9F249AD01A5C6";
-        public const string VileSpitSiax = "BC17A48E8DD2FF44864AA48A732BDC36";
+        public const string NightmareMiasmaDamage = "8A882A495793044D8C4A9AD9080283A7";
+        public const string ArkkShieldIndicator = "5B1B9D29D6242F47A82743330AE4225B"; // Duration 7400
+        public const string ArkkShieldIndicator2 = "1E267990C5098E49AFD5CFD5CA4E2B82"; // Duration 6400
+        public const string SiaxNightmareHallucinationsSpawnIndicator = "0C284B1C201D1846B4D9F249AD01A5C6"; // siax src
+        public const string SiaxVileSpitIndicator = "BC17A48E8DD2FF44864AA48A732BDC36";
+        public const string SiaxVileSpitPoison = "6589BB8F4EE227428CC3DDDE84A67015";
         public const string CausticBarrageIndicator = "C910F1B11A21014AA99F24DBDFBF13FB";
-        public const string CausticBarrageHitEffect = "CAF4E62C2C5CC04499657C2A6A78087B";
-        public const string VolatileExpulsionIndicator = "F22E201EAF24DD42A43D297B2E83CC66";
+        public const string CausticBarrageHitEffect = "CAF4E62C2C5CC04499657C2A6A78087B"; // 1000 duration - green explosion effect when orb lands - conflicts with player effects
+        public const string VolatileExpulsionIndicator = "DCA047DBD6E90A41B46CDDCE5405E4BC"; // 300 - 400 duration
+        public const string VolatileExpulsion2 = "F22E201EAF24DD42A43D297B2E83CC66"; // 0 duration
         public const string CascadeOfTormentRing0 = "EFF32973C7921F41AA3FD65745E06506";
         public const string CascadeOfTormentRing1 = "D919AC7D1B2ABD438F809B3B9DCE9226";
         public const string CascadeOfTormentRing2 = "A5D958EDAD66D7469CA40059915843CC";
@@ -338,8 +343,12 @@ namespace GW2EIEvtcParser
         public const string EnsolyssMiasmaDoughnut66_15 = "3AE042F82A10B84DB7487B0C0F4D2AB1";
         public const string EnsolyssMiasmaDoughnut15_0 = "AB294EC140644E48BC739B8E303D2762";
         public const string EnsolyssNightmareAltarShockwave = "AA31A20BDC52324B945FD660D60429EB";
+        public const string EnsolyssNightmareAltarLightOrangeAoE = "66C6DEE334653342BDC578817254F7C8";
+        public const string EnsolyssNightmareAltarOrangeAoE = "FA097ABEFB8CEF4B89EB12825EEE1FB9"; // same effect as Skorvald's Solar Bolt
+        public const string EnsolyssArrow = "3D85505CEBCF0E4D8993625957405977";
         // Shattered Observatory Fractal
-        public const string SolarBolt = "FA097ABEFB8CEF4B89EB12825EEE1FB9";
+        public const string SolarBoltIndicators = "FA097ABEFB8CEF4B89EB12825EEE1FB9";
+        public const string SkorvaldSolarBoltDamage = "49813989C508464B81FC45E6D24EA8C3";
         public const string KickGroundEffect = "47FE87414A88484AB05A84E1440F5FDD";
         public const string AoeIndicator130Radius = "8DDED161CE26964FA5952D821AD852F7";
         public const string MistBomb = "03FB41386DD2A54FA093795DF2870B7A";

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1987,6 +1987,7 @@
         public const long MistlockInstabilityFluxBomb = 36386;
         public const long FluxBombSkill = 36393;
         public const long PlateOfIslandPudding = 36406;
+        public const long POV_ToxicTrailBuff = 36410;
         public const long ToxicTrail = 36456;
         public const long EnragedFractal = 36498;
         public const long PlateOfSweetCurriedMussels = 36508;
@@ -1997,6 +1998,7 @@
         public const long VolatileExpulsionSiax = 36894;
         public const long Extraction = 36903;
         public const long NightmareBullet2 = 36919;
+        public const long POV_ToxicSicknessBuff = 36922;
         public const long TormentingBlast = 36926;
         public const long LungeNightmareHallucination = 36927;
         public const long CausticExplosionSiaxBreakbar = 36929;
@@ -2015,6 +2017,7 @@
         public const long CausticExplosionEnsolyss = 37096;
         public const long Blastwave2 = 37103;
         public const long BowlOfWinterberrySeaweedSalad = 37111;
+        public const long ExplosiveLaunch = 37121;
         public const long NigthmareMiasmaEnsolyss3 = 37151;
         public const long LungeEnsolyss = 37154;
         public const long GrenadeBarrage2 = 37172;
@@ -2085,6 +2088,7 @@
         public const long SpearImpact = 37816;
         public const long OffBalance = 37846;
         public const long InevitableBetrayalFailBig = 37851;
+        public const long POV_FluxBombCooldownBuff = 37857;
         public const long FixatedSamarog = 37868;
         public const long FormUpAndAdvance = 37871;
         public const long DemonicAura = 37872;
@@ -2124,6 +2128,7 @@
         public const long EnemyTile = 38184;
         public const long WeakMinded = 38187;
         public const long BrutalizeBuff = 38199;
+        public const long POV_FluxBombSafeTimeBuff = 38206;
         public const long Annihilate2 = 38208;
         public const long SharedAgony75 = 38209;
         public const long SharedAgony3 = 38210;


### PR DESCRIPTION
# General
- Added Flux Bomb target buff
- Added Toxic Sickness mechanic
- Cleaned up ArcDPSEnums for some encounters
- Fixed Toxic Sickness decoration not working with the new effect
- Added Flux Bomb on player decoration
- Cleaned up lifespans and removed a bunch of no longer necessary (int) casts
- Added base.ComputeEnvironmentCombatReplayDecorations(log) to some missing Environment overrides
- Moved effect decorations to the environment combat replay for the mechanics that made sense doing so
- Moved Caustic Barrage and Solar Bolt to Fractal Logic

# MAMA
- Corrected Blastwave radius size
- Corrected Leap radius size
- Split the Knights jump and fall attacks into 2 different decorations
- Split Nightmare Miasma into two decorations

# Siax
- Adjusted duration of the orb AoEs during some mechanics

# Ensolyss
- Added Rampage decoration
- Added AoEs during the Nightmare Altar phases
- Adjusted duration of the orb AoEs during some mechanics

# Arkk
- Compacted Horizon Strike decoration

# API
- Converted ComputeEndCastTimeByStun to generic ComputeEndCastTimeByBuffApplication
- Cleaned up Fractal encounters that were using the above to the new API
- Added a couple new colors
- Allow ComputeLifespanWithSecondaryEffectAndPosition to accept a different minimum distance than default