### PR TITLE
Various skill decorations, engineer mine detonation cast finder and Arkk's anomalies as secondary target

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
@@ -108,9 +108,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Power Suit", PowerSuit, Source.Common, BuffClassification.Other, BuffImages.PowerSuit),
             new Buff("Reaper of Grenth", ReaperOfGrenth, Source.Common, BuffClassification.Other, BuffImages.ReaperOfGrenth),
             new Buff("Charrzooka", Charrzooka, Source.Common, BuffClassification.Other, BuffImages.Charrzooka),
-            //
-            new Buff("Guild Item Research", GuildItemResearch, Source.Common, BuffClassification.Other, BuffImages.GuildMagicFind),
-            //
+            // W4
             new Buff("Crystalline Heart", CrystallineHeart, Source.Common, BuffClassification.Other, BuffImages.CrystallineHeart),
             // Mounts
             new Buff("No Mount Use", NoMountUse, Source.Common, BuffClassification.Other, BuffImages.MountsDisabled),
@@ -130,6 +128,9 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Fire Elemental Powder", FireElementalPowderBuff, Source.Common, BuffClassification.Other, BuffImages.FireElementalPowder),
             new Buff("Sunspear Paragon Support", SunspearParagonSupportBuff, Source.Common, BuffClassification.Other, BuffImages.SunspearParagonSupport),
             new Buff("Raven Spirit Shadow", RavenSpiritShadowBuff, Source.Common, BuffClassification.Other, BuffImages.RavenSpiritShadow),
+            // Primers
+            new Buff("Metabolic Primer", MetabolicPrimer, Source.Common, BuffClassification.Other, BuffImages.MetabolicPrimer),
+            new Buff("Utility Primer", UtilityPrimer, Source.Common, BuffClassification.Other, BuffImages.UtilityPrimer),
         };
 
         internal static readonly List<Buff> Gear = new List<Buff>

--- a/GW2EIEvtcParser/EIData/Buffs/UtilityBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/UtilityBuffs.cs
@@ -74,6 +74,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("5% Damage Reduction", DamageReduction5, Source.Item, BuffStackType.Queue, 9, BuffClassification.OtherConsumable, BuffImages.DamageReduction5),
             new Buff("Healthful Rejuvenation", HealthfulRejuvenation, Source.Item, BuffStackType.Queue, 9, BuffClassification.OtherConsumable, BuffImages.HealthfulRejuvenation),
             new Buff("5% Damage Bonus", DamageBonus5, Source.Item, BuffStackType.Queue, 9, BuffClassification.OtherConsumable, BuffImages.DamageBonus5),
+            new Buff("Guild Swiftness Banner Boost", GuildSwiftnessBannerBoost, Source.Item, BuffClassification.OtherConsumable, BuffImages.GuildSwiftnessBanner),
             // Fractals
             new Buff("Fractal Mobility", FractalMobility, Source.Item, BuffStackType.Stacking, 5, BuffClassification.OtherConsumable, BuffImages.FractalMobility),
             new Buff("Fractal Defensive", FractalDefensive, Source.Item, BuffStackType.Stacking, 5, BuffClassification.OtherConsumable, BuffImages.FractalDefensive),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -8,6 +8,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -311,20 +312,18 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in meteorShowerCircles)
                 {
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, 9000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(360, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectMeteorShower, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectMeteorShower);
                 }
                 // The meteors
                 if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.ElementalistMeteorShowerMeteor, out IReadOnlyList<EffectEvent> meteorShowersMeteors))
                 {
                     foreach (EffectEvent effect in meteorShowersMeteors)
                     {
-                        (long, long) lifespan = effect.ComputeLifespan(log, 1330);
+                        (long start, long end) lifespan = effect.ComputeLifespan(log, 1330);
                         var connector = new PositionConnector(effect.Position);
                         // -750 to make the decoration faster than in game
-                        replay.Decorations.Add(new CircleDecoration(180, (lifespan.Item2 - 750, lifespan.Item2), color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                        replay.Decorations.Add(new CircleDecoration(180, (lifespan.Item2 - 750, lifespan.Item2), color, 0.2, connector).UsingFilled(false).UsingGrowingEnd(lifespan.Item2, true).UsingSkillMode(skill));
+                        replay.Decorations.Add(new CircleDecoration(180, (lifespan.start - 750, lifespan.end), color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
+                        replay.Decorations.Add(new CircleDecoration(180, (lifespan.start - 750, lifespan.end), color, 0.2, connector).UsingFilled(false).UsingGrowingEnd(lifespan.end, true).UsingSkillMode(skill));
                     }
                 }
             }
@@ -336,9 +335,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in staticFieldsStaff)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 4000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectStaticField, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectStaticField);
                 }
             }
 
@@ -349,9 +346,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in staticFieldsHammer)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 4000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectStaticField, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectStaticField);
                 }
             }
 
@@ -389,9 +384,7 @@ namespace GW2EIEvtcParser.EIData
                         icon = ParserIcons.EffectFirestormGlyphOrFieryGreatsword;
                     }
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, 10000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, icon);
                 }
             }
 
@@ -408,9 +401,7 @@ namespace GW2EIEvtcParser.EIData
                             continue;
                         }
                         (long, long) lifespan = effect.ComputeLifespan(log, 4000);
-                        var connector = new PositionConnector(effect.Position);
-                        replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                        replay.Decorations.Add(new IconDecoration(ParserIcons.EffectGeyser, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                        AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectGeyser);
                     }
                 }
                 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -319,11 +319,11 @@ namespace GW2EIEvtcParser.EIData
                 {
                     foreach (EffectEvent effect in meteorShowersMeteors)
                     {
-                        (long start, long end) lifespan = effect.ComputeLifespan(log, 1330);
+                        (long start, long end) = effect.ComputeLifespan(log, 1330);
                         var connector = new PositionConnector(effect.Position);
                         // -750 to make the decoration faster than in game
-                        replay.Decorations.Add(new CircleDecoration(180, (lifespan.start - 750, lifespan.end), color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                        replay.Decorations.Add(new CircleDecoration(180, (lifespan.start - 750, lifespan.end), color, 0.2, connector).UsingFilled(false).UsingGrowingEnd(lifespan.end, true).UsingSkillMode(skill));
+                        replay.Decorations.Add(new CircleDecoration(180, (end - 750, end), color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
+                        replay.Decorations.Add(new CircleDecoration(180, (end - 750, end), color, 0.2, connector).UsingFilled(false).UsingGrowingEnd(end, true).UsingSkillMode(skill));
                     }
                 }
             }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/TempestHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/TempestHelper.cs
@@ -9,6 +9,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 
@@ -84,9 +85,7 @@ namespace GW2EIEvtcParser.EIData
                             continue;
                         }
                         (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                        var connector = new PositionConnector(effect.Position);
-                        replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                        replay.Decorations.Add(new IconDecoration(ParserIcons.EffectOverloadFire, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                        AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectOverloadFire);
                     }
                 }
             }
@@ -104,9 +103,7 @@ namespace GW2EIEvtcParser.EIData
                             continue;
                         }
                         (long, long) lifespan = effect.ComputeLifespan(log, 4000);
-                        var connector = new PositionConnector(effect.Position);
-                        replay.Decorations.Add(new CircleDecoration(360, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                        replay.Decorations.Add(new IconDecoration(ParserIcons.EffectOverloadAir, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                        AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectOverloadAir);
                     }
                 }
             }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.EIData.Buffs;
 using GW2EIEvtcParser.ParsedData;
@@ -74,6 +75,58 @@ namespace GW2EIEvtcParser.EIData
             new EngineerKitFinder(EliteMortarKit),
             new EffectCastFinderByDst(HealingMistOrSoothingDetonation, EffectGUIDs.EngineerHealingMist)
                 .UsingDstBaseSpecChecker(Spec.Engineer),
