### PR TITLE
Added spear buff icons and relic casts

### DIFF
--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -242,11 +242,11 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Shattering Stone", ShatteringStoneBuff, Source.Elementalist, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, BuffImages.ShatteringStone)
                 .WithBuilds(GW2Builds.February2024NewWeapons),
             // Spear
-            new Buff("Seethe", SeetheBuff, Source.Elementalist, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Ripple", RippleBuff, Source.Elementalist, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Energize", EnergizeBuff, Source.Elementalist, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Fulgor", FulgorBuff, Source.Elementalist, BuffStackType.StackingTargetUniqueSrc, 999, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Harden", HardenBuff, Source.Elementalist, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Seethe", SeetheBuff, Source.Elementalist, BuffClassification.Other, BuffImages.Seethe),
+            new Buff("Ripple", RippleBuff, Source.Elementalist, BuffClassification.Other, BuffImages.Ripple),
+            new Buff("Energize", EnergizeBuff, Source.Elementalist, BuffClassification.Other, BuffImages.Energize),
+            new Buff("Fulgor", FulgorBuff, Source.Elementalist, BuffStackType.StackingTargetUniqueSrc, 999, BuffClassification.Other, BuffImages.Fulgor),
+            new Buff("Harden", HardenBuff, Source.Elementalist, BuffClassification.Other, BuffImages.Harden),
         };
 
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
@@ -219,10 +219,10 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Elite Mortar", POV_EliteMortarKitOpen, Source.Engineer, BuffClassification.Other, BuffImages.EliteMortarKit),
             */
             // Spear
-            new Buff("Conduit Surge", ConduitSurgeBuff, Source.Engineer, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Electric Artillery", ElectricArtillery, Source.Engineer, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Focused", Focused, Source.Engineer, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Lightning Rod Charges", LightningRodCharges, Source.Engineer, BuffStackType.Stacking, 12, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Conduit Surge", ConduitSurgeBuff, Source.Engineer, BuffClassification.Other, BuffImages.ConduitSurge),
+            new Buff("Electric Artillery", ElectricArtillery, Source.Engineer, BuffClassification.Other, BuffImages.ElectricArtillery),
+            new Buff("Focused", Focused, Source.Engineer, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.Focused),
+            new Buff("Lightning Rod Charges", LightningRodCharges, Source.Engineer, BuffStackType.Stacking, 12, BuffClassification.Other, BuffImages.LightningRod),
         };
 
         public static void ProcessGadgets(IReadOnlyList<Player> players, CombatData combatData)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
@@ -186,8 +186,8 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Inspiring Virtue", InspiringVirtue, Source.Guardian, BuffClassification.Other, BuffImages.VirtuousSolace).WithBuilds(GW2Builds.February2020Balance2),
             new Buff("Force of Will", ForceOfWill, Source.Guardian, BuffClassification.Other, BuffImages.ForceOfWill),
             // Spear
-            new Buff("Symbol of Luminance", SymbolOfLuminanceBuff, Source.Guardian, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Illuminated", Illuminated, Source.Guardian, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Symbol of Luminance", SymbolOfLuminanceBuff, Source.Guardian, BuffClassification.Other, BuffImages.SymbolOfLuminance),
+            new Buff("Illuminated", Illuminated, Source.Guardian, BuffClassification.Other, BuffImages.Illuminated),
         };
 
         private static HashSet<int> Minions = new HashSet<int>()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -174,7 +174,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Morphed (Polymorph Moa)", MorphedPolymorphMoa, Source.Mesmer, BuffClassification.Debuff, BuffImages.MorphedPolymorphMoa),
             new Buff("Morphed (Polymorph Tuna)", MorphedPolymorphTuna, Source.Mesmer, BuffClassification.Debuff, BuffImages.MorphedPolymorphTuna),
             // Spear
