### PR TITLE
Format numbers for better readability

### DIFF
--- a/GW2EIBuilders/Resources/JS/mixins.js
+++ b/GW2EIBuilders/Resources/JS/mixins.js
@@ -2,9 +2,8 @@
 
 var numberComponent = {
     methods: {
-        // https://stackoverflow.com/questions/16637051/adding-space-between-numbers
-        integerWithSpaces: function(x) {
-            return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+        formatNumber: function(x) {
+            return x.toLocaleString("fr").replace(",", "."); // french formatting uses spaces for thousands
         },
         round: function (value) {
             if (isNaN(value) || !isFinite(value)) {

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageTable.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayDamageTable.html
@@ -99,7 +99,7 @@
         },
         methods: {
             tableRound: function (value) {
-                return this.graphdata.damagemode == GraphType.Breakbar ? this.round1(value) : this.round(value)
+                return this.formatNumber(this.graphdata.damagemode == GraphType.Breakbar ? this.round1(value) : this.round(value));
             },
             sortBy: function (key, index) {
                 this.sortByBase(this.sortdata, key, index);

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStatus.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStatus.html
@@ -1,6 +1,6 @@
 <template>
     <div class="d-flex flex-column justify-content-center align-items-center">
-        <div class="target-status" :style="{'background': getHPGradient(time, status)}" @click="select" :title="target.name + ' - ' + target.health + ' health'">
+        <div class="target-status" :style="{'background': getHPGradient(time, status)}" @click="select" :title="target.name + ' - ' + formatNumber(target.health) + ' health'">
             <h6 class="actor-shorten-cr text-center">
                 <img v-for="(marker, index) in activeMarkers()" :src="marker.imageUrl" height="16" width="16">
                 <img :src="target.icon" height="18" width="18"/>
@@ -26,6 +26,7 @@
 
 <script>
     Vue.component("combat-replay-target-status-component", {
+        mixins: [numberComponent],
         props: ["targetindex", "time"],
         template: `${template}`,
         methods: {

--- a/GW2EIBuilders/Resources/ei.js
+++ b/GW2EIBuilders/Resources/ei.js
@@ -6,7 +6,7 @@ function compileTemplates() {
         template: '<div :id="id" class="d-flex flex-row justify-content-center"></div>',
         activated: function () {
             var div = document.querySelector(this.queryID);
-            Plotly.react(div, this.data, this.layout, { showEditInChartStudio: true, plotlyServerURL: "https://chart-studio.plotly.com" });
+            Plotly.react(div, this.data, this.layout, { locale: "custom", showEditInChartStudio: true, plotlyServerURL: "https://chart-studio.plotly.com" });
             var _this = this;
             div.on('plotly_animated', function () {
                 Plotly.relayout(div, _this.layout);
@@ -277,6 +277,14 @@ function mainLoad() {
 
 window.onload = function () {
     Vue.config.devtools = true;
+    Plotly.register({
+        moduleType: "locale",
+        name: "custom",
+        format: {
+            decimal: ".",
+            thousands: " "
+        }
+    });
     // trick from
     var img = document.createElement("img");
     img.style.display = "none";

--- a/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplBarrierDistTable.html
+++ b/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplBarrierDistTable.html
@@ -114,17 +114,17 @@
                     <td :class="getBodyClass('Data', 0)">
                         {{ round3(100*getBarrierOutput(row)/barrierdist.contributedBarrier) }}%
                     </td>
-                    <td :class="getBodyClass('Data', 1)" :data-original-title="round2(getBarrierOutput(row)/phase.durationS) +' hps'">
-                        {{ getBarrierOutput(row) }}
+                    <td :class="getBodyClass('Data', 1)" :data-original-title="formatNumber(round2(getBarrierOutput(row)/phase.durationS)) +' hps'">
+                        {{ formatNumber(getBarrierOutput(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 2)">
-                        {{ getMinBarrier(row) }}
+                        {{ formatNumber(getMinBarrier(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 3)">
-                        {{ round(getBarrierOutput(row)/getConnectedHits(row)) }}
+                        {{ formatNumber(round(getBarrierOutput(row)/getConnectedHits(row))) }}
                     </td>
                     <td :class="getBodyClass('Data', 4)">
-                        {{ getMaxBarrier(row) }}
+                        {{ formatNumber(getMaxBarrier(row)) }}
                     </td>
                     <td :class="getCastBodyClass('Data', 5, row)" v-if="actor !== null">
                         {{ (!getSkill(row).condi && getCast(row)) ? getCast(row) : ''}}
@@ -162,7 +162,7 @@
                     <td class="text-left">Total</td>
                     <td></td>
                     <td :data-original-title="Math.round(barrierdist.contributedBarrier/phase.durationS) +' hps'">
-                        {{barrierdist.contributedBarrier}}
+                        {{ formatNumber(barrierdist.contributedBarrier) }}
                     </td>
                     <td></td>
                     <td></td>
@@ -171,7 +171,7 @@
                     <td></td>
                     <td v-if="actor !== null"></td>
                     <td v-if="actor !== null">
-                        {{round2(barrierdist.contributedBarrier/(0.001 * barrierdist.totalCasting))}}
+                        {{ formatNumber(round2(barrierdist.contributedBarrier/(0.001 * barrierdist.totalCasting))) }}
                     </td>
                     <td v-if="actor !== null"></td>
                     <td v-if="actor !== null"></td>

--- a/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplHealingDistTable.html
+++ b/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplHealingDistTable.html
@@ -121,19 +121,19 @@
                         {{ round3(100*getHealingOutput(row)/healingdist.contributedHealing) }}%
                     </td>
                     <td :class="getBodyClass('Data', 1)" :data-original-title="round2(getHealingOutput(row)/phase.durationS) +' hps'">
-                        {{ getHealingOutput(row) }}
+                        {{ formatNumber(getHealingOutput(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 2)" :data-original-title="round2(getDownedHealingOutput(row)/phase.durationS) +' hps'">
-                        {{ getDownedHealingOutput(row) }}
+                        {{ formatNumber(getDownedHealingOutput(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 3)">
-                        {{ getMinHealing(row) }}
+                        {{ formatNumber(getMinHealing(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 4)">
-                        {{ round(getHealingOutput(row)/getConnectedHits(row)) }}
+                        {{ formatNumber(round(getHealingOutput(row)/getConnectedHits(row))) }}
                     </td>
                     <td :class="getBodyClass('Data', 5)">
-                        {{ getMaxHealing(row) }}
+                        {{ formatNumber(getMaxHealing(row)) }}
                     </td>
                     <td :class="getCastBodyClass('Data', 6, row)" v-if="actor !== null">
                         {{ (!getSkill(row).condi && getCast(row)) ? getCast(row) : ''}}
@@ -145,7 +145,7 @@
                         {{(!getSkill(row).condi && getConnectedHits(row) && getCast(row)) ? round2(getConnectedHits(row)/getCast(row)) : ''}}
                     </td>
                     <td :class="getBodyClass('Data', 9)" v-if="actor !== null">
-                        {{(!getSkill(row).condi && getConnectedHits(row) && getCastDuration(row)) ? round2(getHealingOutput(row)/(0.001 * getCastDuration(row))) : ''}}
+                        {{(!getSkill(row).condi && getConnectedHits(row) && getCastDuration(row)) ? formatNumber(round2(getHealingOutput(row)/(0.001 * getCastDuration(row)))) : ''}}
                     </td>
                     <td :class="getBodyClass('Data', 12)" v-if="actor !== null" >
                         {{ getCastDurationNoInterrupt(row) ? round3(0.001 * getMinCastingTimeNoInterrupt(row)) + 's': ' '}}

--- a/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplIncomingHealingTable.html
+++ b/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplIncomingHealingTable.html
@@ -55,7 +55,7 @@
                         {{row.player.acc}}
                     </td>
                     <td v-for="(value, index) in row.incomingHeal" :class="getBodyClass('Data', index)">
-                        {{value}}
+                        {{ formatNumber(value) }}
                     </td>
                 </tr>
             </tbody>
@@ -68,7 +68,7 @@
                     </td>
                     <td></td>
                     <td v-for="(value, index) in sum.incomingHeal">
-                        {{value}}
+                        {{ formatNumber(value) }}
                     </td>
                 </tr>
             </tfoot>

--- a/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplOutgoingHealingTable.html
+++ b/GW2EIBuilders/Resources/htmlHealingExtensionTemplates/tmplOutgoingHealingTable.html
@@ -85,12 +85,12 @@
                         {{row.player.acc}}
                     </td>
                     <td v-if="!showHealing" v-for="(value, index) in row.hps" :class="getBodyClass('Data', index)"
-                        :data-original-title="value + ' total' + '<br>' + computeTotalContribution(index, row.hps,tableData.sums)+ '<br>'+ computeGroupContribution(row.player.group, index, row.hps,tableData.sums)">
-                        {{round(value/phase.durationS)}}                
+                        :data-original-title="formatNumber(value) + ' total' + '<br>' + computeTotalContribution(index, row.hps,tableData.sums)+ '<br>'+ computeGroupContribution(row.player.group, index, row.hps,tableData.sums)">
+                        {{ formatNumber(round(value/phase.durationS)) }}                
                     </td>
                     <td v-if="showHealing" v-for="(value, index) in row.hps" :class="getBodyClass('Data', index)"
-                        :data-original-title="round(value/phase.durationS) + ' per second' + '<br>' + computeTotalContribution(index, row.hps,tableData.sums)+ '<br>'+ computeGroupContribution(row.player.group, index, row.hps,tableData.sums)">
-                        {{value}}               
+                        :data-original-title="formatNumber(round(value/phase.durationS)) + ' per second' + '<br>' + computeTotalContribution(index, row.hps,tableData.sums)+ '<br>'+ computeGroupContribution(row.player.group, index, row.hps,tableData.sums)">
+                        {{ formatNumber(value) }}               
                     </td>
                 </tr>
             </tbody>
@@ -102,11 +102,11 @@
                         {{sum.name}}
                     </td>
                     <td></td>
-                    <td v-if="!showHealing" v-for="(value, index) in sum.hps" :data-original-title="value + ' healing'">
-                        {{round(value/phase.durationS)}}                
+                    <td v-if="!showHealing" v-for="(value, index) in sum.hps" :data-original-title="formatNumber(value) + ' healing'">
+                        {{ formatNumber(round(value/phase.durationS)) }}
                     </td>
-                    <td v-if="showHealing" v-for="(value, index) in sum.hps" :data-original-title="round(value/phase.durationS) + ' hps'">
-                        {{value}}               
+                    <td v-if="showHealing" v-for="(value, index) in sum.hps" :data-original-title="formatNumber(round(value/phase.durationS)) + ' hps'">
+                        {{ formatNumber(value) }}               
                     </td>
                 </tr>
             </tfoot>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDamageDistTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDamageDistTable.html
@@ -4,21 +4,21 @@
             <div v-if="isminion">
                 <p style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedDamage/dmgdist.totalDamage)}}% of its master's total
-                    {{istarget ? 'Target' :''}} damage ({{dmgdist.contributedDamage}})
+                    {{istarget ? 'Target' :''}} damage ({{ formatNumber(dmgdist.contributedDamage) }})
                 </p>
                 <p v-if="hasBreakbarDamage && dmgdist.contributedBreakbarDamage > 0" style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedBreakbarDamage/dmgdist.totalBreakbarDamage)}}% of its master's total
-                    {{istarget ? 'Target' :''}} breakbar damage ({{round1(dmgdist.contributedBreakbarDamage)}})
+                    {{istarget ? 'Target' :''}} breakbar damage ({{ formatNumber(round1(dmgdist.contributedBreakbarDamage)) }})
                 </p>
             </div>
             <div v-else>
                 <p style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedDamage/dmgdist.totalDamage)}}% of their total {{istarget ?
-                        'Target' :''}} damage ({{dmgdist.contributedDamage}})
+                        'Target' :''}} damage ({{ formatNumber(dmgdist.contributedDamage) }})
                 </p>              
                 <p v-if="hasBreakbarDamage && dmgdist.contributedBreakbarDamage > 0" style="display: table-row;">
                     {{actor.name}} did {{round3(100*dmgdist.contributedBreakbarDamage/dmgdist.totalBreakbarDamage)}}% of their total
-                    {{istarget ? 'Target' :''}} breakbar damage ({{round1(dmgdist.contributedBreakbarDamage)}})
+                    {{istarget ? 'Target' :''}} breakbar damage ({{ formatNumber(round1(dmgdist.contributedBreakbarDamage)) }})
                 </p>
             </div>
         </div>
@@ -164,31 +164,31 @@
                         {{getSkill(row).name.length > 15 ? (getSkill(row).name.slice(0, 15)) + '...': getSkill(row).name}}
                     </td>
                     <td :class="getBodyClass('Data', 0)">
-                        {{ round3(100*getDamage(row)/dmgdist.contributedDamage) }}%
+                        {{ formatNumber(round3(100*getDamage(row)/dmgdist.contributedDamage)) }}%
                     </td>
                     <td :class="getBodyClass('Data', 1)"
-                        :data-original-title="round2(getDamage(row)/phase.durationS) +' dps'">
-                        {{ getDamage(row) }}
+                        :data-original-title="formatNumber(round2(getDamage(row)/phase.durationS)) +' dps'">
+                        {{ formatNumber(getDamage(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 2)"
-                        :data-original-title="round2(getBarrierDamage(row)/phase.durationS) +' dps'">
-                        {{ getBarrierDamage(row) }}
+                        :data-original-title="formatNumber(round2(getBarrierDamage(row)/phase.durationS)) +' dps'">
+                        {{ formatNumber(getBarrierDamage(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 3)">
-                        {{ getMinDamage(row) }}
+                        {{ formatNumber(getMinDamage(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 4)">
-                        {{ round(getDamage(row)/getConnectedHits(row)) }}
+                        {{ formatNumber(round(getDamage(row)/getConnectedHits(row))) }}
                     </td>
                     <td :class="getBodyClass('Data', 5)">
-                        {{ getMaxDamage(row) }}
+                        {{ formatNumber(getMaxDamage(row)) }}
                     </td>
                     <td :class="getBodyClass('Data', 6)" v-if="hasBreakbarDamage">
-                        {{ round3(100*getBreakbarDamage(row)/dmgdist.contributedBreakbarDamage) }}%
+                        {{ formatNumber(round3(100*getBreakbarDamage(row)/dmgdist.contributedBreakbarDamage)) }}%
                     </td>
                     <td :class="getBodyClass('Data', 7)" v-if="hasBreakbarDamage" 
                         :data-original-title="round2(getBreakbarDamage(row)/phase.durationS) +' bps'">
-                        {{ getBreakbarDamage(row) }}
+                        {{ formatNumber(getBreakbarDamage(row)) }}
                     </td>
                     <td :class="getCastBodyClass('Data', 8, row)" v-if="actor !== null">
                         {{ (!getSkill(row).condi && getCast(row)) ? getCast(row) : ''}}
@@ -202,7 +202,7 @@
                         {{(!getSkill(row).condi && getConnectedHits(row) && getCast(row)) ? round2(getConnectedHits(row)/getCast(row)) : ''}}
                     </td>
                     <td :class="getBodyClass('Data', 11)" v-if="actor !== null">
-                        {{(!getSkill(row).condi && getConnectedHits(row) && getCastDuration(row)) ? round2(getDamage(row)/(0.001 * getCastDuration(row))) : ''}}
+                        {{(!getSkill(row).condi && getConnectedHits(row) && getCastDuration(row)) ? formatNumber(round2(getDamage(row)/(0.001 * getCastDuration(row)))) : ''}}
                     </td>              
                     <td :class="getBodyClass('Data', 18)" v-if="actor !== null" >
                         {{ getCastDurationNoInterrupt(row) ? round3(0.001 * getMinCastingTimeNoInterrupt(row)) + 's': ' '}}
@@ -245,11 +245,11 @@
                         Total
                     </td>
                     <td></td>
-                    <td :data-original-title="Math.round(dmgdist.contributedDamage/phase.durationS) +' dps'">
-                        {{dmgdist.contributedDamage}}
+                    <td :data-original-title="formatNumber(Math.round(dmgdist.contributedDamage/phase.durationS)) +' dps'">
+                        {{ formatNumber(dmgdist.contributedDamage) }}
                     </td>
-                    <td :data-original-title="Math.round(dmgdist.contributedShieldDamage/phase.durationS) +' dps'">
-                        {{dmgdist.contributedShieldDamage}}
+                    <td :data-original-title="formatNumber(Math.round(dmgdist.contributedShieldDamage/phase.durationS)) +' dps'">
+                        {{ formatNumber(dmgdist.contributedShieldDamage) }}
                     </td>
                     <td></td>
                     <td></td>
@@ -262,7 +262,7 @@
                     <td></td>
                     <td v-if="actor !== null"></td>
                     <td v-if="actor !== null">
-                        {{round2(dmgdist.contributedDamage/(0.001 * dmgdist.totalCasting))}}
+                        {{ formatNumber(round2(dmgdist.contributedDamage/(0.001 * dmgdist.totalCasting))) }}
                     </td>
                     <td v-if="actor !== null"></td>
                     <td v-if="actor !== null"></td>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDamageModifierTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDamageModifierTable.html
@@ -285,9 +285,9 @@
                 } else {
                     gain = "Pure Damage: ";
                 }
-                gain += this.round(item[2]);
+                gain += this.formatNumber(this.round(item[2]));
                 if (mod.nonMultiplier) {
-                    gain += "<br>Total Damage: " + this.round3(100.0 * item[2] / item[3]) + "%";
+                    gain += "<br>Total Damage: " + this.formatNumber(this.round3(100.0 * item[2] / item[3])) + "%";
                 }
                 return res + "<br>" + gain;
             },
@@ -314,7 +314,7 @@
                 if (Math.abs(damageIncrease) < 1e-6 || isNaN(damageIncrease) || !isFinite(damageIncrease)) {
                     return "-";
                 }
-                return damageIncrease + '%';
+                return this.formatNumber(damageIncrease) + '%';
             }
         },
     });

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDamageTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDamageTable.html
@@ -61,7 +61,7 @@
                         {{getPlayerCell(2, row)}}</td>
                     <td v-if="!targetless && hasBreakbarDamage" :class="getBodyClass('Data', 3)"
                         :data-original-title="computeTotalContribution(3, row.dps,tableData.sums)+ '<br>'+ computeGroupContribution(row.player.group, 3, row.dps,tableData.sums)">
-                        {{round1(row.dps[3])}}
+                        {{ formatNumber(round1(row.dps[3])) }}
                     </td>
                     <td :class="getBodyClass('Data', 4)"
                         :data-original-title="getPlayerTooltip(4, row, tableData.sums)">
@@ -75,7 +75,7 @@
 
                     <td v-if="hasBreakbarDamage" :class="getBodyClass('Data', 7)"
                         :data-original-title="computeTotalContribution(7, row.dps,tableData.sums)+ '<br>'+ computeGroupContribution(row.player.group, 7, row.dps,tableData.sums)">
-                        {{round1(row.dps[7])}}
+                        {{ formatNumber(round1(row.dps[7])) }}
                     </td>
                 </tr>
             </tbody>
@@ -92,7 +92,7 @@
                     <td v-if="!targetless" :data-original-title="getSumTooltip(2, sum)">
                         {{getSumCell(2, sum)}}</td>
                     <td v-if="!targetless && hasBreakbarDamage">
-                        {{round1(sum.dps[3])}}
+                        {{ formatNumber(round1(sum.dps[3])) }}
                     </td>
                     <td :data-original-title="getSumTooltip(4, sum)">
                         {{getSumCell(4, sum)}}</td>
@@ -101,7 +101,7 @@
                     <td :data-original-title="getSumTooltip(6, sum)">
                         {{getSumCell(6, sum)}}</td>
                     <td v-if="hasBreakbarDamage">
-                        {{round1(sum.dps[7])}}
+                        {{ formatNumber(round1(sum.dps[7])) }}
                     </td>
                 </tr>
             </tfoot>
@@ -176,18 +176,18 @@
                 return this.round2(row[index] * 100 / sums[sumId].dps[index]) + '% of group';
             },
             getPlayerTooltip: function(index, row, sums) {
-                return (!this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS)) + ' damage'+
+                return this.formatNumber(!this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS)) + ' damage'+
                  '<br>' + this.computeTotalContribution(index, row.dps, sums) +
                  '<br>'+ this.computeGroupContribution(row.player.group, index, row.dps, sums);
             },
             getPlayerCell: function(index, row) {
-                return this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS)
+                return this.formatNumber(this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS));
             },
             getSumTooltip: function(index, row) {
-                return (!this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS)) + ' damage';
+                return this.formatNumber(!this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS)) + ' damage';
             },
             getSumCell: function(index, row) {
-                return this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS)
+                return this.formatNumber(this.showDamage ? row.dps[index] : this.round(row.dps[index]/this.phase.durationS));
             }
         },
         computed: {

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplDefenseTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplDefenseTable.html
@@ -102,10 +102,10 @@
                         {{row.player.acc}}
                     </td>
                     <td :class="getBodyClass('Data', 0)">
-                        {{row.def[0]}}
+                        {{ formatNumber(row.def[0]) }}
                     </td>
                     <td :class="getBodyClass('Data', 1)">
-                        {{row.def[1]}}
+                        {{ formatNumber(row.def[1]) }}
                     </td>
                     <td :class="getBodyClass('Data', 2)">
                         {{row.def[2]}}
@@ -135,7 +135,7 @@
                         {{row.def[12]}}
                     </td>
                     <td :class="getBodyClass('Data', 16)">
-                        {{row.def[16]}}
+                        {{ formatNumber(row.def[16]) }}
                     </td>
                     <td :class="getBodyClass('Data', 14)" :data-original-title="row.def[15]">
                         {{row.def[14]}}
@@ -148,8 +148,8 @@
                     <td></td>
                     <td class="text-left">{{sum.name}}</td>
                     <td></td>
-                    <td>{{sum.def[0]}}</td>
-                    <td>{{sum.def[1]}}</td>
+                    <td>{{ formatNumber(sum.def[0]) }}</td>
+                    <td>{{ formatNumber(sum.def[1]) }}</td>
                     <td>{{sum.def[2]}}</td>
                     <td>
                         {{sum.def[3]}}
@@ -161,7 +161,7 @@
                     <td>{{sum.def[8]}}</td>
                     <td>{{sum.def[10]}}</td>
                     <td>{{sum.def[12]}}</td>
-                    <td>{{sum.def[16]}}</td>
+                    <td>{{ formatNumber(sum.def[16]) }}</td>
                     <td>{{sum.def[14]}}</td>
                 </tr>
             </tfoot>

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplEncounter.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplEncounter.html
@@ -19,7 +19,7 @@
                             {{target.name}}
                         </div>
                         <div v-if="target.health > 0" class="super-small" style="text-align:center;">
-                            {{ target.health }} Health
+                            {{ formatNumber(target.health) }} Health
                         </div>
                         <div :data-original-title="healthRemaining(target)">
                             <div :style="{'background': getGradient(target), 'height': '10px', 'width': '100%', 'border-radius': '5px'}">
@@ -45,6 +45,7 @@
 
 <script>
     Vue.component("encounter-component", {
+        mixins: [numberComponent],
         props: [],
         template: `${template}`,
         data: function () {
@@ -71,13 +72,13 @@
                 var hpLeft = target.hpLeft;
                 var barrierLeft = target.barrierLeft;
                 if (hpLeft > 0 && barrierLeft > 0) {
-                    return 'Health: ' + hpLeft + '<br>Barrier: ' + barrierLeft;
+                    return `Health: ${this.formatNumber(hpLeft)}<br>Barrier: ${this.formatNumber(barrierLeft)}`;
                 }
                 else if (hpLeft > 0 && barrierLeft == 0) {
-                    return 'Health: ' + hpLeft;
+                    return `Health: ${this.formatNumber(hpLeft)}`;
                 }
                 else if (barrierLeft > 0) {
-                    return 'Barrier: ' + barrierLeft;
+                    return `Barrier: ${this.formatNumber(barrierLeft)}`;
                 }
                 return false;
             },

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplOffensiveTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplOffensiveTable.html
@@ -131,7 +131,7 @@
                     </td>
                     <td :class="getBodyClass('Data', 2)"
                         :data-original-title="row.data[2] + ' out of ' + row.data[1] + ' critable hit(s)' +
-                                    '<br>Total Critical Damage: ' + row.data[3] +
+                                    '<br>Total Critical Damage: ' + formatNumber(row.data[3]) +
                                     '<br>' + round2(100*row.data[3]/ row.data[18]) +'% of total damage' +
                                     '<br>' + round2(100*row.data[3]/ row.data[19]) +'% of total direct damage'">
                         {{round2(100*row.data[2] / row.data[1])}}%
@@ -199,7 +199,7 @@
                     <td></td>
                     <td
                         :data-original-title="row.data[2] + ' out of ' + row.data[1] + ' critable hit(s)' +
-                                    '<br>Total Critical Damage: ' + row.data[3] +
+                                    '<br>Total Critical Damage: ' + formatNumber(row.data[3]) +
                                     '<br>' + round2(100*row.data[3]/ row.data[18]) +'% of total damage' +
                                     '<br>' + round2(100*row.data[3]/ row.data[19]) +'% of total direct damage'">
                         {{round2(100*row.data[2] / row.data[1])}}%

--- a/GW2EIBuilders/Resources/htmlTemplates/tmplTargetData.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/tmplTargetData.html
@@ -1,7 +1,7 @@
 <template>
     <div class="d-flex flex-row justify-content-center align-items-center mb-2">
         <img v-if="target.health > 0" src="https://wiki.guildwars2.com/images/b/be/Vitality.png" alt="Health"
-            class="icon" :data-original-title="'Health: ' + target.health">
+            class="icon" :data-original-title="'Health: ' + formatNumber(target.health)">
         <img v-if="target.tough > 0" src="https://wiki.guildwars2.com/images/1/12/Toughness.png" alt="Toughness"
             class="icon" hbHeight :data-original-title="'Toughness: ' + target.tough">
         <img v-if="target.hbWidth > 0" src="https://i.imgur.com/QSI79aT.png" alt="Hitbox Width"
@@ -13,6 +13,7 @@
 
 <script>
     Vue.component('target-data-component', {
+        mixins: [numberComponent],
         props: ['targetid'],
         template: `${template}`,
         computed: {


### PR DESCRIPTION
This attempts to change number formatting for better readability.
Current format is space as thousand separator and `.` as decimal separator like `1 234 567.89`.

Alternatively, we could also shorten to `1.23M` and `45.6k` and display the full number as tooltip on hover.