### PR TITLE
Fix incorrect phase names due to filtering

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicPhaseUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicPhaseUtils.cs
@@ -74,7 +74,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             {
                 phases.Add(new PhaseData(last, end));
             }
-            return phases; // skip filtering too short phases here, it may mess with phase names
+            return phases.Where(x => x.DurationInMS > 100).ToList(); // only filter unrealistically short phases, otherwise it may mess with phase names
         }
 
         internal static List<PhaseData> GetPhasesByInvul(ParsedEvtcLog log, long skillID, AbstractSingleActor mainTarget, bool addSkipPhases, bool beginWithStart, long start, long end)

--- a/GW2EIEvtcParser/EncounterLogic/EncounterLogicPhaseUtils.cs
+++ b/GW2EIEvtcParser/EncounterLogic/EncounterLogicPhaseUtils.cs
@@ -70,11 +70,11 @@ namespace GW2EIEvtcParser.EncounterLogic
                     nextToAddIsSkipPhase = false;
                 }
             }
-            if (end - last > ParserHelper.PhaseTimeLimit && (!nextToAddIsSkipPhase || (nextToAddIsSkipPhase && addSkipPhases)))
+            if (!nextToAddIsSkipPhase || (nextToAddIsSkipPhase && addSkipPhases))
             {
                 phases.Add(new PhaseData(last, end));
             }
-            return phases.Where(x => x.DurationInMS > ParserHelper.PhaseTimeLimit).ToList();
+            return phases; // skip filtering too short phases here, it may mess with phase names
         }
 
         internal static List<PhaseData> GetPhasesByInvul(ParsedEvtcLog log, long skillID, AbstractSingleActor mainTarget, bool addSkipPhases, bool beginWithStart, long start, long end)


### PR DESCRIPTION
This fixes incorrect phase names for phases after a < 2s phase, which can theoretically occur for several encounters. The problem was that `GetPhasesByInvul` filtered < 2s phases already, resulting in encounter logic implementations assigning incorrect phase names since some of them assume all phases to be present.