### PR TITLE
Encounter template improvements

### DIFF
--- a/GW2EIBuilders/HtmlModels/HtmlActors/TargetDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlActors/TargetDto.cs
@@ -13,6 +13,7 @@ namespace GW2EIBuilders.HtmlModels.HTMLActors
         public long HbHeight { get; set; }
         public double Percent { get; set; }
         public double HpLeft { get; set; }
+        public double BarrierLeft { get; set; }
 
         public TargetDto(AbstractSingleActor target, ParsedEvtcLog log, ActorDetailsDto details) : base(target, log, details)
         {
@@ -22,6 +23,7 @@ namespace GW2EIBuilders.HtmlModels.HTMLActors
             if (log.FightData.Success)
             {
                 HpLeft = 0;
+                BarrierLeft = 0;
             }
             else
             {
@@ -29,6 +31,11 @@ namespace GW2EIBuilders.HtmlModels.HTMLActors
                 if (hpUpdates.Count > 0)
                 {
                     HpLeft = hpUpdates.Last().HPPercent;
+                }
+                IReadOnlyList<BarrierUpdateEvent> barrierUpdates = log.CombatData.GetBarrierUpdateEvents(target.AgentItem);
+                if (barrierUpdates.Count > 0)
+                {
+                    BarrierLeft = barrierUpdates.Last().BarrierPercent;
                 }
             }
             Percent = Math.Round(100.0 - HpLeft, 2);

--- a/GW2EIBuilders/JsonModels/JsonActors/JsonNPCBuilder.cs
+++ b/GW2EIBuilders/JsonModels/JsonActors/JsonNPCBuilder.cs
@@ -25,10 +25,12 @@ namespace GW2EIBuilders.JsonModels.JsonActors
             //
             jsonNPC.Id = npc.ID;
             IReadOnlyList<HealthUpdateEvent> hpUpdates = log.CombatData.GetHealthUpdateEvents(npc.AgentItem);
+            IReadOnlyList<BarrierUpdateEvent> barrierUpdates = log.CombatData.GetBarrierUpdateEvents(npc.AgentItem);
             jsonNPC.FirstAware = (int)npc.FirstAware;
             jsonNPC.LastAware = (int)npc.LastAware;
             jsonNPC.EnemyPlayer = npc is PlayerNonSquad;
             double hpLeft = 100.0;
+            double barrierLeft = 0.0;
             if (log.FightData.Success)
             {
                 hpLeft = 0;
@@ -39,9 +41,15 @@ namespace GW2EIBuilders.JsonModels.JsonActors
                 {
                     hpLeft = hpUpdates.Last().HPPercent;
                 }
+                if (barrierUpdates.Count > 0)
+                {
+                    barrierLeft = barrierUpdates.Last().BarrierPercent;
+                }
             }
             jsonNPC.HealthPercentBurned = 100.0 - hpLeft;
+            jsonNPC.BarrierPercent = barrierLeft;
             jsonNPC.FinalHealth = (int)Math.Round(jsonNPC.TotalHealth * hpLeft / 100.0);
+            jsonNPC.FinalBarrier = (int)Math.Round(jsonNPC.TotalHealth * barrierLeft / 100.0);
             //
             jsonNPC.Buffs = GetNPCJsonBuffsUptime(npc, log, settings, buffDesc);
             // Breakbar

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplEncounter.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplEncounter.html
@@ -21,10 +21,15 @@
                         <div v-if="target.health > 0" class="super-small" style="text-align:center;">
                             {{ target.health }} Health
                         </div>
-                        <div :style="{'background': getGradient(target.hpLeft ? target.hpLeft : 0), 'height': '10px', 'width': '100%', 'border-radius': '5px'}">
-                        </div>
-                        <div class="small" style="text-align:center;">
-                            {{ target.hpLeft ? target.hpLeft : 0 }}% remaining
+                        <div :data-original-title="healthRemaining(target)">
+                            <div :style="{'background': getGradient(target), 'height': '10px', 'width': '100%', 'border-radius': '5px'}">
+                            </div>
+                            <div v-if="target.hpLeft > 0" class="small" style="text-align:center;">
+                                {{ target.hpLeft ? target.hpLeft : 0 }}% health remaining
+                            </div>
+                            <div v-if="target.barrierLeft > 0" class="small" style="text-align:center;">
+                                {{ target.barrierLeft }}% barrier remaining
+                            </div>
                         </div>
                     </div>
                     <div v-if="!wvw" class="mb-2 text" :class="resultStatus.class">
@@ -48,16 +53,34 @@
             };
         },
         methods: {
-            getGradient: function (percent) {
-                var template = 'linear-gradient(to right, $left$, $middle$, $right$)';
-                var greenPercent = "green " + (100 - percent) + "%";
-                var redPercent = "red " + (percent) + "%";
-                var middle = percent + "%";
-                template = template.replace('$right$', greenPercent);
-                template = template.replace('$left$', redPercent);
-                template = template.replace('$middle$', middle);
+            getGradient: function (target) {
+                var healthAndBarrier = target.hpLeft + target.barrierLeft;
+                if (healthAndBarrier > 100) {
+                    healthAndBarrier = 100;
+                }
+                var template = 'linear-gradient(to right, $red$, $yellow$, $green$)';
+                var red = "red " + target.hpLeft + "%";
+                var yellow = "yellow " + target.hpLeft + "% " + healthAndBarrier + "%";
+                var green = "green " + healthAndBarrier + "%";
+                template = template.replace('$red$', red);
+                template = template.replace('$yellow$', yellow);
+                template = template.replace('$green$', green);
                 return template;
-            }
+            },
+            healthRemaining: function (target) {
+                var hpLeft = Math.round(target.health * target.hpLeft / 100.0);
+                var barrierLeft = Math.round(target.health * target.barrierLeft / 100.0);
+                if (hpLeft > 0 && barrierLeft > 0) {
+                    return 'Health: ' + hpLeft + '<br>Barrier: ' + barrierLeft;
+                }
+                else if (hpLeft > 0 && barrierLeft == 0) {
+                    return 'Health: ' + hpLeft;
+                }
+                else if (barrierLeft > 0) {
+                    return 'Barrier: ' + barrierLeft;
+                }
+                return false;
+            },
         },
         computed: {
             encounter: function () {

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplEncounter.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplEncounter.html
@@ -25,7 +25,7 @@
                             <div :style="{'background': getGradient(target), 'height': '10px', 'width': '100%', 'border-radius': '5px'}">
                             </div>
                             <div v-if="target.hpLeftPercent > 0" class="small" style="text-align:center;">
-                                {{ target.hpLeftPercent ? target.hpLeftPercent : 0 }}% health remaining
+                                {{ target.hpLeftPercent }}% health remaining
                             </div>
                             <div v-if="target.barrierLeft > 0" class="small" style="text-align:center;">
                                 {{ target.barrierLeft }}% barrier remaining

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -179,6 +179,8 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Selfless Amplification", SelflessAmplification, Source.Revenant, BuffClassification.Other, BuffImages.SelflessAmplification),
             new Buff("Battle Scars", BattleScars, Source.Revenant, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, BuffImages.ThrillOfCombat).WithBuilds(GW2Builds.February2020Balance, GW2Builds.EndOfLife),
             new Buff("Steadfast Rejuvenation", SteadfastRejuvenation, Source.Revenant, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.SteadfastRejuvenation),
+            // Scepter
+            new Buff("Blossoming Aura", BlossomingAuraBuff, Source.Revenant, BuffClassification.Other, BuffImages.BlossomingAura),
         };
 
         private static readonly HashSet<long> _legendSwaps = new HashSet<long>

--- a/GW2EIEvtcParser/ParserHelpers/BuffImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/BuffImages.cs
@@ -1614,6 +1614,7 @@
         public const string TappedOut = "https://wiki.guildwars2.com/images/9/94/Tapped_Out.png";
         public const string NaturesStrength = "https://wiki.guildwars2.com/images/8/84/Nature%27s_Strength.png";
         public const string DimensionalAperture = "https://wiki.guildwars2.com/images/8/80/Dimensional_Aperture.png";
+        public const string BlossomingAura = "https://wiki.guildwars2.com/images/6/62/Blossoming_Aura.png";
         #endregion Cast
 
         #region Traits

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -4183,6 +4183,7 @@
         public const long RampartSplitter = 71875;
         public const long EarthBullet = 71881;
         public const long EssenceOfLivingShadows = 71882;
+        public const long BlossomingAuraBuff = 71887;
         public const long DimensionalAperturePortalBuff = 71890;
         public const long FriendlyFire = 71892;
         public const long Journey = 71897;

--- a/GW2EIJSON/JsonActors/JsonNPC.cs
+++ b/GW2EIJSON/JsonActors/JsonNPC.cs
@@ -20,6 +20,16 @@ namespace GW2EIJSON
         /// Final health of the target
         /// </summary>
         public int FinalHealth { get; set; }
+
+        /// <summary>
+        /// Final barrier on the target
+        /// </summary>
+        public int FinalBarrier { get; set; }
+
+        /// <summary>
+        /// % of barrier remaining on the target
+        /// </summary>
+        public double BarrierPercent { get; set; }
         
         /// <summary>
         /// % of health burned


### PR DESCRIPTION
- Added BarrierLeft to TargetDto
- Added BarrierPercent and FinalBarrier to jsonNPC
- Added text displaying barrier % left on target when log ends
- Hp % and Barrier % left will be hidden when either of them are 0
- Added hover tooltip displaying Health and Barrier left in numerical value
- The Hp bar now displays barrier as yellow
- Added Blossoming Aura to Revenant Scepter