### PR TITLE
Added new relics, ranger pet and icons

### DIFF
--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -145,6 +145,8 @@ namespace GW2EIEvtcParser.EIData
             new EffectCastFinder(RelicOfTheWizardsTower, EffectGUIDs.RelicWhiteCircle)
                 .UsingSecondaryEffectChecker(EffectGUIDs.RelicOfTheWizardsTower)
                 .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfTheTwinGenerals, EffectGUIDs.RelicOfTheTwinGenerals)
+                .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EXTHealingCastFinder(RelicOfKarakosaHealing, RelicOfKarakosaHealing)
                 .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EXTHealingCastFinder(RelicOfNayosHealing, RelicOfNayosHealing)
@@ -154,6 +156,8 @@ namespace GW2EIEvtcParser.EIData
             new EXTHealingCastFinder(RelicOfTheFlock, RelicOfTheFlock)
                 .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EXTBarrierCastFinder(RelicOfTheFlockBarrier, RelicOfTheFlockBarrier)
+                .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EXTBarrierCastFinder(RelicOfTheFoundingBarrier, RelicOfTheFoundingBarrier)
                 .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             // Mounts
             new BuffGainCastFinder(BondOfLifeSkill, BondOfLifeBuff),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -92,6 +92,7 @@ namespace GW2EIEvtcParser.EIData
             (int)MinionID.JuvenileHyena,
             (int)MinionID.JuvenileAetherHunter,
             (int)MinionID.JuvenileSkyChakStriker,
+            (int)MinionID.JuvenileSpinegazer,
         };
 
         private static bool IsJuvenilePetID(int id)

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -765,9 +765,6 @@ namespace GW2EIEvtcParser.ParsedData
             { PhotosynthesizeJacaranda, "https://wiki.guildwars2.com/images/2/2f/Photosynthesize.png" },
             { EvilEye, "https://wiki.guildwars2.com/images/2/27/Evil_Eye.png" },
             { TormentingVisionSpinegazer, "https://wiki.guildwars2.com/images/0/0b/Tormenting_Visions.png" },
-            { Panopticon, "https://wiki.guildwars2.com/images/d/dd/Panopticon.png" },
-            { TormentingVisionsMergedSoulbeast, "https://wiki.guildwars2.com/images/0/0b/Tormenting_Visions.png" },
-            { StaringVoid, "https://wiki.guildwars2.com/images/9/9e/Staring_Void.png" },
             #endregion RangerIcons
             #region RevenantIcons
             { RiftSlashRiftHit, "https://wiki.guildwars2.com/images/a/a8/Rift_Slash.png" },

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -101,6 +101,7 @@ namespace GW2EIEvtcParser.ParsedData
             { RelicOfMercyHealing, "Relic of Mercy" },
             { MabonsStrength, "Relic of Mabon" },
             { NouryssHungerDamageBuff, "Relic of Nourys" },
+            { RelicOfTheFoundingBarrier, "Relic of the Founding (Barrier)" },
             // Elementalist
             { DualFireAttunement, "Dual Fire Attunement" },
             { FireWaterAttunement, "Fire Water Attunement" },
@@ -476,6 +477,8 @@ namespace GW2EIEvtcParser.ParsedData
             { RelicOfKarakosaHealing, "https://wiki.guildwars2.com/images/6/6e/Relic_of_Karakosa.png" },
             { RelicOfNayosHealing, "https://wiki.guildwars2.com/images/e/e4/Relic_of_Nayos.png" },
             { RelicOfTheDefenderHealing, BuffImages.RelicOfTheDefender },
+            { RelicOfTheFoundingBarrier, "https://wiki.guildwars2.com/images/8/81/Relic_of_the_Founding.png" },
+            { RelicOfTheTwinGenerals, "https://wiki.guildwars2.com/images/0/0e/Relic_of_the_Twin_Generals.png" },
 #endregion RelicIcons
             #region ElementalistIcons
             { DualFireAttunement, "https://wiki.guildwars2.com/images/b/b4/Fire_Attunement.png" },
@@ -760,6 +763,11 @@ namespace GW2EIEvtcParser.ParsedData
             { TakedownSmokescale, "https://wiki.guildwars2.com/images/e/e6/Takedown.png" },
             { PhasePounceWhiteTiger, "https://wiki.guildwars2.com/images/2/20/Phase_Pounce.png" },
             { PhotosynthesizeJacaranda, "https://wiki.guildwars2.com/images/2/2f/Photosynthesize.png" },