+            new EffectCastFinder(DetonateThrowMineOrMineField, EffectGUIDs.EngineerMineExplosion1)
+                .UsingSecondaryEffectChecker(EffectGUIDs.EngineerMineExplosion2)
+                .UsingChecker((effect, combatData, agentData, skillData) =>
+                {
+                    // If Throw Mine and Mine Field are precasted out of combat, there won't be an DynamicEffectEnd event so we use the custom ID
+                    if(combatData.TryGetEffectEventsBySrcWithGUIDs(effect.Src, 
+                        new string [] { EffectGUIDs.EngineerMineField, EffectGUIDs.EngineerThrowMineInactive1 }, out IReadOnlyList<EffectEvent> mines))
+                    {
+                        foreach(EffectEvent e in mines)
+                        {
+                            if (e.HasDynamicEndTime && Math.Abs(e.DynamicEndTime - effect.Time) < ServerDelayConstant)
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                    return true;
+                }),
+            new EffectCastFinder(DetonateMineField, EffectGUIDs.EngineerMineExplosion1)
+                .UsingSecondaryEffectChecker(EffectGUIDs.EngineerMineExplosion2)
+                .UsingChecker((effect, combatData, agentData, skillData) =>
+                {
+                    // Find the DynamicEffectEnd of Mine Field at the time of the explosion effects.
+                    if(combatData.TryGetEffectEventsBySrcWithGUID(effect.Src, EffectGUIDs.EngineerMineField, out IReadOnlyList<EffectEvent> mineFields))
+                    {
+                        foreach(EffectEvent e in mineFields)
+                        {
+                            if (e.HasDynamicEndTime && Math.Abs(e.DynamicEndTime - effect.Time) < ServerDelayConstant)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }),
+             new EffectCastFinder(DetonateThrowMine, EffectGUIDs.EngineerMineExplosion1)
+                .UsingSecondaryEffectChecker(EffectGUIDs.EngineerMineExplosion2)
+                .UsingChecker((effect, combatData, agentData, skillData) =>
+                {
+                    // Find the DynamicEffectEnd of Throw Mine at the time of the explosion effects.
+                    if(combatData.TryGetEffectEventsBySrcWithGUID(effect.Src, EffectGUIDs.EngineerThrowMineInactive1, out IReadOnlyList<EffectEvent> throwMines))
+                    {
+                        foreach(EffectEvent e in throwMines)
+                        {
+                            if (e.HasDynamicEndTime && Math.Abs(e.DynamicEndTime - effect.Time) < ServerDelayConstant)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                }),
         };
 
         internal static readonly List<DamageModifierDescriptor> OutgoingDamageModifiers = new List<DamageModifierDescriptor>
@@ -245,6 +298,99 @@ namespace GW2EIEvtcParser.EIData
                     replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
                     replay.Decorations.Add(new IconDecoration(ParserIcons.EffectThunderclap, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
                 }
+            }
+
+            // Throw Mine / Mine Field
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.EngineerMineExplosion1, out IReadOnlyList<EffectEvent> mineDetonations))
+            {
+                var throwMine = new SkillModeDescriptor(player, Spec.Engineer, ThrowMine, SkillModeCategory.Strip | SkillModeCategory.CC);
+                var mineField = new SkillModeDescriptor(player, Spec.Engineer, MineField);
+                var detonate = new SkillModeDescriptor(player, Spec.Engineer, DetonateThrowMineOrMineField);
+                var detonateThrowMine = new SkillModeDescriptor(player, Spec.Engineer, DetonateThrowMine, SkillModeCategory.Strip | SkillModeCategory.CC);
+                var detonateMineField = new SkillModeDescriptor(player, Spec.Engineer, DetonateMineField);
+
+                foreach (EffectEvent detonation in mineDetonations)
+                {
+                    bool isThrowMine = false;
+                    bool isMineField = false;
+
+                    // Check if the detonation is sourced by Throw Mine
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.EngineerThrowMineInactive1, out IReadOnlyList<EffectEvent> throwMines))
+                    {
+                        foreach (EffectEvent mine in throwMines)
+                        {
+                            if (mine.HasDynamicEndTime && Math.Abs(mine.DynamicEndTime - detonation.Time) < ServerDelayConstant)
+                            {
+                                isThrowMine = true;
+                                AddMineDecoration(log, replay, mine, color, throwMine, ParserIcons.EffectThrowMine);
+                                AddMineDetonationDecoration(log, replay, detonation, color, detonateThrowMine, 240);
+                            }
+                        }
+                    }
+
+                    // Check if the detonation is sourced by Mine Field
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.EngineerMineField, out IReadOnlyList<EffectEvent> mineFields))
+                    {
+                        // The mine field has 10 events, all using the same GUID, 5 with 0 duration and 5 with infinite duration, filter out half of them.
+                        foreach (EffectEvent mine in mineFields.Where(x => x.Duration > 0))
+                        {
+                            if (mine.HasDynamicEndTime && Math.Abs(mine.DynamicEndTime - detonation.Time) < ServerDelayConstant)
+                            {
+                                isMineField = true;
+                                AddMineDecoration(log, replay, mine, color, mineField, ParserIcons.EffectMineField);
+                                AddMineDetonationDecoration(log, replay, detonation, color, detonateMineField, 180);
+                            }
+                        }
+                    }
+
+                    // Throw Mine or Mine Field were placed before entering combat, log isn't aware of the source
+                    if (!isThrowMine && !isMineField)
+                    {
+                        AddMineDetonationDecoration(log, replay, detonation, color, detonate, 180, true);
+                    }
+                    
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds the decorations for <see cref="ThrowMine"/> or <see cref="MineField"/>.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="replay">The Combat Replay.</param>
+        /// <param name="effect">The mine effect.</param>
+        /// <param name="color">The specialization color.</param>
+        /// <param name="skill">The source skill.</param>
+        /// <param name="icon">The skill icon.</param>
+        private static void AddMineDecoration(ParsedEvtcLog log, CombatReplay replay, EffectEvent effect, Color color, SkillModeDescriptor skill, string icon)
+        {
+            (long, long) lifespan = effect.ComputeDynamicLifespan(log, 60000);
+            var connector = new PositionConnector(effect.Position);
+            replay.Decorations.Add(new CircleDecoration(120, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
+            replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+        }
+
+        /// <summary>
+        /// Adds the decorations for <see cref="DetonateThrowMine"/> or <see cref="DetonateMineField"/>.<br></br>
+        /// If the source of the detonation isn't known, use <see cref="DetonateThrowMineOrMineField"/>.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="replay">The Combat Replay.</param>
+        /// <param name="effect">The detonation effect.</param>
+        /// <param name="color">The specialization color.</param>
+        /// <param name="skill">The source skill.</param>
+        /// <param name="radius">The detonation radius.</param>
+        /// <param name="unknownSource">Wether the source skill is known or not.</param>
+        private static void AddMineDetonationDecoration(ParsedEvtcLog log, CombatReplay replay, EffectEvent effect, Color color, SkillModeDescriptor skill, uint radius, bool unknownSource = false)
+        {
+            (long, long) lifespan = effect.ComputeLifespan(log, 500);
+            var connector = new PositionConnector(effect.Position);
+            replay.Decorations.Add(new CircleDecoration(radius, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
+            replay.Decorations.Add(new IconDecoration(ParserIcons.EffectDetonateThrowMineOrMineField, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+            // If we do not know the source of the detonation, show both radiuses
+            if (unknownSource)
+            {
+                replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
             }
         }
     }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
@@ -7,6 +7,7 @@ using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
@@ -233,23 +234,23 @@ namespace GW2EIEvtcParser.EIData
         {
             var playerAgents = new HashSet<AgentItem>(players.Select(x => x.AgentItem));
 
-            HashSet<AgentItem> flameTurrets = ProfHelper.GetOffensiveGadgetAgents(combatData, FireTurretDamage, playerAgents);
+            HashSet<AgentItem> flameTurrets = GetOffensiveGadgetAgents(combatData, FireTurretDamage, playerAgents);
 
-            HashSet<AgentItem> rifleTurrets = ProfHelper.GetOffensiveGadgetAgents(combatData, RifleTurretDamage, playerAgents);
-            rifleTurrets.UnionWith(ProfHelper.GetOffensiveGadgetAgents(combatData, RifleTurretDamageUW, playerAgents));
+            HashSet<AgentItem> rifleTurrets = GetOffensiveGadgetAgents(combatData, RifleTurretDamage, playerAgents);
+            rifleTurrets.UnionWith(GetOffensiveGadgetAgents(combatData, RifleTurretDamageUW, playerAgents));
 
-            HashSet<AgentItem> netTurrets = ProfHelper.GetOffensiveGadgetAgents(combatData, NetTurretDamage, playerAgents);
-            netTurrets.UnionWith(ProfHelper.GetOffensiveGadgetAgents(combatData, NetTurretDamageUW, playerAgents));
+            HashSet<AgentItem> netTurrets = GetOffensiveGadgetAgents(combatData, NetTurretDamage, playerAgents);
+            netTurrets.UnionWith(GetOffensiveGadgetAgents(combatData, NetTurretDamageUW, playerAgents));
 
-            HashSet<AgentItem> rocketTurrets = ProfHelper.GetOffensiveGadgetAgents(combatData, RocketTurretDamage, playerAgents);
-            rocketTurrets.UnionWith(ProfHelper.GetOffensiveGadgetAgents(combatData, RocketTurretDamageUW, playerAgents));
+            HashSet<AgentItem> rocketTurrets = GetOffensiveGadgetAgents(combatData, RocketTurretDamage, playerAgents);
+            rocketTurrets.UnionWith(GetOffensiveGadgetAgents(combatData, RocketTurretDamageUW, playerAgents));
 
-            HashSet<AgentItem> thumperTurrets = ProfHelper.GetOffensiveGadgetAgents(combatData, ThumperTurret, playerAgents);
-            thumperTurrets.UnionWith(ProfHelper.GetOffensiveGadgetAgents(combatData, ThumperTurretUW, playerAgents));
+            HashSet<AgentItem> thumperTurrets = GetOffensiveGadgetAgents(combatData, ThumperTurret, playerAgents);
+            thumperTurrets.UnionWith(GetOffensiveGadgetAgents(combatData, ThumperTurretUW, playerAgents));
             // TODO: need ID here
-            HashSet<AgentItem> harpoonTurrets = ProfHelper.GetOffensiveGadgetAgents(combatData, Unknown, playerAgents);
+            HashSet<AgentItem> harpoonTurrets = GetOffensiveGadgetAgents(combatData, Unknown, playerAgents);
 
-            HashSet<AgentItem> healingTurrets = ProfHelper.GetOffensiveGadgetAgents(combatData, TurretExplosion, playerAgents);
+            HashSet<AgentItem> healingTurrets = GetOffensiveGadgetAgents(combatData, TurretExplosion, playerAgents);
             healingTurrets.RemoveWhere(x => thumperTurrets.Contains(x) || rocketTurrets.Contains(x) || netTurrets.Contains(x) || rifleTurrets.Contains(x) || flameTurrets.Contains(x) || harpoonTurrets.Contains(x));
 
             var engineers = players.Where(x => x.BaseSpec == Spec.Engineer).ToList();
@@ -257,21 +258,21 @@ namespace GW2EIEvtcParser.EIData
             if (engineers.Count == 1)
             {
                 Player engineer = engineers[0];
-                ProfHelper.SetGadgetMaster(flameTurrets, engineer.AgentItem);
-                ProfHelper.SetGadgetMaster(netTurrets, engineer.AgentItem);
-                ProfHelper.SetGadgetMaster(rocketTurrets, engineer.AgentItem);
-                ProfHelper.SetGadgetMaster(rifleTurrets, engineer.AgentItem);
-                ProfHelper.SetGadgetMaster(thumperTurrets, engineer.AgentItem);
-                ProfHelper.SetGadgetMaster(harpoonTurrets, engineer.AgentItem);
-                ProfHelper.SetGadgetMaster(healingTurrets, engineer.AgentItem);
+                SetGadgetMaster(flameTurrets, engineer.AgentItem);
+                SetGadgetMaster(netTurrets, engineer.AgentItem);
+                SetGadgetMaster(rocketTurrets, engineer.AgentItem);
+                SetGadgetMaster(rifleTurrets, engineer.AgentItem);
+                SetGadgetMaster(thumperTurrets, engineer.AgentItem);
+                SetGadgetMaster(harpoonTurrets, engineer.AgentItem);
+                SetGadgetMaster(healingTurrets, engineer.AgentItem);
             }
             else if (engineers.Count > 1)
             {
-                ProfHelper.AttachMasterToGadgetByCastData(combatData, flameTurrets, new List<long> { FlameTurretCast, SupplyCrate }, 1000);
-                ProfHelper.AttachMasterToGadgetByCastData(combatData, rifleTurrets, new List<long> { RifleTurretCast }, 1000);
-                ProfHelper.AttachMasterToGadgetByCastData(combatData, netTurrets, new List<long> { NetTurretCast, SupplyCrate, SupplyCrateUW }, 1000);
-                ProfHelper.AttachMasterToGadgetByCastData(combatData, rocketTurrets, new List<long> { RocketTurretCast, RocketTurretCast2, SupplyCrateUW }, 1000);
-                ProfHelper.AttachMasterToGadgetByCastData(combatData, thumperTurrets, new List<long> { ThumperTurretCast }, 1000);
+                AttachMasterToGadgetByCastData(combatData, flameTurrets, new List<long> { FlameTurretCast, SupplyCrate }, 1000);
+                AttachMasterToGadgetByCastData(combatData, rifleTurrets, new List<long> { RifleTurretCast }, 1000);
+                AttachMasterToGadgetByCastData(combatData, netTurrets, new List<long> { NetTurretCast, SupplyCrate, SupplyCrateUW }, 1000);
+                AttachMasterToGadgetByCastData(combatData, rocketTurrets, new List<long> { RocketTurretCast, RocketTurretCast2, SupplyCrateUW }, 1000);
+                AttachMasterToGadgetByCastData(combatData, thumperTurrets, new List<long> { ThumperTurretCast }, 1000);
                 //AttachMasterToGadgetByCastData(castData, harpoonTurrets, new List<long> { 6093, 6183 }, 1000);
                 //AttachMasterToGadgetByCastData(castData, healingTurrets, new List<long> { 5857, 5868 }, 1000);
             }
@@ -365,9 +366,7 @@ namespace GW2EIEvtcParser.EIData
         private static void AddMineDecoration(ParsedEvtcLog log, CombatReplay replay, EffectEvent effect, Color color, SkillModeDescriptor skill, string icon)
         {
             (long, long) lifespan = effect.ComputeDynamicLifespan(log, 60000);
-            var connector = new PositionConnector(effect.Position);
-            replay.Decorations.Add(new CircleDecoration(120, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-            replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+            AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 120, icon);
         }
 
         /// <summary>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/ScrapperHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/ScrapperHelper.cs
@@ -6,6 +6,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -70,9 +71,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in functionGyros)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectFunctionGyro, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectFunctionGyro);
                 }
             }
             // Defense Field
@@ -82,9 +81,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in defenseFields)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectDefenseField, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectDefenseField);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/FirebrandHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/FirebrandHelper.cs
@@ -5,6 +5,7 @@ using GW2EIEvtcParser.ParsedData;
 using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -141,9 +142,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in valiantBulwarks)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectValiantBulwark, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectValiantBulwark);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/FirebrandHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/FirebrandHelper.cs