-            new Buff("Clarity", Clarity, Source.Mesmer, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Clarity", Clarity, Source.Mesmer, BuffClassification.Other, BuffImages.Clarity),
         };
 
         private static readonly HashSet<int> _cloneIDs = new HashSet<int>()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -112,9 +112,9 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Last Rites", LastRites, Source.Necromancer, BuffClassification.Defensive, BuffImages.LastRites),
             new Buff("Soul Barbs", SoulBarbs, Source.Necromancer, BuffClassification.Other, BuffImages.SoulBarbs),
             // Spear
-            new Buff("Extirpation", Extirpation, Source.Necromancer, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Soul Shards", SoulShards, Source.Necromancer, BuffStackType.StackingConditionalLoss, 6, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Distress", DistressBuff, Source.Necromancer, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Extirpation", Extirpation, Source.Necromancer, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, BuffImages.Extirpate),
+            new Buff("Soul Shards", SoulShards, Source.Necromancer, BuffStackType.StackingConditionalLoss, 6, BuffClassification.Other, BuffImages.SoulShards),
+            new Buff("Distress", DistressBuff, Source.Necromancer, BuffClassification.Other, BuffImages.Distress),
             new Buff("Dark Stalker", DarkStalker, Source.Necromancer, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.MonsterSkill),
         };
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -150,6 +150,10 @@ namespace GW2EIEvtcParser.EIData
                 .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EffectCastFinder(RelicOfTheTwinGenerals, EffectGUIDs.RelicOfTheTwinGenerals)
                 .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfSorrowBuff, EffectGUIDs.RelicOfSorrow3)
+                .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+            new EffectCastFinder(RelicOfTheStormsingerDamage, EffectGUIDs.RelicOfTheStormsinger)
+                .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EXTHealingCastFinder(RelicOfKarakosaHealing, RelicOfKarakosaHealing)
                 .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
             new EXTHealingCastFinder(RelicOfNayosHealing, RelicOfNayosHealing)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -328,6 +328,8 @@ namespace GW2EIEvtcParser.EIData
                 .WithBuilds(GW2Builds.February2024NewWeapons),
             new Buff("Tapped Out", TappedOut, Source.Ranger, BuffClassification.Other, BuffImages.TappedOut)
                 .WithBuilds(GW2Builds.February2024NewWeapons),
+            // Spear
+            new Buff("Hunter's Prowess", HuntersProwess, Source.Ranger, BuffClassification.Other, BuffImages.HuntersProwess),
         };
 
         public static void ProcessGadgets(IReadOnlyList<Player> players, CombatData combatData)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -329,7 +329,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Tapped Out", TappedOut, Source.Ranger, BuffClassification.Other, BuffImages.TappedOut)
                 .WithBuilds(GW2Builds.February2024NewWeapons),
             // Spear
-            new Buff("Hunter's Prowess", HuntersProwess, Source.Ranger, BuffClassification.Other, BuffImages.HuntersProwess),
+            new Buff("Hunter's Prowess", HuntersProwess, Source.Ranger, BuffStackType.Queue, 9, BuffClassification.Other, BuffImages.HuntersProwess),
         };
 
         public static void ProcessGadgets(IReadOnlyList<Player> players, CombatData combatData)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -186,7 +186,7 @@ namespace GW2EIEvtcParser.EIData
             // Scepter
             new Buff("Blossoming Aura", BlossomingAuraBuff, Source.Revenant, BuffClassification.Other, BuffImages.BlossomingAura),
             // Spear
-            new Buff("Crushing Abyss", CrushingAbyss, Source.Revenant, BuffStackType.Stacking, 5, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Crushing Abyss", CrushingAbyss, Source.Revenant, BuffStackType.Stacking, 5, BuffClassification.Other, BuffImages.CrushingAbyss),
         };
 
         private static readonly HashSet<long> _legendSwaps = new HashSet<long>

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
@@ -110,8 +110,9 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Instant Reflexes", InstantReflexes, Source.Thief, BuffClassification.Other, BuffImages.InstantReflexes),
             new Buff("Fluid Strikes", FluidStrikes, Source.Thief, BuffClassification.Other, BuffImages.FluidStrikes).WithBuilds(GW2Builds.July2023BalanceAndSilentSurfCM),
             // Spear
