### PR TITLE
Add instant cast detection for Renegade Band Together

### DIFF
--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using GW2EIEvtcParser.ParsedData;
 using GW2EIEvtcParser.ParserHelpers;
@@ -18,10 +17,7 @@ namespace GW2EIEvtcParser.EIData
             public BandTogetherCastFinder(long baseSkillID, long enhancedSkill, string effect) : base(enhancedSkill, effect)
             {
                 UsingSrcSpecChecker(Spec.Renegade);
-                UsingChecker((evt, combatData, agentData, skillData) =>
-                {
-                    return !combatData.IsCasting(baseSkillID, evt.Src, evt.Time);
-                });
+                UsingChecker((evt, combatData, agentData, skillData) => !combatData.IsCasting(baseSkillID, evt.Src, evt.Time));
             }
         }
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
@@ -13,15 +13,14 @@ namespace GW2EIEvtcParser.EIData
 {
     internal static class RenegadeHelper
     {
-        private class BandTogetherCastFinder : BuffLossCastFinder
+        private class BandTogetherCastFinder : EffectCastFinder
         {
-            public BandTogetherCastFinder(long skillID, MinionID minionID) : base(skillID, BandTogetherBuff)
+            public BandTogetherCastFinder(long baseSkillID, long enhancedSkill, string effect) : base(enhancedSkill, effect)
             {
+                UsingSrcSpecChecker(Spec.Renegade);
                 UsingChecker((evt, combatData, agentData, skillData) =>
                 {
-                    // check for no expire and minion spawning ~200ms after
-                    const long minionDelay = 200;
-                    return evt.RemovedDuration > 0 && agentData.GetNPCsByID(minionID).Any(x => Math.Abs(x.FirstAware - minionDelay - evt.Time) < ServerDelayConstant);
+                    return !combatData.IsCasting(baseSkillID, evt.Src, evt.Time);
                 });
             }
         }
@@ -34,10 +33,10 @@ namespace GW2EIEvtcParser.EIData
                 .UsingSrcSpecChecker(Spec.Renegade),
             new EffectCastFinder(OrdersFromAbove, EffectGUIDs.RenegadeOrdersFromAbove)
                 .UsingSrcSpecChecker(Spec.Renegade),
-            new BandTogetherCastFinder(BreakrazorsBastionSkillEnhanced, MinionID.EraBreakrazor),
-            new BandTogetherCastFinder(RazorclawsRageSkillEnhanced, MinionID.JasRazorclaw),
-            new BandTogetherCastFinder(DarkrazorsDaringSkillEnhanced, MinionID.KusDarkrazor),
-            new BandTogetherCastFinder(IcerazorsIreSkillEnhanced, MinionID.ViskIcerazor),
+            new BandTogetherCastFinder(BreakrazorsBastionSkill, BreakrazorsBastionSkillEnhanced, EffectGUIDs.RenegadeBreakrazorsBastion),
+            new BandTogetherCastFinder(RazorclawsRageSkill, RazorclawsRageSkillEnhanced, EffectGUIDs.RenegadeRazorclawsRage),
+            new BandTogetherCastFinder(DarkrazorsDaringSkill, DarkrazorsDaringSkillEnhanced, EffectGUIDs.RenegadeDarkrazorsDaring),
+            new BandTogetherCastFinder(IcerazorsIreSkill, IcerazorsIreSkillEnhanced, EffectGUIDs.RenegadeIcerazorsIre),
         };
 
         internal static readonly List<DamageModifierDescriptor> OutgoingDamageModifiers = new List<DamageModifierDescriptor>

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -210,6 +210,10 @@
         public const string RenegadeCitadelBombardmentPortal = "145B288ECA42CF43A40DFD759419C904";
         public const string RenegadeCitadelBombardment1 = "5BBF59761E6B9D49A91E79D5474CC61C";
         public const string RenegadeCitadelBombardment2 = "6C8201B551CF274C9C1AF51C33AA062A"; // duration 0
+        public const string RenegadeBreakrazorsBastion = "72FC15613B4B2C44A1906617998859F9";
+        public const string RenegadeRazorclawsRage = "71B04F91F9B3DF4A8954059FCFAD630E";
+        public const string RenegadeDarkrazorsDaring = "C8FDB04E59C1034CABEFBECE470AA1BC";
+        public const string RenegadeIcerazorsIre = "E725FC2FD486A84EBEAC403DB4DA30DE";
         #endregion
         #region Guardian
         public const string GuardianGenericFlames = "EA98C3533AA46E4A9B550929356B7277"; // used e.g. with judges intervention, signet of judgment

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -4277,11 +4277,16 @@
         public const long InsatiableHunger17 = 72351;
         public const long InsatiableHunger19 = 72352;
         public const long IcerazorsIreSkillMinionReworked = 72353;
+        public const long BandTogetherBuff = 72354;
+        public const long IcerazorsIreSkillEnhanced = 72359;
         public const long DarkrazorsDaringSkillMinionReworked = 72360;
+        public const long RazorclawsRageSkillEnhanced = 72363;
         public const long BreakrazorsBastionSkillMinionReworked = 72365;
+        public const long DarkrazorsDaringSkillEnhanced = 72366;
         public const long RazorclawsRageSkillMinionReworked = 72370;
         public const long SoulcleavesSummitHitReworked = 72376;
         public const long RazorclawsRageHitReworked = 72388;
+        public const long BreakrazorsBastionSkillEnhanced = 72389;
         public const long RageEmpowerment = 72399;
         public const long EnvyAttunement = 72403;
         public const long EnragedSmashEparch = 72437;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -4277,7 +4277,7 @@
         public const long InsatiableHunger17 = 72351;
         public const long InsatiableHunger19 = 72352;
         public const long IcerazorsIreSkillMinionReworked = 72353;
-        public const long BandTogetherBuff = 72354;
+        public const long POV_BandTogetherBuff = 72354;
         public const long IcerazorsIreSkillEnhanced = 72359;
         public const long DarkrazorsDaringSkillMinionReworked = 72360;
         public const long RazorclawsRageSkillEnhanced = 72363;


### PR DESCRIPTION
This adds instant cast finders for the enhanced versions of the Legendary Renegade skills. Initially wanted to to it based on the buff, but turns out it's POV only. Using effects instead now, for the instant casts they occur at the same time as the buff remove.