@@ -145,6 +145,39 @@ namespace GW2EIEvtcParser.EIData
                     AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectValiantBulwark);
                 }
             }
+
+            // Stalwart Stand
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.FirebrandStalwartStand1, out IReadOnlyList<EffectEvent> stalwartStands))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Firebrand, Chapter4StalwartStand, SkillModeCategory.ImportantBuffs);
+                foreach (EffectEvent effect in stalwartStands)
+                {
+                    (long, long) lifespan = effect.ComputeLifespan(log, 4000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectStalwartStand);
+                }
+            }
+
+            // Shining River
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.FirebrandShiningRiver1, out IReadOnlyList<EffectEvent> shiningRiver))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Firebrand, Chapter4ShiningRiver, SkillModeCategory.Heal);
+                foreach (EffectEvent effect in shiningRiver)
+                {
+                    (long, long) lifespan = effect.ComputeLifespan(log, 4000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectShiningRiver);
+                }
+            }
+
+            // Scorched Aftermath
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.FirebrandScorchedAftermath1, out IReadOnlyList<EffectEvent> scorchedAftermath))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Firebrand, Chapter4ScorchedAftermath, SkillModeCategory.ShowOnSelect);
+                foreach (EffectEvent effect in scorchedAftermath)
+                {
+                    (long, long) lifespan = effect.ComputeLifespan(log, 4000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectScorchedAftermath);
+                }
+            }
         }
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.EIData.Buffs;
+using GW2EIEvtcParser.EncounterLogic;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.ArcDPSEnums;
@@ -202,10 +203,7 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, RingOfWarding, SkillModeCategory.CC);
                 foreach (EffectEvent effect in ringOfWardings)
                 {
-                    (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectRingOfWarding, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddGenericCircleDecoration(log, replay, effect, color, skill, 5000, 180, ParserIcons.EffectRingOfWarding);
                 }
             }
             // Line of Warding (Staff 5)
@@ -252,10 +250,7 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, ShieldOfTheAvenger, SkillModeCategory.ProjectileManagement);
                 foreach (EffectEvent effect in shieldOfTheAvengers)
                 {
-                    (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectShieldOfTheAvenger, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddGenericCircleDecoration(log, replay, effect, color, skill, 5000, 180, ParserIcons.EffectShieldOfTheAvenger);
                 }
             }
 
@@ -271,6 +266,90 @@ namespace GW2EIEvtcParser.EIData
                     replay.Decorations.Add(new IconDecoration(ParserIcons.EffectSignetOfMercy, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
                 }
             }
