### PR TITLE
Fix down contribution support in WvW post lastDownBefore90 event removal

### DIFF
--- a/GW2EIBuilders/Resources/htmlTemplates/Statistics/tmplOffensiveTable.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/Statistics/tmplOffensiveTable.html
@@ -175,7 +175,7 @@
                         :data-original-title="round2(100*row.data[10]/ row.data[0]) + '% of '+ row.data[0] + ' direct hit(s)'">
                         {{row.data[10]}}
                     </td>
-                    <td v-if="wvw && !noLastDown90" :class="getBodyClass('Data', 17)"
+                    <td v-if="wvw" :class="getBodyClass('Data', 17)"
                         :data-original-title="round2(100*row.data[17]/ row.data[26]) +'% of total damage'">
                         {{row.data[17]}}
                     </td>
@@ -234,7 +234,7 @@
                     <td :data-original-title="round2(100*row.data[10]/ row.data[0]) + '% of '+ row.data[0] + ' direct hit(s)'">
                         {{row.data[10]}}
                     </td>
-                    <td v-if="wvw && !noLastDown90" :data-original-title="round2(100*row.data[17]/ row.data[26]) +'% of total damage'">
+                    <td v-if="wvw" :data-original-title="round2(100*row.data[17]/ row.data[26]) +'% of total damage'">
                         {{row.data[17]}}
                     </td>
                     <td v-if="wvw">
@@ -262,7 +262,6 @@
                 targetless: logData.targetless,
                 wvw: logData.wvw,
                 mode: logData.targetless ? 0 : 1,
-                noLastDown90: logData.evtcBuild >= 20240529,
                 cache: new Map(),
                 cacheTarget: new Map(),
                 sortdata: {

--- a/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractSingleActor.cs
@@ -100,6 +100,10 @@ namespace GW2EIEvtcParser.EIData
         {
             return _statusHelper.GetActiveDuration(log, start, end);
         }
+        public bool IsDownBefore90(ParsedEvtcLog log, long curTime)
+        {
+            return _statusHelper.IsDownBeforeNext90(log, curTime);
+        }
         public bool IsDowned(ParsedEvtcLog log, long time)
         {
             (_, IReadOnlyList<Segment> downs, _) = _statusHelper.GetStatus(log);

--- a/GW2EIEvtcParser/EIData/Actors/ActorsHelper/SingleActorStatusHelper.cs
+++ b/GW2EIEvtcParser/EIData/Actors/ActorsHelper/SingleActorStatusHelper.cs
@@ -100,8 +100,8 @@ namespace GW2EIEvtcParser.EIData
             // get remaining fight segment
             var remainingFightTime = new Segment(curTime, log.FightData.FightEnd);
 
-            // return false if actor currently above 90
-            if (Actor.GetCurrentHealthPercent(log, curTime) > 90)
+            // return false if actor currently above 90 or already downed
+            if (Actor.GetCurrentHealthPercent(log, curTime) > 90 || Actor.IsDowned(log, curTime))
             {
                 return false;
             }

--- a/GW2EIEvtcParser/EIData/Statistics/FinalOffensiveStats.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/FinalOffensiveStats.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.ParsedData;
 

--- a/GW2EIEvtcParser/EIData/Statistics/FinalOffensiveStats.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/FinalOffensiveStats.cs
@@ -116,9 +116,9 @@ namespace GW2EIEvtcParser.EIData
                         else
                         {
                             if (dl.To.IsDownedBeforeNext90(log, dl.Time))
-                        {
-                            DownContribution += dl.HealthDamage;
-                        }
+                            {
+                                DownContribution += dl.HealthDamage;
+                            }
                         }
                         if (dl.AgainstMoving)
                         {

--- a/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
@@ -394,7 +394,7 @@ namespace GW2EIEvtcParser.ParsedData
         /// </summary>
         /// <param name="log">The log.</param>
         /// <param name="time">Current log time</param>
-        /// <returns><see langword="true"/> if the agent will down before the next time they go above 90% health <see langword="false"/>.</returns>
+        /// <returns><see langword="true"/> if the agent will down before the next time they go above 90% health, otherwise <see langword="false"/>.</returns>
         public bool IsDownedBeforeNext90(ParsedEvtcLog log, long time)
         {
             AbstractSingleActor actor = log.FindActor(this);

--- a/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
@@ -388,6 +388,19 @@ namespace GW2EIEvtcParser.ParsedData
             return actor.GetBuffStatus(log, by, buffId, start, end);
         }
 
+
+        /// <summary>
+        /// Checks if the agent will go into downstate before the next time they go above 90% health, or the fight ends.
+        /// </summary>
+        /// <param name="log">The log.</param>
+        /// <param name="time">Current log time</param>
+        /// <returns><see langword="true"/> if the agent will down before the next time they go above 90% health <see langword="false"/>.</returns>
+        public bool IsDownedBeforeNext90(ParsedEvtcLog log, long time)
+        {
+            AbstractSingleActor actor = log.FindActor(this);
+            return actor.IsDownBefore90(log, time);
+        }
+
         /// <summary>
         /// Checks if the agent is downed at given time.
         /// </summary>


### PR DESCRIPTION
Small PR to re-enable support for parsing down contribution in detailed WvW logs now that health update events are available in the limited WvW set as of Arc evtc build 20240529. The method appears correct when comparing with in-game arcdps numbers for down contribution, please let me know if you have other tests you normally like to run against this sort of calculation change.

Note down contribution in non-detailed WvW is unchanged (all zeroes as that is current release behaviour).
I've attached some sample manual test scenarios below for logs from both before and after the change to confirm backwards compatibility.

Sample Offensive Stats table with log from Pre EVTCBuild 20240529
![image](https://github.com/baaron4/GW2-Elite-Insights-Parser/assets/49768670/110c4069-3234-4c27-8c1d-d2cc7df6dc26)
[PreEVTCBuildSample.zip](https://github.com/user-attachments/files/16038273/PreEVTCBuildSample.zip)

Post-EVTCBuild 20240529
![image](https://github.com/baaron4/GW2-Elite-Insights-Parser/assets/49768670/05a5de7c-af87-4cb1-8f32-61b0868f0cbf)
![image](https://github.com/baaron4/GW2-Elite-Insights-Parser/assets/49768670/e8f0c67e-ba2d-46d3-82b9-e79a74cb3029)
[PostEVTC20240529LogSample.zip](https://github.com/user-attachments/files/16038265/PostEVTC20240529LogSample.zip)