+            { EvilEye, "https://wiki.guildwars2.com/images/2/27/Evil_Eye.png" },
+            { TormentingVisionSpinegazer, "https://wiki.guildwars2.com/images/0/0b/Tormenting_Visions.png" },
+            { Panopticon, "https://wiki.guildwars2.com/images/d/dd/Panopticon.png" },
+            { TormentingVisionsMergedSoulbeast, "https://wiki.guildwars2.com/images/0/0b/Tormenting_Visions.png" },
+            { StaringVoid, "https://wiki.guildwars2.com/images/9/9e/Staring_Void.png" },
             #endregion RangerIcons
             #region RevenantIcons
             { RiftSlashRiftHit, "https://wiki.guildwars2.com/images/a/a8/Rift_Slash.png" },

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -1388,6 +1388,7 @@ namespace GW2EIEvtcParser
             JuvenilePhoenix = 25131,
             JuvenileAetherHunter = 25652,
             JuvenileSkyChakStriker = 26147,
+            JuvenileSpinegazer = 26220,
             // Guardian Weapon Summons
             BowOfTruth = 6383,
             HammerOfWisdom = 5791,

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -47,6 +47,7 @@ namespace GW2EIEvtcParser
         public const string RelicOfTheWizardsTower = "2A1D0C23F448C348A83E9A4F2669B73F";
         public const string RelicOfPeitha = "0CBFB70434661647B68003ECD77207E6"; // Projectile
         public const string RelicOfAkeem = "8181E21A43EAFB42BC8FFB001F02CF44"; // Target Src
+        public const string RelicOfTheTwinGenerals = "40ECD58F39B30041B3E6C7CEDB7C4D8C";
         #endregion
         #region Mesmer
         public const string MesmerThePrestigeDisappear1 = "48B69FBC3090E144BFC067D6C0208878";

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -491,6 +491,7 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string MinionJuvenileHyena = "https://i.imgur.com/XtYVyhH.png";
         private const string MinionJuvenileAetherHunter = "https://i.imgur.com/qMVHHki.png";
         private const string MinionSkyChakStriker = "https://i.imgur.com/bfmZsdK.png";
+        private const string MinionSpinegazer = "https://i.imgur.com/xCcnGrr.png"; // TODO update this image
         private const string MinionBloodFiend = "https://i.imgur.com/PrOpULe.png";
         private const string MinionBoneFiend = "https://i.imgur.com/BEntBIt.png";
         private const string MinionFleshGolem = "https://i.imgur.com/JkYUNug.png";
@@ -1369,6 +1370,7 @@ namespace GW2EIEvtcParser.ParserHelpers
             { MinionID.JuvenileHyena, MinionJuvenileHyena },
             { MinionID.JuvenileAetherHunter, MinionJuvenileAetherHunter },
             { MinionID.JuvenileSkyChakStriker, MinionSkyChakStriker },
+            { MinionID.JuvenileSpinegazer, MinionSpinegazer },
             { MinionID.BloodFiend, MinionBloodFiend },
             { MinionID.BoneFiend, MinionBoneFiend },
             { MinionID.FleshGolem, MinionFleshGolem },

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -4263,6 +4263,13 @@
         public const long RazorclawsRageSkillMinionReworked = 72370;
         public const long SoulcleavesSummitHitReworked = 72376;
         public const long RazorclawsRageHitReworked = 72388;
+        public const long TormentingVisionSpinegazer = 72527;
+        public const long RelicOfTheFoundingBarrier = 72548;
+        public const long EvilEye = 72603;
+        public const long TormentingVisionsMergedSoulbeast = 72636;
+        public const long RelicOfTheTwinGenerals = 72707;
+        public const long Panopticon = 72843;
+        public const long StaringVoid = 72851;
         #endregion
     }
 


### PR DESCRIPTION
Added:

- Relic of the Twin Generals
- Relic of the Founding
- Juvenile Spinegazer

I have added icons for the new pet skills and merged soulbeast skills because the API doesn't have them.
The Spinegazer image will need an update once the correct pet art is datamined and uploaded to the wiki.

[logs.zip](https://github.com/baaron4/GW2-Elite-Insights-Parser/files/15400947/logs.zip)