+
+            // Hunter's Ward
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.DragonhunterHuntersWardCage, out IReadOnlyList<EffectEvent> huntersWards))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Guardian, HuntersWard, SkillModeCategory.CC);
+                foreach (EffectEvent effect in huntersWards)
+                {
+                    long duration = log.FightData.Logic.SkillMode == FightLogic.SkillModeEnum.WvW ? 3000 : 5000;
+                    (long start, long end) lifespan = effect.ComputeDynamicLifespan(log, duration);
+                    var connector = new PositionConnector(effect.Position);
+                    replay.Decorations.Add(new CircleDecoration(140, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill)); // radius approximation
+                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectHuntersWard, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                }
+            }
+
+            // Symbol of Energy
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.DragonhunterSymbolOfEnergy, out IReadOnlyList<EffectEvent> symbolsOfEnergy))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfEnergy, SkillModeCategory.ShowOnSelect);
+                foreach (EffectEvent effect in symbolsOfEnergy)
+                {
+                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfEnergy);
+                }
+            }
+
+            // Symbol of Vengeance
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.FirebrandSymbolOfVengeance1, out IReadOnlyList<EffectEvent> symbolsOfVengeance))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfVengeance, SkillModeCategory.ShowOnSelect | SkillModeCategory.CC); // CC when traited
+                foreach(EffectEvent effect in symbolsOfVengeance)
+                {
+                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfVengeance);
+                }
+            }
+
+            // Symbol of Punishment
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.GuardianSymbolOfPunishment1, out IReadOnlyList<EffectEvent> symbolsOfPunishment))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfPunishment, SkillModeCategory.ShowOnSelect);
+                foreach (EffectEvent effect in symbolsOfPunishment)
+                {
+                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfPunishment);
+                }
+            }
+
+            // Symbol of Blades
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.GuardianSymbolOfBlades, out IReadOnlyList<EffectEvent> symbolsOfBlades))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfBlades, SkillModeCategory.ShowOnSelect);
+                foreach (EffectEvent effect in symbolsOfBlades)
+                {
+                    AddGenericCircleDecoration(log, replay, effect, color, skill, 5000, 180, ParserIcons.EffectSymbolOfBlades);
+                }
+            }
+
+            // Symbol of Resolution
+            if (log.CombatData.TryGetEffectEventsBySrcWithGUID(player.AgentItem, EffectGUIDs.GuardianSymbolOfResolution, out IReadOnlyList<EffectEvent> symbolsOfResolution))
+            {
+                var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfWrath_SymbolOfResolution, SkillModeCategory.ShowOnSelect);
+                foreach (EffectEvent effect in symbolsOfResolution)
+                {
+                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfResolution);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds generic circle decorations.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="replay">The Combat Replay.</param>
+        /// <param name="effect">The mine effect.</param>
+        /// <param name="color">The specialization color.</param>
+        /// <param name="skill">The source skill.</param>
+        /// <param name="icon">The skill icon.</param>
+        /// <param name="effectDuration">Effect duration.</param>
+        /// <param name="radius">Circle radius.</param>
+        /// <param name="icon">The skill icon.</param>
+        private static void AddGenericCircleDecoration(ParsedEvtcLog log, CombatReplay replay, EffectEvent effect, Color color, SkillModeDescriptor skill, long effectDuration, uint radius, string icon)
+        {
+            (long start, long end) lifespan = effect.ComputeLifespan(log, effectDuration);
+            var connector = new PositionConnector(effect.Position);
+            replay.Decorations.Add(new CircleDecoration(radius, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
+            replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
         }
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
@@ -7,6 +7,7 @@ using GW2EIEvtcParser.ParsedData;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using GW2EIEvtcParser.ParserHelpers;
@@ -203,7 +204,8 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, RingOfWarding, SkillModeCategory.CC);
                 foreach (EffectEvent effect in ringOfWardings)
                 {
-                    AddGenericCircleDecoration(log, replay, effect, color, skill, 5000, 180, ParserIcons.EffectRingOfWarding);
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 5000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectRingOfWarding);
                 }
             }
             // Line of Warding (Staff 5)
@@ -239,9 +241,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in sanctuaries)
                 {
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, 7000); // 7s with trait
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectSanctuary, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectSanctuary);
                 }
             }
             // Shield of the Avenger
@@ -250,7 +250,8 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, ShieldOfTheAvenger, SkillModeCategory.ProjectileManagement);
                 foreach (EffectEvent effect in shieldOfTheAvengers)
                 {
-                    AddGenericCircleDecoration(log, replay, effect, color, skill, 5000, 180, ParserIcons.EffectShieldOfTheAvenger);
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 5000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectShieldOfTheAvenger);
                 }
             }
 
@@ -261,9 +262,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in signetOfMercy)
                 {
                     (long, long) lifespan = (effect.Time, effect.Time + 500);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectSignetOfMercy, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectSignetOfMercy);
                 }
             }
 
@@ -275,9 +274,7 @@ namespace GW2EIEvtcParser.EIData
                 {
                     long duration = log.FightData.Logic.SkillMode == FightLogic.SkillModeEnum.WvW ? 3000 : 5000;
                     (long start, long end) lifespan = effect.ComputeDynamicLifespan(log, duration);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(140, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill)); // radius approximation
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectHuntersWard, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 140, ParserIcons.EffectHuntersWard); // radius approximation
                 }
             }
 
@@ -287,7 +284,8 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfEnergy, SkillModeCategory.ShowOnSelect);
                 foreach (EffectEvent effect in symbolsOfEnergy)
                 {
-                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfEnergy);
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 4000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectSymbolOfEnergy);
                 }
             }
 
@@ -297,7 +295,8 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfVengeance, SkillModeCategory.ShowOnSelect | SkillModeCategory.CC); // CC when traited
                 foreach(EffectEvent effect in symbolsOfVengeance)
                 {
-                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfVengeance);
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 4000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectSymbolOfVengeance);
                 }
             }
 
@@ -307,7 +306,8 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfPunishment, SkillModeCategory.ShowOnSelect);
                 foreach (EffectEvent effect in symbolsOfPunishment)
                 {
-                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfPunishment);
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 4000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectSymbolOfPunishment);
                 }
             }
 
@@ -317,7 +317,8 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfBlades, SkillModeCategory.ShowOnSelect);
                 foreach (EffectEvent effect in symbolsOfBlades)
                 {
-                    AddGenericCircleDecoration(log, replay, effect, color, skill, 5000, 180, ParserIcons.EffectSymbolOfBlades);
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 5000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectSymbolOfBlades);
                 }
             }
 
@@ -327,29 +328,10 @@ namespace GW2EIEvtcParser.EIData
                 var skill = new SkillModeDescriptor(player, Spec.Guardian, SymbolOfWrath_SymbolOfResolution, SkillModeCategory.ShowOnSelect);
                 foreach (EffectEvent effect in symbolsOfResolution)
                 {
-                    AddGenericCircleDecoration(log, replay, effect, color, skill, 4000, 180, ParserIcons.EffectSymbolOfResolution);
+                    (long start, long end) lifespan = effect.ComputeLifespan(log, 4000);
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectSymbolOfResolution);
                 }
             }
-        }
-
-        /// <summary>
-        /// Adds generic circle decorations.
-        /// </summary>
-        /// <param name="log">The log.</param>
-        /// <param name="replay">The Combat Replay.</param>
-        /// <param name="effect">The mine effect.</param>
-        /// <param name="color">The specialization color.</param>
-        /// <param name="skill">The source skill.</param>
-        /// <param name="icon">The skill icon.</param>
-        /// <param name="effectDuration">Effect duration.</param>
-        /// <param name="radius">Circle radius.</param>
-        /// <param name="icon">The skill icon.</param>
-        private static void AddGenericCircleDecoration(ParsedEvtcLog log, CombatReplay replay, EffectEvent effect, Color color, SkillModeDescriptor skill, long effectDuration, uint radius, string icon)
-        {
-            (long start, long end) lifespan = effect.ComputeLifespan(log, effectDuration);
-            var connector = new PositionConnector(effect.Position);
-            replay.Decorations.Add(new CircleDecoration(radius, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-            replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
         }
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
@@ -8,6 +8,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -64,9 +65,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfEternity)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 3000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfEternity, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfEternity);
                 }
             }
             // Well of Eternity - Pulses
@@ -123,9 +122,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfCalamity)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 3000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfCalamity, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfCalamity);
                 }
             }
             // Well of Calamity - Pulses
@@ -148,9 +145,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfPrecognition)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 3000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfPrecognition, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfPrecognition);
                 }
             }
             // Well of Precognition - Pulses
