### PR TITLE
Add secondary targets

### DIFF
--- a/GW2EIEvtcParser/EIData/Actors/AbstractActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/AbstractActor.cs
@@ -85,6 +85,11 @@ namespace GW2EIEvtcParser.EIData
             return AgentItem.IsSpecies(id);
         }
 
+        public bool IsAnySpecies(IEnumerable<int> ids)
+        {
+            return AgentItem.IsAnySpecies(ids);
+        }
+
         public bool IsAnySpecies(IEnumerable<ArcDPSEnums.TrashID> ids)
         {
             return AgentItem.IsAnySpecies(ids);

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -79,6 +79,13 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor mama = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.MAMA)) ?? throw new MissingKeyActorsException("MAMA not found");
             phases[0].AddTarget(mama);
+            var knightIds = new List<int>
+            {
+                (int) TrashID.GreenKnight,
+                (int) TrashID.RedKnight,
+                (int) TrashID.BlueKnight,
+            };
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsAnySpecies(knightIds)));
             if (!requirePhases)
             {
                 return phases;
@@ -89,13 +96,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 PhaseData phase = phases[i];
                 if (i % 2 == 0)
                 {
-                    var ids = new List<int>
-                    {
-                       (int) TrashID.GreenKnight,
-                       (int) TrashID.RedKnight,
-                       (int) TrashID.BlueKnight,
-                    };
-                    AddTargetsToPhaseAndFit(phase, ids, log);
+                    AddTargetsToPhaseAndFit(phase, knightIds, log);
                     if (phase.Targets.Count > 0)
                     {
                         AbstractSingleActor phaseTar = phase.Targets[0];

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -74,6 +74,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor siax = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Siax)) ?? throw new MissingKeyActorsException("Siax not found");
             phases[0].AddTarget(siax);
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsSpecies(TrashID.EchoOfTheUnclean)));
             if (!requirePhases)
             {
                 return phases;

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
@@ -126,6 +126,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor arkk = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Arkk)) ?? throw new MissingKeyActorsException("Arkk not found");
             phases[0].AddTarget(arkk);
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsSpecies(TrashID.Archdiviner) || x.IsSpecies(TrashID.EliteBrazenGladiator)));
             if (!requirePhases)
             {
                 return phases;

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -58,6 +58,18 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor skorvald = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Skorvald)) ?? throw new MissingKeyActorsException("Skorvald not found");
             phases[0].AddTarget(skorvald);
+            var anomalyIds = new List<int>
+            {
+                (int)TrashID.FluxAnomaly1,
+                (int)TrashID.FluxAnomaly2,
+                (int)TrashID.FluxAnomaly3,
+                (int)TrashID.FluxAnomaly4,
+                (int)TrashID.FluxAnomalyCM1,
+                (int)TrashID.FluxAnomalyCM2,
+                (int)TrashID.FluxAnomalyCM3,
+                (int)TrashID.FluxAnomalyCM4,
+            };
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsAnySpecies(anomalyIds)));
             if (!requirePhases)
             {
                 return phases;
@@ -69,18 +81,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 if (i % 2 == 0)
                 {
                     phase.Name = "Split " + (i) / 2;
-                    var ids = new List<int>
-                    {
-                        (int)TrashID.FluxAnomaly1,
-                        (int)TrashID.FluxAnomaly2,
-                        (int)TrashID.FluxAnomaly3,
-                        (int)TrashID.FluxAnomaly4,
-                        (int)TrashID.FluxAnomalyCM1,
-                        (int)TrashID.FluxAnomalyCM2,
-                        (int)TrashID.FluxAnomalyCM3,
-                        (int)TrashID.FluxAnomalyCM4,
-                    };
-                    AddTargetsToPhaseAndFit(phase, ids, log);
+                    AddTargetsToPhaseAndFit(phase, anomalyIds, log);
                 }
                 else
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/TheLonelyTower/Eparch.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/TheLonelyTower/Eparch.cs
@@ -108,6 +108,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor eparch = GetEparchActor();
             phases[0].AddTarget(eparch);
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsSpecies(TrashID.IncarnationOfCruelty) || x.IsSpecies(TrashID.IncarnationOfJudgement)));
             if (!requirePhases || !log.FightData.IsCM)
             {
                 return phases;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
@@ -53,6 +53,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor mainTarget = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TargetID.Gorseval)) ?? throw new MissingKeyActorsException("Gorseval not found");
             phases[0].AddTarget(mainTarget);
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsSpecies(ArcDPSEnums.TrashID.ChargedSoul)));
             if (!requirePhases)
             {
                 return phases;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
+using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
+using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.SkillIDs;
 
@@ -78,6 +80,33 @@ namespace GW2EIEvtcParser.EncounterLogic
                 }
             }
             return phases;