-            new Buff("Distracting Throw", DistractingThrowBuff, Source.Thief, BuffStackType.Queue, 9, BuffClassification.Other, BuffImages.MonsterSkill),
-            new Buff("Shadow Veil", ShadowVeilBuff, Source.Thief, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Distracting Throw", DistractingThrowBuff, Source.Thief, BuffStackType.Queue, 9, BuffClassification.Other, BuffImages.DistractingThrow),
+            new Buff("Shadow Veil", ShadowVeilBuff, Source.Thief, BuffClassification.Other, BuffImages.ShadowVeil),
+            new Buff("Shadow Veil (Stacks)", ShadowVeilBuffStacks, Source.Thief, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, BuffImages.ShadowVeil),
         };
 
         private static HashSet<int> Minions = new HashSet<int>()

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -206,6 +206,8 @@ namespace GW2EIEvtcParser.ParsedData
             { ImpairingDaggersDaredevilMinionHit2, "Impairing Daggers (Dagger Hit 2)" },
             { ImpairingDaggersDaredevilMinionHit3, "Impairing Daggers (Dagger Hit 3)" },
             { BoundHit, "Bound (Hit)" },
+            { BarbedSpearMelee, "Barbed Spear (Melee)" },
+            { BarbedSpearRanged, "Barbed Spear (Ranged)" },
             // Warrior
             { RushDamage, "Rush (Hit)" },
             { MightyThrowScatter, "Mighty Throw (Scattered Spear)" },
@@ -488,6 +490,9 @@ namespace GW2EIEvtcParser.ParsedData
             { RelicOfTheFoundingBarrier, "https://wiki.guildwars2.com/images/8/81/Relic_of_the_Founding.png" },
             { RelicOfTheTwinGenerals, "https://wiki.guildwars2.com/images/0/0e/Relic_of_the_Twin_Generals.png" },
             { RelicOfTheClawBuffLoss, "https://i.imgur.com/x6AU9B4.png" },
+            { RelicOfTheClaw, BuffImages.RelicOfTheClaw },
+            { RelicOfSorrowBuff, BuffImages.RelicOfTheSorrow },
+            { RelicOfTheStormsingerDamage, BuffImages.RelicOfTheStormsinger },
 #endregion RelicIcons
             #region ElementalistIcons
             { DualFireAttunement, "https://wiki.guildwars2.com/images/b/b4/Fire_Attunement.png" },
@@ -554,6 +559,7 @@ namespace GW2EIEvtcParser.ParsedData
             { RifleBurstGrenadeDamage, "https://wiki.guildwars2.com/images/e/ed/Grenade_Barrage.png" },
             { GyroExplosion, "https://wiki.guildwars2.com/images/4/4e/Function_Gyro_%28tool_belt_skill%29.png" },
             { DetonateThrowMineOrMineField, "https://wiki.guildwars2.com/images/d/d1/Detonate_Mine_Field.png" },
+            { ConduitSurge, "https://wiki.guildwars2.com/images/6/6b/Conduit_Surge.png" },
 #endregion EngineerIcons
             #region GuardianIcons
             { ProtectorsStrikeCounterHit, "https://wiki.guildwars2.com/images/e/e0/Protector%27s_Strike.png" },
@@ -597,6 +603,8 @@ namespace GW2EIEvtcParser.ParsedData
             { FireJurisdictionLevel1, "https://render.guildwars2.com/file/61186008B920AADD9A0D47E1A10C63AFF28030A9/3256356.png" },
             { FireJurisdictionLevel2, "https://render.guildwars2.com/file/61186008B920AADD9A0D47E1A10C63AFF28030A9/3256356.png" },
             { FireJurisdictionLevel3, "https://render.guildwars2.com/file/61186008B920AADD9A0D47E1A10C63AFF28030A9/3256356.png" },