@@ -207,9 +202,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in gravityWells)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 3000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectGravityWell, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectGravityWell);
                 }
             }
             // Gravity Well - Pulses

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -8,6 +8,7 @@ using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
@@ -366,9 +367,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in feedbacks)
                 {
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, gw2Build >= GW2Builds.March2024BalanceAndCerusLegendary ? 6000 : 7000); // 7s with trait pre March 2024
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectFeedback, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectFeedback);
                 }
             }
             // Veil
@@ -391,9 +390,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in nullFields)
                 {
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, gw2Build >= GW2Builds.March2024BalanceAndCerusLegendary ? 5000 : 6000); // 6s with trait pre March 2024
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectNullField, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectNullField);
                 }
             }
 
@@ -404,9 +401,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in illusionOfLife)
                 {
                     (long, long) lifespan = (effect.Time, effect.Time + 500);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectIllusionOfLife, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectIllusionOfLife);
                 }
             }
 
@@ -455,9 +450,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in unstableBladestorm)
                 {
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, 6000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectUnstableBladestorm, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectUnstableBladestorm);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
@@ -8,6 +8,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 
@@ -124,9 +125,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in rainOfSwords)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 6000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(280, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectRainOfSwords, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 280, ParserIcons.EffectRainOfSwords);
                 }
             }
             // Thousand Cuts

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/HarbingerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/HarbingerHelper.cs
@@ -6,6 +6,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -72,9 +73,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in vitalDraws)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 3000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectVitalDraw, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectVitalDraw);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -7,6 +7,7 @@ using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
@@ -150,9 +151,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellOfBloods)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfBlood, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfBlood);
                 }
             }
             // Well of Suffering
@@ -162,9 +161,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellOfSufferings)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 6000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfSuffering, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfSuffering);
                 }
             }
             // Well of Darkness
@@ -174,9 +171,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellOfDarknesses)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfDarkness, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfDarkness);
                 }
             }
             // Well of Corruption
@@ -186,9 +181,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellOfCorruptions)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfCorruption, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfCorruption);
                 }
             }
             // Corrosive Poison Cloud
@@ -198,9 +191,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in poisonClouds)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 8000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectCorrosivePoisonCloud, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectCorrosivePoisonCloud);
                 }
             }
             // Plaguelands
@@ -256,9 +247,7 @@ namespace GW2EIEvtcParser.EIData
                         icon = ParserIcons.EffectMarkOfBloodOrChillblains;
                     }
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, fromDodge ? 6000 : 30000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.2, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.2f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, icon);
                 }
             }
             // Mark of Blood Activated (Staff 2)
@@ -268,9 +257,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in marksOfBloodActivated)
                 {
                     (long, long) lifespan = ((int)effect.Time, (int)effect.Time + 500);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(300, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectMarkOfBlood, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 300, ParserIcons.EffectMarkOfBlood);
                 }
             }
             // Chillblains Activated (Staff 3)
@@ -280,9 +267,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in chillblainsActivated)
                 {
                     (long, long) lifespan = ((int)effect.Time, (int)effect.Time + 500);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration( 300, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectChillblains, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 300, ParserIcons.EffectChillblains);
                 }
             }
 
@@ -293,9 +278,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in putridMarks)
                 {
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, 30000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.2, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectPutridMark, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.2f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectPutridMark);
                 }
             }
             // Putrid Mark (Staff 4) Activated
@@ -305,9 +288,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in putridMarksActivated)
                 {
                     (long, long) lifespan = ((int)effect.Time, (int)effect.Time + 500);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(300, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectPutridMark, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 300, ParserIcons.EffectPutridMark);
                 }
             }
 
@@ -318,9 +299,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in reapersMarks)
                 {
                     (long, long) lifespan = effect.ComputeDynamicLifespan(log, 30000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.2, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectReapersMark, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.2f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectReapersMark);
                 }
             }
             // Reaper's Mark (Staff 5) Activated
@@ -330,9 +309,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in reapersMarksActivated)
                 {
                     (long, long) lifespan = ((int)effect.Time, (int)effect.Time + 500);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(300, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectReapersMark, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 300, ParserIcons.EffectReapersMark);
                 }
             }
 
@@ -343,9 +320,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in signetOfUndeath)
                 {
                     (long, long) lifespan = ((int)effect.Time, (int)effect.Time + 500);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectSignetOfUndeath, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectSignetOfUndeath);
                 }
             }
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/ScourgeHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/ScourgeHelper.cs
@@ -7,6 +7,7 @@ using GW2EIEvtcParser.ParsedData;
 using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -99,9 +100,7 @@ namespace GW2EIEvtcParser.EIData
                         duration = log.LogData.GW2Build >= GW2Builds.July2023BalanceAndSilentSurfCM ? 8000 : 20000;
                     }
                     (long, long) lifespan = effect.ComputeLifespan(log, duration);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(180, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectShade, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 180, ParserIcons.EffectShade);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -630,5 +630,23 @@ namespace GW2EIEvtcParser.EIData
             }
             return res;
         }
+
+        /// <summary>
+        /// Adds generic circle decorations, to be used for player skills.
+        /// </summary>
+        /// <param name="replay">The Combat Replay.</param>
+        /// <param name="effect">The mine effect.</param>
+        /// <param name="color">The specialization color.</param>
+        /// <param name="skill">The source skill.</param>
+        /// <param name="icon">The skill icon.</param>
+        /// <param name="lifespan">Decoration lifespan.</param>
+        /// <param name="radius">Circle radius.</param>
+        /// <param name="icon">The skill icon.</param>
+        internal static void AddCircleSkillDecoration(CombatReplay replay, EffectEvent effect, Color color, SkillModeDescriptor skill, (long start, long end) lifespan, uint radius, string icon)
+        {
+            var connector = new PositionConnector(effect.Position);
+            replay.Decorations.Add(new CircleDecoration(radius, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
+            replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+        }
     }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/DruidHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/DruidHelper.cs
@@ -8,6 +8,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -71,9 +72,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in glyphOfTheStars)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(360, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectGlyphOfTheStars, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectGlyphOfTheStars);
                 }
             }
 
@@ -84,9 +83,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in glyphOfTheStarsCA)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(360, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectGlyphOfTheStarsCA, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectGlyphOfTheStarsCA);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -9,6 +9,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -332,20 +333,20 @@ namespace GW2EIEvtcParser.EIData
         {
             var playerAgents = new HashSet<AgentItem>(players.Select(x => x.AgentItem));
             // entangle works fine already
-            HashSet<AgentItem> jacarandaEmbraces = ProfHelper.GetOffensiveGadgetAgents(combatData, JacarandasEmbraceMinion, playerAgents);
-            HashSet<AgentItem> blackHoles = ProfHelper.GetOffensiveGadgetAgents(combatData, BlackHoleMinion, playerAgents);
+            HashSet<AgentItem> jacarandaEmbraces = GetOffensiveGadgetAgents(combatData, JacarandasEmbraceMinion, playerAgents);
+            HashSet<AgentItem> blackHoles = GetOffensiveGadgetAgents(combatData, BlackHoleMinion, playerAgents);
             var rangers = players.Where(x => x.BaseSpec == Spec.Ranger).ToList();
             // if only one ranger, could only be that one
             if (rangers.Count == 1)
             {
                 Player ranger = rangers[0];
-                ProfHelper.SetGadgetMaster(jacarandaEmbraces, ranger.AgentItem);
-                ProfHelper.SetGadgetMaster(blackHoles, ranger.AgentItem);
+                SetGadgetMaster(jacarandaEmbraces, ranger.AgentItem);
+                SetGadgetMaster(blackHoles, ranger.AgentItem);
             }
             else if (rangers.Count > 1)
             {
-                ProfHelper.AttachMasterToGadgetByCastData(combatData, jacarandaEmbraces, new List<long> { JacarandasEmbraceSkill }, 1000);
-                ProfHelper.AttachMasterToGadgetByCastData(combatData, blackHoles, new List<long> { BlackHoleSkill }, 1000);
+                AttachMasterToGadgetByCastData(combatData, jacarandaEmbraces, new List<long> { JacarandasEmbraceSkill }, 1000);
+                AttachMasterToGadgetByCastData(combatData, blackHoles, new List<long> { BlackHoleSkill }, 1000);
             }
         }
 
@@ -360,9 +361,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in hunkerDowns)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectHunkerDown, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectHunkerDown);
                 }
             }
             // Barrage
@@ -372,9 +371,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in barrages)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 600); // ~600ms interval
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(360, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectBarrage, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 360, ParserIcons.EffectBarrage);
                 }
             }
             // Bonfire