+        }
+
+        // note: 2nd split spawn locations are further out
+        static readonly List<(string, Point3D)> SoulLocations = new List<(string, Point3D)> {
+            ("NE", new Point3D(2523.4495f, -3665.1294f)),
+            ("NW", new Point3D(842.77686f, -3657.2395f)),
+            ("SW", new Point3D(866.719f, -5306.719f)),
+            ("SE", new Point3D(2470.5596f, -5194.389f)),
+        };
+
+        internal override void EIEvtcParse(ulong gw2Build, EvtcVersionEvent evtcVersion, FightData fightData, AgentData agentData, List<CombatItem> combatData, IReadOnlyDictionary<uint, AbstractExtensionHandler> extensions)
+        {
+            base.EIEvtcParse(gw2Build, evtcVersion, fightData, agentData, combatData, extensions);
+            var nameCount = new Dictionary<string, int>{ { "NE", 1 }, { "NW", 1 }, { "SW", 1 }, { "SE", 1 } };
+            foreach (AbstractSingleActor target in _targets)
+            {
+                if (target.IsSpecies(ArcDPSEnums.TrashID.ChargedSoul))
+                {
+                    // 2nd split souls spawn further out, check in larger radius
+                    string suffix = AddNameSuffixBasedOnInitialPosition(target, combatData, SoulLocations, 300);
+                    if (suffix != null && nameCount.ContainsKey(suffix))
+                    {
+                        // deduplicate name
+                        target.OverrideName(target.Character + " " + (nameCount[suffix]++));
+                    }
+                }
+            }
         }
 
         protected override List<int> GetTargetsIDs()

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -71,25 +71,26 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor mainTarget = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TargetID.Sabetha)) ?? throw new MissingKeyActorsException("Sabetha not found");
             phases[0].AddTarget(mainTarget);
+            var miniBossIds = new List<int>
+            {
+                (int) ArcDPSEnums.TrashID.Kernan,
+                (int) ArcDPSEnums.TrashID.Knuckles,
+                (int) ArcDPSEnums.TrashID.Karde,
+            };
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsAnySpecies(miniBossIds)));
             if (!requirePhases)
             {
                 return phases;
             }
             // Invul check
             phases.AddRange(GetPhasesByInvul(log, Invulnerability757, mainTarget, true, true));