+            { DaybreakingSlash1, "https://wiki.guildwars2.com/images/1/1f/Daybreaking_Slash.png" },
+            { BindingBladeSelf, BuffImages.BindingBlade },
 #endregion GuardianIcons
             #region MesmerIcons
             { HealingPrism, "https://wiki.guildwars2.com/images/f/f4/Healing_Prism.png" },
@@ -777,6 +785,7 @@ namespace GW2EIEvtcParser.ParsedData
             { PhotosynthesizeJacaranda, "https://wiki.guildwars2.com/images/2/2f/Photosynthesize.png" },
             { EvilEye, "https://wiki.guildwars2.com/images/2/27/Evil_Eye.png" },
             { TormentingVisionSpinegazer, "https://wiki.guildwars2.com/images/0/0b/Tormenting_Visions.png" },
+            { WolfsOnslaughtFollowUp, "https://wiki.guildwars2.com/images/6/61/Wolf%27s_Onslaught.png" },
             #endregion RangerIcons
             #region RevenantIcons
             { RiftSlashRiftHit, "https://wiki.guildwars2.com/images/a/a8/Rift_Slash.png" },
@@ -823,6 +832,10 @@ namespace GW2EIEvtcParser.ParsedData
             { EchoingEruptionExtra, "https://wiki.guildwars2.com/images/b/ba/Echoing_Eruption.png" },
             { PhaseTraversal2, "https://wiki.guildwars2.com/images/f/f2/Phase_Traversal.png" },
             { CoalescenceOfRuinExtra, "https://wiki.guildwars2.com/images/1/10/Coalescence_of_Ruin.png" },
+            { AbyssalRaze2, "https://wiki.guildwars2.com/images/5/52/Abyssal_Raze.png" },
+            { AbyssalStrike_SecondHit, "https://wiki.guildwars2.com/images/9/98/Abyssal_Fire.png" },
+            { BlitzMinesDrop, "https://wiki.guildwars2.com/images/8/86/Abyssal_Blitz.png" },
+            { BlitzMines, "https://wiki.guildwars2.com/images/8/86/Abyssal_Blitz.png" },
             #endregion RevenantIcons
             #region ThiefIcons
             { ThrowMagneticBomb, "https://wiki.guildwars2.com/images/e/e7/Throw_Magnetic_Bomb.png" },
@@ -873,6 +886,7 @@ namespace GW2EIEvtcParser.ParsedData
             { ShadowShot, "https://wiki.guildwars2.com/images/4/46/Shadow_Strike.png" },
             { ShadowStrike, "https://wiki.guildwars2.com/images/6/66/Shadow_Assault.png" },
             { InfiltratorsStrikeSomething, "https://wiki.guildwars2.com/images/2/2c/Infiltrator%27s_Strike.png" },
+            { BarbedSpearRanged, "https://wiki.guildwars2.com/images/a/a4/Barbed_Spear.png" },
             #endregion ThiefIcons
             #region WarriorIcons
             { MendingMight, "https://wiki.guildwars2.com/images/e/e7/Mending_Might.png" },
@@ -915,6 +929,8 @@ namespace GW2EIEvtcParser.ParsedData
             { EnchantmentCollapse, "https://wiki.guildwars2.com/images/7/7f/Enchantment_Collapse.png" },
             { LineBreakerHeal, "https://wiki.guildwars2.com/images/0/0e/Line_Breaker.png" },
             { VigorousShouts, "https://wiki.guildwars2.com/images/d/de/Vigorous_Shouts.png" },