@@ -384,9 +381,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in bonfires)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 8000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectBonfire, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectBonfire);
                 }
             }
             // Frost Trap
@@ -396,9 +391,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in frostTraps)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 4000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectFrostTrap, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectFrostTrap);
                 }
             }
             // Flame Trap
@@ -408,9 +401,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in flameTraps)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 3000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectFlameTrap, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectFlameTrap);
                 }
             }
             // Viper's Nest
@@ -420,9 +411,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in vipersNests)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 3000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectVipersNest, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectVipersNest);
                 }
             }
             // Spike Trap
@@ -432,9 +421,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in spikeTraps)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 2000); // roughly time displayed ingame
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectSpikeTrap, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectSpikeTrap);
                 }
             }
             // Sublime Conversion

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using System;
@@ -333,9 +334,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in dropTheHammer)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 1220);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectDropTheHammer, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectDropTheHammer);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/SpecterHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/SpecterHelper.cs
@@ -7,6 +7,7 @@ using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
 using static GW2EIEvtcParser.EIData.DamageModifiersUtils;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
@@ -82,9 +83,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfGloom)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfGloom, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfGloom);
                 }
             }
             // Well of Bounty
@@ -94,9 +93,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfBounty)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfBounty, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfBounty);
                 }
             }
             // Well of Tears
@@ -106,9 +103,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfTears)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfTears, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfTears);
                 }
             }
             // Well of Silence
@@ -118,9 +113,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfSilence)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfSilence, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfSilence);
                 }
             }
             // Well of Sorrow
@@ -130,9 +123,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in wellsOfSorrow)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 5000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectWellOfSorrow, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectWellOfSorrow);
                 }
             }
             // Shadowfall
@@ -142,9 +133,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in shadowfalls)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 2250);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectShadowfall, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectShadowfall);
                 }
             }
         }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
@@ -7,6 +7,7 @@ using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.EIData.Buff;
 using static GW2EIEvtcParser.EIData.DamageModifier;
+using static GW2EIEvtcParser.EIData.ProfHelper;
 using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EIData.SkillModeDescriptor;
@@ -184,9 +185,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in sealAreaAoEs)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 8000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectSealArea, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectSealArea);
                 }
             }
             // Shadow Refuge
@@ -196,9 +195,7 @@ namespace GW2EIEvtcParser.EIData
                 foreach (EffectEvent effect in shadowRefuges)
                 {
                     (long, long) lifespan = effect.ComputeLifespan(log, 4000);
-                    var connector = new PositionConnector(effect.Position);
-                    replay.Decorations.Add(new CircleDecoration(240, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
-                    replay.Decorations.Add(new IconDecoration(ParserIcons.EffectShadowRefuge, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
+                    AddCircleSkillDecoration(replay, effect, color, skill, lifespan, 240, ParserIcons.EffectShadowRefuge);
                 }
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
@@ -74,7 +74,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                 new EffectCastFinder(FlashDischargeSAK, EffectGUIDs.SabirFlashDischarge)
                     .UsingChecker((effect, combatData, agentData, skillData) =>
                     {
-                        BuffRemoveAllEvent buffRemove = combatData.GetBuffRemoveAllData(ViolentCurrents).Where(x => Math.Abs(effect.Time - x.Time) < ServerDelayConstant).FirstOrDefault();
+                        BuffRemoveAllEvent buffRemove = combatData.GetBuffRemoveAllData(ViolentCurrents)
+                            .Where(x => Math.Abs(effect.Time - x.Time) < ServerDelayConstant && x.To == effect.Src)
+                            .FirstOrDefault();
                         return buffRemove != null;
                     }),
             };

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
@@ -20,7 +22,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 new PlayerDstSkillMechanic(DireDrafts, "Dire Drafts", new MechanicPlotlySetting(Symbols.Circle,Colors.Orange), "B.Tornado", "Hit by big tornado", "Big Tornado Hit", 500).UsingChecker((de, log) => de.HasDowned || de.HasKilled),
                 new PlayerDstSkillMechanic(UnbridledTempest, "Unbridled Tempest", new MechanicPlotlySetting(Symbols.Hexagon,Colors.Pink), "Shockwave", "Hit by Shockwave", "Shockwave Hit", 0).UsingChecker((de, log) => de.HasDowned || de.HasKilled),
                 new PlayerDstSkillMechanic(FuryOfTheStorm, "Fury of the Storm", new MechanicPlotlySetting(Symbols.Circle,Colors.Purple), "Arena AoE", "Hit by Arena wide AoE", "Arena AoE hit", 0).UsingChecker( (de, log) => de.HasDowned || de.HasKilled ),
-                new PlayerDstHitMechanic(new long [] { DynamicDeterrentNM, DynamicDeterrentCM }, "Dynamic Deterrent", new MechanicPlotlySetting(Symbols.YUpOpen,Colors.Pink), "Pushed", "Pushed by rotating breakbar", "Pushed", 0).UsingChecker((de, log) => !de.To.HasBuff(log, Stability, de.Time - ParserHelper.ServerDelayConstant)),
+                new PlayerDstHitMechanic(new long [] { DynamicDeterrentNM, DynamicDeterrentCM }, "Dynamic Deterrent", new MechanicPlotlySetting(Symbols.YUpOpen,Colors.Pink), "Pushed", "Pushed by rotating breakbar", "Pushed", 0).UsingChecker((de, log) => !de.To.HasBuff(log, Stability, de.Time - ServerDelayConstant)),
                 new PlayerDstHitMechanic(new long [] { StormsEdgeLeftHand, StormsEdgeRightHand }, "Storm's Edge", new MechanicPlotlySetting(Symbols.BowtieOpen, Colors.Blue), "Storm's Edge", "Hit by Storm's Edge", "Storm's Edge", 0),
                 new PlayerDstHitMechanic(ChainLightning, "Chain Lightning", new MechanicPlotlySetting(Symbols.HexagonOpen, Colors.White), "Chain Lightning", "Hit by Chain Lightning", "Chain Lightning Hit", 0),
                 new PlayerDstHitMechanic(Electrospark, "Electrospark", new MechanicPlotlySetting(Symbols.CircleCross, Colors.Orange), "Electrospark", "Hit by Electrospark", "Electrospark", 0),
@@ -69,7 +71,12 @@ namespace GW2EIEvtcParser.EncounterLogic
             return new List<InstantCastFinder>()
             {
                 new DamageCastFinder(BoltBreakSabir, BoltBreakSabir),
-                new EffectCastFinder(FlashDischargeSAK, EffectGUIDs.SabirFlashDischarge),
+                new EffectCastFinder(FlashDischargeSAK, EffectGUIDs.SabirFlashDischarge)
+                    .UsingChecker((effect, combatData, agentData, skillData) =>
+                    {
+                        BuffRemoveAllEvent buffRemove = combatData.GetBuffRemoveAllData(ViolentCurrents).Where(x => Math.Abs(effect.Time - x.Time) < ServerDelayConstant).FirstOrDefault();
+                        return buffRemove != null;
+                    }),
             };
         }
 

--- a/GW2EIEvtcParser/Extensions/ExtensionHandlers/HealingStats/HealingStatsExtensionHandler.cs
+++ b/GW2EIEvtcParser/Extensions/ExtensionHandlers/HealingStats/HealingStatsExtensionHandler.cs
@@ -28,7 +28,7 @@ namespace GW2EIEvtcParser.Extensions
             SymbolOfFaith,
             FaithfulStrike,
             SymbolOfSwiftness,
-            SymbolOfWrath,
+            SymbolOfWrath_SymbolOfResolution,
             SymbolOfProtection,
             SymbolOfSpears,
             SymbolOfLight,

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvents/EffectEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvents/EffectEvent.cs
@@ -175,12 +175,5 @@ namespace GW2EIEvtcParser.ParsedData
             }
             return (start, end);
         }
-
-        //public bool CanDynamicEndTime()
-        //{
-        //    return HasDynamicEndTime;
-        //}
-
-        //public long 
     }
 }

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvents/EffectEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvents/EffectEvent.cs
@@ -17,9 +17,9 @@ namespace GW2EIEvtcParser.ParsedData
         /// <summary>
         /// End of the effect, provided by an <see cref="EffectEndEvent"/>
         /// </summary>
-        private long DynamicEndTime { get; set; } = long.MinValue;
+        internal long DynamicEndTime { get; set; } = long.MinValue;
 
-        private bool HasDynamicEndTime => DynamicEndTime != long.MinValue;
+        internal bool HasDynamicEndTime => DynamicEndTime != long.MinValue;
 
         /// <summary>
         /// Duration of the effect in milliseconds.