-            var ids = new List<int>
-                    {
-                       (int) ArcDPSEnums.TrashID.Kernan,
-                       (int) ArcDPSEnums.TrashID.Knuckles,
-                       (int) ArcDPSEnums.TrashID.Karde,
-                    };
             for (int i = 1; i < phases.Count; i++)
             {
                 PhaseData phase = phases[i];
                 if (i % 2 == 0)
                 {
                     int phaseID = i / 2;
-                    AddTargetsToPhaseAndFit(phase, ids, log);
+                    AddTargetsToPhaseAndFit(phase, miniBossIds, log);
                     if (phase.Targets.Count > 0)
                     {
                         AbstractSingleActor phaseTar = phase.Targets[0];

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -77,6 +77,13 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor mainTarget = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TargetID.ValeGuardian)) ?? throw new MissingKeyActorsException("Vale Guardian not found");
             phases[0].AddTarget(mainTarget);
+            var splitGuardianIds = new List<int>
+            {
+                (int) ArcDPSEnums.TrashID.BlueGuardian,
+                (int) ArcDPSEnums.TrashID.GreenGuardian,
+                (int) ArcDPSEnums.TrashID.RedGuardian
+            };
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsAnySpecies(splitGuardianIds)));
             if (!requirePhases)
             {
                 return phases;
@@ -89,13 +96,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                 if (i % 2 == 0)
                 {
                     phase.Name = "Split " + (i) / 2;
-                    var ids = new List<int>
-                    {
-                       (int) ArcDPSEnums.TrashID.BlueGuardian,
-                       (int) ArcDPSEnums.TrashID.GreenGuardian,
-                       (int) ArcDPSEnums.TrashID.RedGuardian
-                    };
-                    AddTargetsToPhaseAndFit(phase, ids, log);
+                    AddTargetsToPhaseAndFit(phase, splitGuardianIds, log);
                 }
                 else
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
@@ -101,6 +101,7 @@ namespace GW2EIEvtcParser.EncounterLogic
             List<PhaseData> phases = GetInitialPhase(log);
             AbstractSingleActor mainTarget = Targets.FirstOrDefault(x => x.IsSpecies(ArcDPSEnums.TargetID.Samarog)) ?? throw new MissingKeyActorsException("Samarog not found");
             phases[0].AddTarget(mainTarget);
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsSpecies(ArcDPSEnums.TrashID.Guldhem)));
             if (!requirePhases)
             {
                 return phases;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
@@ -242,8 +242,9 @@ namespace GW2EIEvtcParser.EncounterLogic
             phases[0].AddTarget(adina);
             var handIds = new ArcDPSEnums.TrashID[] { ArcDPSEnums.TrashID.HandOfErosion, ArcDPSEnums.TrashID.HandOfEruption };
             List<AbstractBuffEvent> invuls = GetFilteredList(log.CombatData, Determined762, adina, true, true);
-            var phase4Start = invuls.OfType<BuffRemoveAllEvent>().ElementAtOrDefault(2)?.Time ?? log.FightData.LogEnd; // 3x determined remove until phase 4
-            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsAnySpecies(handIds) && x.FirstAware < phase4Start));
+            AbstractBuffEvent lastInvuln = invuls.LastOrDefault();
+            long lastBossPhaseStart = lastInvuln is BuffRemoveAllEvent ? lastInvuln.Time : log.FightData.LogEnd; // if log ends with any boss phase, ignore hands after that point
+            phases[0].AddSecondaryTargets(Targets.Where(x => x.IsAnySpecies(handIds) && x.FirstAware < lastBossPhaseStart));
             if (!requirePhases)
             {
                 return phases;

--- a/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
@@ -545,6 +545,11 @@ namespace GW2EIEvtcParser.ParsedData
             return IsSpecies((int)id);
         }
 
+        public bool IsAnySpecies(IEnumerable<int> ids)
+        {
+            return ids.Any(x => IsSpecies(x));
+        }
+
         public bool IsAnySpecies(IEnumerable<ArcDPSEnums.TrashID> ids)
         {
             return ids.Any(x => IsSpecies(x));


### PR DESCRIPTION
This adds some "progress-blocking" split phase DPS targets as secondary targets to the main phase (akin to Kaineng Overlook).

Fractals:
- Knights at MAMA (3 targets)
- Echos at Siax (8 targets)
- Anomalies at Skorvald (8 targets)
- Archdiviner & Gladiator at Arkk (2 targets)
- Incarnations at Eparch (5 targets)

Raids:
- Split Guardians at Vale Guardian (6 targets)
- Souls at Gorseval (8 targets)
- Kernan, Knuckles & Karde at Sabetha (3 targets)
- Guldhem at Samarog (2 targets)
- Hands at Adina (10 targets)