+            { MightyThrowScatter, "https://wiki.guildwars2.com/images/9/97/Mighty_Throw.png" },
+            { SpearmarshalsSupport, "https://wiki.guildwars2.com/images/f/ff/Spearmarshal%27s_Support.png" },
             #endregion WarriorIcons
             #region EncounterIcons
             // Silent Surf Fractal

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -835,7 +835,6 @@ namespace GW2EIEvtcParser.ParsedData
             { AbyssalRaze2, "https://wiki.guildwars2.com/images/5/52/Abyssal_Raze.png" },
             { AbyssalStrike_SecondHit, "https://wiki.guildwars2.com/images/9/98/Abyssal_Fire.png" },
             { BlitzMinesDrop, "https://wiki.guildwars2.com/images/8/86/Abyssal_Blitz.png" },
-            { BlitzMines, "https://wiki.guildwars2.com/images/8/86/Abyssal_Blitz.png" },
             #endregion RevenantIcons
             #region ThiefIcons
             { ThrowMagneticBomb, "https://wiki.guildwars2.com/images/e/e7/Throw_Magnetic_Bomb.png" },

--- a/GW2EIEvtcParser/ParserHelpers/BuffImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/BuffImages.cs
@@ -1632,6 +1632,25 @@
         public const string NaturesStrength = "https://wiki.guildwars2.com/images/8/84/Nature%27s_Strength.png";
         public const string DimensionalAperture = "https://wiki.guildwars2.com/images/8/80/Dimensional_Aperture.png";
         public const string BlossomingAura = "https://wiki.guildwars2.com/images/6/62/Blossoming_Aura.png";
+        public const string Extirpate = "https://wiki.guildwars2.com/images/1/15/Extirpate.png";
+        public const string SoulShards = "https://wiki.guildwars2.com/images/e/e3/Soul_Shards.png";
+        public const string Distress = "https://wiki.guildwars2.com/images/b/b6/Distress.png";
+        public const string Clarity = "https://wiki.guildwars2.com/images/d/d7/Clarity.png";
+        public const string Seethe = "https://wiki.guildwars2.com/images/8/88/Seethe.png";
+        public const string Energize = "https://wiki.guildwars2.com/images/4/45/Energize.png";
+        public const string Ripple = "https://wiki.guildwars2.com/images/2/23/Ripple.png";
+        public const string Harden = "https://wiki.guildwars2.com/images/0/02/Harden.png";
+        public const string Fulgor = "https://wiki.guildwars2.com/images/5/53/Fulgor.png";
+        public const string Illuminated = "https://wiki.guildwars2.com/images/7/7d/Illuminated.png";
+        public const string SymbolOfLuminance = "https://wiki.guildwars2.com/images/c/c5/Symbol_of_Luminance_%28effect%29.png";
+        public const string HuntersProwess = "https://wiki.guildwars2.com/images/b/b9/Panther%27s_Prowl.png";
+        public const string CrushingAbyss = "https://wiki.guildwars2.com/images/5/52/Abyssal_Raze.png";
+        public const string ConduitSurge = "https://wiki.guildwars2.com/images/6/6b/Conduit_Surge.png";
+        public const string ElectricArtillery = "https://wiki.guildwars2.com/images/1/13/Electric_Artillery.png";
+        public const string Focused = "https://wiki.guildwars2.com/images/5/51/Focused.png";
+        public const string LightningRod = "https://wiki.guildwars2.com/images/f/f9/Lightning_Rod_%28engineer_spear_skill%29.png";
+        public const string DistractingThrow = "https://wiki.guildwars2.com/images/d/d8/Distracting_Throw.png";
+        public const string ShadowVeil = "https://wiki.guildwars2.com/images/d/dd/Shadow_Veil.png";
         #endregion Cast
 
         #region Traits

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -43,6 +43,10 @@
         public const string RelicOfPeitha = "0CBFB70434661647B68003ECD77207E6"; // Projectile
         public const string RelicOfAkeem = "8181E21A43EAFB42BC8FFB001F02CF44"; // Target Src
         public const string RelicOfTheTwinGenerals = "40ECD58F39B30041B3E6C7CEDB7C4D8C";