@@ -175,5 +175,12 @@ namespace GW2EIEvtcParser.ParsedData
             }
             return (start, end);
         }
+
+        //public bool CanDynamicEndTime()
+        //{
+        //    return HasDynamicEndTime;
+        //}
+
+        //public long 
     }
 }

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -102,6 +102,7 @@ namespace GW2EIEvtcParser.ParsedData
             { SoothingDetonation, "Soothing Detonation" },
             { HealingTurretHeal, "Healing Turret (Heal)" },
             { BladeBurstOrParticleAccelerator, "Blade Burst or Particle Accelerator" },
+            { DetonateThrowMineOrMineField, "Detonate (Throw Mine / Mine Field)" },
             // Guardian
             { SelflessDaring, "Selfless Daring" }, // The game maps this name incorrectly to "Selflessness Daring"
             { ProtectorsStrikeCounterHit, "Protector's Strike (Counter Hit)" },
@@ -493,6 +494,7 @@ namespace GW2EIEvtcParser.ParsedData
             { JadeEnergyShot2JadeMech, "https://wiki.guildwars2.com/images/c/c0/Anchor.png" },
             { RifleBurstGrenadeDamage, "https://wiki.guildwars2.com/images/e/ed/Grenade_Barrage.png" },
             { GyroExplosion, "https://wiki.guildwars2.com/images/4/4e/Function_Gyro_%28tool_belt_skill%29.png" },
+            { DetonateThrowMineOrMineField, "https://wiki.guildwars2.com/images/d/d1/Detonate_Mine_Field.png" },
 #endregion EngineerIcons
             #region GuardianIcons
             { ProtectorsStrikeCounterHit, "https://wiki.guildwars2.com/images/e/e0/Protector%27s_Strike.png" },

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -846,7 +846,8 @@ namespace GW2EIEvtcParser.ParsedData
             { VolleyWvW, "https://wiki.guildwars2.com/images/5/5d/Volley.png" },
             { BleedingShotWvW, "https://wiki.guildwars2.com/images/9/97/Fierce_Shot.png" },
             { BolaTossWvW, "https://wiki.guildwars2.com/images/7/7e/Bola_Shot.png" },
-            { MagebaneTether, BuffImages.MagebaneTether },
+            { MagebaneTetherBuff, BuffImages.MagebaneTether },
+            { MagebaneTetherSkill, BuffImages.MagebaneTether },
             { EnchantmentCollapse, "https://wiki.guildwars2.com/images/7/7f/Enchantment_Collapse.png" },
             { LineBreakerHeal, "https://wiki.guildwars2.com/images/0/0e/Line_Breaker.png" },
             #endregion WarriorIcons

--- a/GW2EIEvtcParser/ParserHelpers/BuffImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/BuffImages.cs
@@ -84,7 +84,10 @@
         public const string ReaperOfGrenth = "https://wiki.guildwars2.com/images/0/07/Reaper_of_Grenth.png";
         public const string Charrzooka = "https://wiki.guildwars2.com/images/1/17/Charrzooka.png";
         // Guild
-        public const string GuildMagicFind = "https://wiki.guildwars2.com/images/c/c6/Guild_Magic_Find_Banner_Boost.png";
+        public const string GuildSwiftnessBanner = "https://wiki.guildwars2.com/images/4/45/Guild_Swiftness_Banner_Boost.png";
+        // Primers
+        public const string UtilityPrimer = "https://wiki.guildwars2.com/images/a/a8/Utility_Primer_%28effect%29.png";
+        public const string MetabolicPrimer = "https://wiki.guildwars2.com/images/a/af/Metabolic_Primer_%28effect%29.png";
         // Wing 4
         public const string CrystallineHeart = "https://wiki.guildwars2.com/images/5/56/Crystalline_Heart.png";
         // WvW

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -244,9 +244,11 @@ namespace GW2EIEvtcParser
         #region Engineer
         public const string EngineerHealingMist = "B02D3D0FF0A4FC47B23B1478D8E770AE"; // used with healing mist, soothing detonation
         public const string EngineerMagneticInversion = "F8BD502E5B0D9444AA6DC5B5918801EE";
-        public const string EngineerMineInactive = "2EE26B8656BD424B9BF9A7EA4CB0AA06";
-        public const string EngineerMineExplode1 = "885B7AAA68F09E48A926BFFE488DB5AD";
-        public const string EngineerMineExplode2 = "1B3ACEE36F61DE42AB1C24BD33B5B5AD";
+        public const string EngineerThrowMineInactive1 = "2EE26B8656BD424B9BF9A7EA4CB0AA06"; // infinite duration
+        public const string EngineerThrowMineInactive2 = "67649A4CB18C5C4A8D48ACFCF50B21CE"; // 0 duration
+        public const string EngineerMineField = "997750CA2636154E9FFBFEE4AA51A970"; // 0 duration and infinite duration, both logged at the same time
+        public const string EngineerMineExplosion1 = "885B7AAA68F09E48A926BFFE488DB5AD"; // 0 duration - Throw Mine and Mine Field use this effect
+        public const string EngineerMineExplosion2 = "1B3ACEE36F61DE42AB1C24BD33B5B5AD"; // 0 duration - Throw Mine and Mine Field use this effect
         public const string ScrapperThunderclap = "8C8E0AB8328CC1418F9A815E022E20B6"; // has owner, 5s duration
         public const string ScrapperThunderclapSpawn = "039F8B46E5595C4E9C2D52AA58FDD8B0"; // has owner, 1s duration
         public const string ScrapperFunctionGyro = "B4CA602E8A849F47BFC105C740005162"; // has owner, 5s duration

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -227,6 +227,12 @@ namespace GW2EIEvtcParser
         public const string GuardianSymbolOfResolution = "98C9834C6381204A85DC67C375D135E4"; // duration 4000
         public const string GuardianSymbolOfBlades = "FA37E0B77272314AA1ADCFF824F24C27"; // duration 5000
         public const string FirebrandValiantBulwark = "1430A107F74F164387668DE2744A1528";
+        public const string FirebrandStalwartStand1 = "E20B6672FDCE57409B229DB152BF2286"; // duration 4000
+        public const string FirebrandStalwartStand2 = "CA4F198982BFD44180D63EB043F9F710"; // duration 4000
+        public const string FirebrandShiningRiver1 = "D2803F97338434488CD789E22E797CE2"; // duration 4000
+        public const string FirebrandShiningRiver2 = "AEBF45AEDFF2CC48A64ED01441241288"; // duration 4000
+        public const string FirebrandScorchedAftermath1 = "3B0AF49A77811F4EA3CFD1BF671BDDE5"; // duration 4000
+        public const string FirebrandScorchedAftermath2 = "4CC8C2BAB89D1C488CD69D4F711D49B3"; // duration 0
         public const string FirebrandMantraOfLiberationCone = "86CC98C9D9D2B64689F8993AB02B09E5";
         public const string FirebrandMantraOfLiberationSymbol = "A8E0E4C48848424D85503B674015D247";
         public const string FirebrandMantraOfLoreCone = "C2B55AE44B295849A2983745203D19A1";

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -221,6 +221,11 @@ namespace GW2EIEvtcParser
         public const string GuardianShieldOfTheAvenger = "0885D553A0A0A341B4C31B7964243407";
         public const string GuardianSignetOfMercyLightTray = "E9D10435E997D846B736B62EDCC6B4BD"; // Duration 2000 - light ray at the start of the cast
         public const string GuardianSignetOfMercyEnd = "61ED02C4AA44C0429790A79E8EFCA7CC"; // Duration 0 - end cast
+        public const string GuardianSymbolOfPunishment1 = "D20225BED809BE4D86FFE87D6C5AD2B0"; // duration 5000
+        public const string GuardianSymbolOfPunishment2 = "5F56361FEE7463448CA988CE773F4F63"; // duration 6000 - has effect end after 5000
+        public const string GuardianSymbolOfPunishmentOrb = "A8C650860481DD48B1B41F76B3054576"; // duration 500
+        public const string GuardianSymbolOfResolution = "98C9834C6381204A85DC67C375D135E4"; // duration 4000
+        public const string GuardianSymbolOfBlades = "FA37E0B77272314AA1ADCFF824F24C27"; // duration 5000
         public const string FirebrandValiantBulwark = "1430A107F74F164387668DE2744A1528";
         public const string FirebrandMantraOfLiberationCone = "86CC98C9D9D2B64689F8993AB02B09E5";
         public const string FirebrandMantraOfLiberationSymbol = "A8E0E4C48848424D85503B674015D247";