+        public const string RelicOfSorrow1 = "DB02EB39ABBEE241859DC9662AD49FA5"; // Duration 0, No Src
+        public const string RelicOfSorrow2 = "FEEA4632BAF0B1438D83F6C8B71AEA15"; // Duration 0, No Src
+        public const string RelicOfSorrow3 = "3D981397D9C6A44B888212CE4E3F6F9A"; // Duration 4000
+        public const string RelicOfTheStormsinger = "E8EB2CDF97F34C42A8AAC0D3BA6551D0"; // Effect appears twice
         #endregion
         #region Mesmer
         public const string MesmerThePrestigeDisappear1 = "48B69FBC3090E144BFC067D6C0208878";

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -4341,7 +4341,7 @@
         public const long DaybreakingSlash1 = 72923;
         public const long DistractingThrowSkill = 72927;
         public const long FalconsStoop = 72928;
-        public const long AbyssalStrike1 = 72931;
+        public const long AbyssalFire = 72931; // Renamed from Abyssal Strike during beta
         public const long RavagersAbandon = 72932;
         public const long Psycut_Clone = 72934;
         public const long LesserHaboob = 72935;
@@ -4387,13 +4387,14 @@
         public const long SeetheBuff = 73011;
         public const long DarkSlash = 73012;
         public const long Addle = 73013;
-        public const long AbyssalStrike2 = 73015;
+        public const long AbyssalStrike_FirstHit = 73015;
         public const long Haboob = 73017;
         public const long HardenSkill = 73019;
         public const long WarclawsEngage = 73020;
         public const long FieryImpactBuff = 73023;
         public const long SymbolOfLuminanceBuff = 73025;
         public const long WolfsOnslaught = 73030;
+        public const long ShadowVeilBuffStacks = 73034;
         public const long EnergizeSkill = 73037;
         public const long DarkStalker = 73039; // Necromancer Spear - Buff applied from player to target
         public const long DeadlySlice = 73040;
@@ -4419,6 +4420,7 @@
         public const long ImaginedImpairment = 73069;
         public const long EnergizeBuff = 73071;
         public const long GalvanizeBuff = 73073;
+        public const long AbyssalRaze2 = 73077;
         public const long BlazingBarrage = 73080;
         public const long BarbedSpearRanged = 73082;
         public const long CheetahsStrike = 73087;
@@ -4450,7 +4452,7 @@
         public const long SymbolOfLuminanceSkill = 73132;
         public const long ShadowVeilBuff = 73134;
         public const long SeetheSkill = 73137;
-        public const long AbyssalStrike3 = 73139;
+        public const long AbyssalStrike_SecondHit = 73139;
         public const long Jokulhlaup = 73140;
         public const long ElectricArtillery = 73143;
         public const long BarbedSpearMelee = 73145;
@@ -4461,8 +4463,11 @@
         public const long Psycut = 73154;
         public const long GreersVirulence = 73181;
         public const long RelicOfTheStormsingerBuff = 73455;
+        public const long HuntersProwess = 73541;
+        public const long RelicOfTheStormsingerDamage = 73851;
         public const long RelicOfTheClaw = 73955;
-        public const long RelicOfSorrowBuff = long.MaxValue; // To be added
+        public const long SprearmarshalsSupport = 74290;
+        public const long RelicOfSorrowBuff = 74410;
         #endregion
     }
 


### PR DESCRIPTION
Added Relic of Sorrow and Relic of the Stormsinger casts detection
Added new ranger buff Hunter's Prowess
Added new thief buff Shadow Veil (Stacks)
Renamed Barber Spear to distinguish melee and ranged version
Added various icons to some skills not in the API

Note: Dark Stalker for necromancer is a hidden buff on the target, kept the default monster skill icon.