@@ -237,9 +242,14 @@ namespace GW2EIEvtcParser
         public const string FirebrandTomeOfJusticeOpen = "D573910FDB59434ABF6E7433061995BD";
         public const string FirebrandTomeOfResolveOpen = "39C1BD24ADA04C4788A99C7B0FD9B53F";
         public const string FirebrandTomeOfCourageOpen = "9EE3EAFEF333BE44AD8A7D234A1C3899";
+        public const string FirebrandSymbolOfVengeance1 = "9E41C2BEFD43D64299C41FD6EFB9ECBE";
+        public const string FirebrandSymbolOfVengeance2 = "0B22F631EBB04341A17FDC57431385EB";
+        public const string FirebrandSymbolOfVengeance3 = "60C2DD0478450F4B81BAA6486227872A";
         public const string DragonhunterTrapEffect = "CCF55B3EAA4D514BBB8340E01B6A1DEC";
         public const string DragonhunterTestOfFaith = "D7006AC247BBE74BA54E912188EF6B12";
         public const string DragonhunterFragmentsOfFaith = "C84644DDAA59E542989FDB98CD69134C";
+        public const string DragonhunterHuntersWardCage = "F70A6157503537478331C8F82C0AB76E";
+        public const string DragonhunterSymbolOfEnergy = "8493CB203B40E04BAE5DC6F141B40743";
         #endregion
         #region Engineer
         public const string EngineerHealingMist = "B02D3D0FF0A4FC47B23B1478D8E770AE"; // used with healing mist, soothing detonation

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -614,6 +614,9 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string EffectEternitysRequiem = "https://i.imgur.com/weWJdsh.png";
         internal const string EffectCitadelBombardment = "https://i.imgur.com/IUZceLh.png";
         internal const string EffectCitadelBombardmentPortal = "https://i.imgur.com/sYUZpkj.png";
+        internal const string EffectThrowMine = "https://i.imgur.com/q9Z4xdI.png";
+        internal const string EffectMineField = "https://i.imgur.com/Miy0H2G.png";
+        internal const string EffectDetonateThrowMineOrMineField = "https://i.imgur.com/0Jbtf2q.png";
         #endregion
 
         #region Marker

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -623,6 +623,9 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string EffectSymbolOfResolution = "https://i.imgur.com/Vy3948S.png";
         internal const string EffectSymbolOfPunishment = "https://i.imgur.com/cSoxJvd.png";
         internal const string EffectSymbolOfBlades = "https://i.imgur.com/4vyfoTs.png";
+        internal const string EffectStalwartStand = "https://i.imgur.com/uBAyxRu.png";
+        internal const string EffectShiningRiver = "https://i.imgur.com/5ahjMoe.png";
+        internal const string EffectScorchedAftermath = "https://i.imgur.com/XvxyVC7.png";
         #endregion
 
         #region Marker

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -617,6 +617,12 @@ namespace GW2EIEvtcParser.ParserHelpers
         internal const string EffectThrowMine = "https://i.imgur.com/q9Z4xdI.png";
         internal const string EffectMineField = "https://i.imgur.com/Miy0H2G.png";
         internal const string EffectDetonateThrowMineOrMineField = "https://i.imgur.com/0Jbtf2q.png";
+        internal const string EffectHuntersWard = "https://i.imgur.com/Di7OvVr.png";
+        internal const string EffectSymbolOfEnergy = "https://i.imgur.com/tPaAF8S.png";
+        internal const string EffectSymbolOfVengeance = "https://i.imgur.com/1niDRW8.png";
+        internal const string EffectSymbolOfResolution = "https://i.imgur.com/Vy3948S.png";
+        internal const string EffectSymbolOfPunishment = "https://i.imgur.com/cSoxJvd.png";
+        internal const string EffectSymbolOfBlades = "https://i.imgur.com/4vyfoTs.png";
         #endregion
 
         #region Marker

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -2379,9 +2379,10 @@
         public const long EchoOfTrue = 42360;
         public const long TomeOfCourageOpen = 42404;
         public const long ElementsOfRage = 42416;
-        public const long MagebaneTether = 42428;
+        public const long MagebaneTetherBuff = 42428;
         public const long Chapter3HeatedRebuke = 42449;
         public const long LesserSignetOfStone = 42470;
+        public const long MagebaneTetherSkill = 43532;
         public const long BerserkersPower = 42539;
         public const long SoulcleavesSummitSkillMinion = 42614; // cast by created minion, does not hit
         public const long GrimSpecterBuff = 42651;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1076,6 +1076,13 @@
         public const long VirtueOfResolveBattlePresence = 17046;
         public const long VirtueOfResolveBattlePresenceAbsoluteResolve = 17047;
         public const long DeployGuildArrowCart = 17676;
+        public const long GuildSwiftnessBannerBoost = 17681;
+        public const long GuildGatheringBannerBoost = 17682;
+        public const long GuildKarmaBannerBoost = 17683;
+        public const long GuildMagicFindBannerBoost = 17684;
+        public const long GuildExperienceBannerBoost = 17685;
+        public const long GuildGoldBannerBoost15 = 17686;
+        public const long GuildGoldBannerBoost5 = 17690;
         public const long PlateOfSpicyHerbedChicken = 17823;
         public const long MushroomLoaf = 17822;
         public const long SpicyMarinatedMushroom = 17824;
@@ -1212,6 +1219,7 @@
         public const long IntenseFlameBlast = 21475;
         public const long ImpactSlam = 21479;
         public const long IronHideRam = 21484;
+        public const long MetabolicPrimer = 21487;
         public const long ElectricDischarge = 21636;
         public const long ArcaneBrilliance = 21656;
         public const long AED = 21660;
@@ -1313,6 +1321,7 @@
         public const long BowlOfSweetAndSpicyBeans = 24804;
         public const long BowlOfCactusSoup = 24807;
         public const long LeyLineFinisher = 25173;
+        public const long UtilityPrimer = 25179;
         public const long FeastOfDelectableBirthdayCake = 25318;
         public const long GuildFlagFinisher = 25435;
         public const long AvatarOfDeathFinisher = 25436;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -292,7 +292,7 @@
         public const long HolyStrike = 9140;
         public const long SymbolOfSwiftness = 9143;
         public const long LineOfWarding = 9144;
-        public const long SymbolOfWrath = 9146;
+        public const long SymbolOfWrath_SymbolOfResolution = 9146;
         public const long BindingBlade = 9148;
         public const long SignetOfJudgmentSkill = 9120;
         public const long HoldTheLine = 9152;
@@ -1522,6 +1522,7 @@
         public const long SoothingDetonation = 30564;
         public const long RapidRegeneration = 30581;
         public const long Vault = 30597;
+        public const long HuntersWard = 30628;
         public const long FeelTheBurn = 30662;
         public const long Suffer = 30670;
         public const long LightOnYourFeet = 30673;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -53,6 +53,7 @@
         public const long FirestormGlyphOfStormsOrFieryGreatsword = -34;
         public const long NumberOfRangerPets = -35;
         public const long AchievementEligibilityApathetic = -36;
+        public const long DetonateThrowMineOrMineField = -37;
         #endregion
         #region ArcDPS Hardcoded
         internal const long ArcDPSDodge = 65001;
@@ -254,6 +255,12 @@
         public const long RocketTurretDamage = 6108;
         public const long MagneticInversion = 6126;
         public const long OverchargedShot = 6154;
+        public const long POV_ThrowMineBuff = 6160;
+        public const long ThrowMine = 6161;
+        public const long DetonateThrowMine = 6162;
+        public const long MineField = 6164;
+        public const long POV_MineFieldBuff = 6165;
+        public const long DetonateMineField = 6166;
         public const long SupplyCrateUW = 6183;
         public const long HaresSpeedSkill = 6221;
         public const long WvWSpendingSupplies = 6852;


### PR DESCRIPTION
Added decorations:
- Throw Mine
- Mine Field
- Throw Mine Detonation
- Mine Field Detonation
- Generic Mine Detonation (in case of precast out of combat)
- Hunter's Ward
- Symbol of Energy
- Symbol of Vengeance
- Symbol of Punishment
- Symbol of Blades
- Symbol of Resolution
- Stalwart Stand
- Shining River
- Scorched Aftermath

Instant Casts:
- Detonate Throw Mine
- Detonate Mine Field
- Generic Detonate (in case of precast)
- Magebane Tether

Other:
- Added generic Skill ID for Detonate when the source is unknown.
- Moved Temporeal Anomaly from Trash to Secondary Targets to check who damaged them and the health in Combat Replay. They show up only on selected subphases like the Enforcers on Dhuum.
- Added AddCircleSkillDecoration in ProfHelper and moved profession skill decoration to be using this API when appropriate.
- Fixed a bug on Sabir where the Flash Discharge SAK would conflict with other skill effects