### PR TITLE
Old Lion's Court Combat Replay

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -600,6 +600,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Malfunctioning Ley-Woven Shielding", MalfunctioningLeyWovenShielding, Source.FightSpecific, BuffClassification.Other, BuffImages.Unblockable),
             new Buff("Power Transfer", PowerTransfer, Source.FightSpecific, BuffStackType.Queue, 99, BuffClassification.Other, BuffImages.SpiritEnergyTracker),
             new Buff("Empowered (Watchknight Triumverate)", EmpoweredWatchknightTriumverate, Source.FightSpecific, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.ChargingEnergies),
+            new Buff("Tribocharge", TribochargePlayerToNPCBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
             new Buff("Achievement Eligibility: Aether Aversion", AchievementEligibilityAetherAversion, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             new Buff("Achievement Eligibility: Fear Not This Knight", AchievementEligibilityFearNotThisKnight, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             new Buff("Achievement Eligibility: Static-Dynamic Synergy", AchievementEligibilityStaticDynamicSynergy, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),

--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -601,6 +601,7 @@ namespace GW2EIEvtcParser.EIData
             new Buff("Power Transfer", PowerTransfer, Source.FightSpecific, BuffStackType.Queue, 99, BuffClassification.Other, BuffImages.SpiritEnergyTracker),
             new Buff("Empowered (Watchknight Triumverate)", EmpoweredWatchknightTriumverate, Source.FightSpecific, BuffStackType.Stacking, 10, BuffClassification.Other, BuffImages.ChargingEnergies),
             new Buff("Tribocharge", TribochargePlayerToNPCBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
+            new Buff("Noxious Vapor Blade (Target)", NoxiousVaporBladeTargetBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.MonsterSkill),
             new Buff("Achievement Eligibility: Aether Aversion", AchievementEligibilityAetherAversion, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             new Buff("Achievement Eligibility: Fear Not This Knight", AchievementEligibilityFearNotThisKnight, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             new Buff("Achievement Eligibility: Static-Dynamic Synergy", AchievementEligibilityStaticDynamicSynergy, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplay.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplay.cs
@@ -644,6 +644,32 @@ namespace GW2EIEvtcParser.EIData
                 Hidden.Add(new Segment(segment));
             }
         }
+
+        /// <summary>
+        /// Adds concentric doughnuts.
+        /// </summary>
+        /// <param name="minRadius">Starting radius.</param>
+        /// <param name="radiusIncrease">Radius increase for each concentric ring.</param>
+        /// <param name="lifespan">Lifespan of the decoration.</param>
+        /// <param name="position">Starting position.</param>
+        /// <param name="color">Color of the rings.</param>
+        /// <param name="initialOpacity">Starting opacity of the rings' color.</param>
+        /// <param name="rings">Total number of rings.</param>
+        /// <param name="inverted">Inverts the opacity direction.</param>
+        internal void AddContrenticRings(uint minRadius, uint radiusIncrease, (long, long) lifespan, Point3D position, Color color, float initialOpacity = 0.5f, int rings = 8, bool inverted = false)
+        {
+            var positionConnector = new PositionConnector(position);
+
+            for (int i = 1; i <= rings; i++)
+            {
+                uint maxRadius = minRadius + radiusIncrease;
+                float opacity = inverted ? initialOpacity * i : initialOpacity / i;
+                var circle = new DoughnutDecoration(minRadius, maxRadius, lifespan, color, opacity, positionConnector);
+                AddDecorationWithBorder(circle, color, 0.2);
+                minRadius = maxRadius;
+            }
+            
+        }
     }
 }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -843,8 +843,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                             (long start, long end) lifespan = (orbEffect.Time, orbEffect.Time + duration);
                             // Radius is an estimate - orb exploding on edge doesn't quite cover the entirety of the arena
                             uint radius = 2700;
-                            var circle = (CircleDecoration)new CircleDecoration(radius, lifespan, Colors.White, 0.2, new PositionConnector(orbEffect.Position)).UsingFilled(false);
-                            replay.AddDecorationWithGrowing(circle, lifespan.end);
+                            replay.AddShockwave(new PositionConnector(orbEffect.Position), lifespan, Colors.White, 0.2, radius);
                         }
                     }
                     // Breakbar Active
@@ -1810,8 +1809,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                     continue;
                 }
                 int puddleEnd = Math.Min((int)dragonVoid.LastAware, start + duration);
-                EnvironmentDecorations.Add(new CircleDecoration(radius, (start, puddleEnd), "rgba(250, 0, 0, 0.3)", new PositionConnector(effect.Position)).UsingGrowingEnd(start + inactiveDuration));
-                EnvironmentDecorations.Add(new CircleDecoration(radius, (start, puddleEnd), "rgba(250, 0, 0, 0.3)", new PositionConnector(effect.Position)));
+                EnvironmentDecorations.Add(new CircleDecoration(radius, (start, puddleEnd), Colors.Red, 0.2, new PositionConnector(effect.Position)).UsingGrowingEnd(start + inactiveDuration));
+                EnvironmentDecorations.Add(new CircleDecoration(radius, (start, puddleEnd), Colors.Red, 0.2, new PositionConnector(effect.Position)));
             }
         }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -1347,20 +1347,8 @@ namespace GW2EIEvtcParser.EncounterLogic
                     {
                         foreach (EffectEvent effect in gravityCrushIndicators)
                         {
-                            uint minRadius = 0;
-                            uint radiusIncrease = 40;
-                            float initialOpacity = 0.5f;
                             (long start, long end) lifespan = effect.ComputeLifespan(log, 1600);
-                            var positionConnector = new PositionConnector(effect.Position);
-                            // The indicator has 8 circles
-                            for (int i = 1; i <= 8; i++)
-                            {
-                                uint maxRadius = minRadius + radiusIncrease;
-                                float opacity = initialOpacity / i;
-                                var circle = new CircleDecoration(maxRadius, minRadius, lifespan, Colors.Orange, opacity, positionConnector);
-                                replay.AddDecorationWithBorder(circle, Colors.Orange, 0.2);
-                                minRadius = maxRadius;
-                            }
+                            replay.AddContrenticRings(0, 40, lifespan, effect.Position, Colors.Orange);
                         }
                     }
                     // Nightmare Epoch - AoEs

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
@@ -491,6 +491,48 @@ namespace GW2EIEvtcParser.EncounterLogic
                         }
                     }
 
+                    // Pernicious Vortex - First Indicator - Orange Doughnuts
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.OldLionsCourtPerniciousVortexWarning1, out IReadOnlyList<EffectEvent> vortexWarnings1))
+                    {
+                        foreach (EffectEvent effect in vortexWarnings1)
+                        {
+                            (long start, long end) lifespan = effect.ComputeLifespan(log, 4000);
+                            replay.AddContrenticRings(0, 120, lifespan, effect.Position, Colors.LightOrange);
+                        }
+                    }
+                    // Pernicious Vortex - Second Indicator - Red Ring
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.OldLionsCourtPerniciousVortexWarning2, out IReadOnlyList<EffectEvent> vortexWarnings2))
+                    {
+                        foreach (EffectEvent effect in vortexWarnings2)
+                        {
+                            (long start, long end) lifespan = effect.ComputeLifespan(log, 4000);
+                            var circle = (CircleDecoration)new CircleDecoration(300, lifespan, Colors.Red, 0.3, new PositionConnector(effect.Position)).UsingFilled(false);
+                            replay.Decorations.Add(circle);
+                        }
+                    }
+
+                    // Pernicious Vortex - Damage Indicator
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.OldLionsCourtPerniciousVortexActive, out IReadOnlyList<EffectEvent> vortexDamage))
+                    {
+                        foreach (EffectEvent effect in vortexDamage)
+                        {
+                            (long start, long end) lifespan = effect.ComputeLifespan(log, 5000);
+                            var circle = new CircleDecoration(300, lifespan, Colors.Red, 0.3, new PositionConnector(effect.Position));
+                            replay.Decorations.Add(circle);
+                        }
+                    }
+
+                    // Rupture
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.OldLionsCourtRuptureIndicator, out IReadOnlyList<EffectEvent> ruptures))
+                    {
+                        foreach (EffectEvent effect in ruptures)
+                        {
+                            (long start, long end) lifespan = effect.ComputeDynamicLifespan(log, 2000);
+                            var circle = new CircleDecoration(180, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position));
+                            replay.AddDecorationWithGrowing(circle, lifespan.end);
+                        }
+                    }
+
                     // Hide when inactive
                     replay.AddHideByBuff(target, log, Determined762);
                     break;
@@ -561,6 +603,19 @@ namespace GW2EIEvtcParser.EncounterLogic
                             var rotation = new AngleConnector(effect.Rotation.Z + 90);
                             var pie = (PieDecoration)new PieDecoration(3000, 120, lifespan, Colors.White, 0.2, new PositionConnector(effect.Position)).UsingRotationConnector(rotation);
                             replay.Decorations.Add(pie);
+                        }
+                    }
+
+                    // Crackling Wind
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.OldLionsCourtCracklingWindIndicator, out IReadOnlyList<EffectEvent> crackingWind))
+                    {
+                        foreach (EffectEvent effect in crackingWind)
+                        {
+                            (long start, long end) lifespan = effect.ComputeLifespan(log, 4000);
+                            replay.AddContrenticRings(0, 140, lifespan, effect.Position, Colors.LightOrange, 0.01f, 8, true);
+                            // Add bigger doughnut past 1120 radius (140 * 8)
+                            var doughnut = new DoughnutDecoration(1120, 2500, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position));
+                            replay.Decorations.Add(doughnut);
                         }
                     }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/OldLionsCourt.cs
@@ -27,26 +27,29 @@ namespace GW2EIEvtcParser.EncounterLogic
                 new PlayerDstHitMechanic(new long [] { NoxiousVaporBlade, NoxiousVaporBladeCM }, "Noxious Vapor Blade", new MechanicPlotlySetting(Symbols.CircleXOpen, Colors.Green), "BladeOut.H", "Hit by Noxious Vapor Blade (to player)", "Noxious Vapor Blade Hit", 150),
                 new PlayerDstHitMechanic(new long [] { NoxiousReturn, NoxiousReturnCM }, "Noxious Return", new MechanicPlotlySetting(Symbols.CircleX, Colors.Green), "BladeBack.H", "Hit by Noxious Return (to Arsenite)", "Noxious Return Hit", 150),
                 new PlayerDstHitMechanic(new long [] { BoilingAetherRedBlueNM, BoilingAetherRedBlueCM, BoilingAetherGreenNM, BoilingAetherGreenCM }, "Boiling Aether", new MechanicPlotlySetting(Symbols.CircleCrossOpen, Colors.Red), "AethAver.Achiv", "Achievement Eligibility: Aether Aversion", "Achiv Aether Aversion", 150).UsingAchievementEligibility(true),
-                new PlayerDstSkillMechanic(ExhaustPlume, "Exhaust Plume", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Red), "VermFall.H", "Hit by Exhaust Plume (Vermilion Fall)", "Exhaust Plume Hit (Vermilion)", 150).UsingChecker((de, log) => de.CreditedFrom.IsAnySpecies(new List<ArcDPSEnums.TargetID> { TargetID.PrototypeVermilion, TargetID.PrototypeVermilionCM })),
-                new PlayerDstSkillMechanic(ExhaustPlume, "Exhaust Plume", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Green), "ArseFall.H", "Hit by Exhaust Plume (Arsenite Fall)", "Exhaust Plume Hit (Arsenite)", 150).UsingChecker((de, log) => de.CreditedFrom.IsAnySpecies(new List<ArcDPSEnums.TargetID> { TargetID.PrototypeArsenite, TargetID.PrototypeArseniteCM })),
-                new PlayerDstSkillMechanic(ExhaustPlume, "Exhaust Plume", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Blue), "IndiFall.H", "Hit by Exhaust Plume (Indigo Fall)", "Exhaust Plume Hit (Indigo)", 150).UsingChecker((de, log) => de.CreditedFrom.IsAnySpecies(new List<ArcDPSEnums.TargetID> { TargetID.PrototypeIndigo, TargetID.PrototypeIndigoCM })),
+                new PlayerDstHitMechanic(new long [] { PerniciousVortex, PerniciousVortexCM }, "Pernicious Vortex", new MechanicPlotlySetting(Symbols.CircleX, Colors.DarkGreen), "PernVort.H", "Hit by Pernicious Vortex (Pull)", "Pernicious Vortex Hit", 0),
+                new PlayerDstHitMechanic(new long [] { CracklingWind, CracklingWindCM }, "Crackling Wind", new MechanicPlotlySetting(Symbols.Hexagon, Colors.CobaltBlue), "CrackWind.H", "Hit by Crackling Wind (Push)", "Crackling Wind Hit", 0),
+                new PlayerDstSkillMechanic(ExhaustPlume, "Exhaust Plume", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Red), "VermFall.H", "Hit by Exhaust Plume (Vermilion Fall)", "Exhaust Plume Hit (Vermilion)", 150).UsingChecker((de, log) => de.CreditedFrom.IsAnySpecies(new List<TargetID> { TargetID.PrototypeVermilion, TargetID.PrototypeVermilionCM })),
+                new PlayerDstSkillMechanic(ExhaustPlume, "Exhaust Plume", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Green), "ArseFall.H", "Hit by Exhaust Plume (Arsenite Fall)", "Exhaust Plume Hit (Arsenite)", 150).UsingChecker((de, log) => de.CreditedFrom.IsAnySpecies(new List<TargetID> { TargetID.PrototypeArsenite, TargetID.PrototypeArseniteCM })),
+                new PlayerDstSkillMechanic(ExhaustPlume, "Exhaust Plume", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Blue), "IndiFall.H", "Hit by Exhaust Plume (Indigo Fall)", "Exhaust Plume Hit (Indigo)", 150).UsingChecker((de, log) => de.CreditedFrom.IsAnySpecies(new List<TargetID> { TargetID.PrototypeIndigo, TargetID.PrototypeIndigoCM })),
                 new PlayerDstBuffApplyMechanic(Spaghettification, "Spaghettification", new MechanicPlotlySetting(Symbols.Bowtie, Colors.DarkRed), "Spgt.H", "Hit by Spaghettification", "Spaghettification Hit", 0),
                 new PlayerDstBuffApplyMechanic(Dysapoptosis, "Dysapoptosis", new MechanicPlotlySetting(Symbols.BowtieOpen, Colors.DarkRed), "Dysp.H", "Hit by Dysapoptosis", "Dysapoptosis Hit", 0),
                 new PlayerDstBuffApplyMechanic(ThunderingUltimatum, "Thundering Ultimatum", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.DarkRed), "ThunUlti.H", "Hit by Thundering Ultimatum", "Thunderin gUltimatum Hit", 0),
                 new PlayerDstBuffApplyMechanic(new long [] { TidalTorment, TidalTormentCM }, "Tidal Torment", new MechanicPlotlySetting(Symbols.Star, Colors.Red), "TidTorm.A", "Tidal Torment Applied", "Tidal Torment Applied", 0),
                 new PlayerDstBuffApplyMechanic(new long [] { ErgoShear, ErgoShearCM }, "Ergo Shear", new MechanicPlotlySetting(Symbols.StarOpen, Colors.Red), "ErgShr.A", "Ergo Shear Applied", "Ergo Shear Applied", 0),
-                new PlayerDstBuffApplyMechanic(FixatedOldLionsCourt, "Fixated (Vermilion)", new MechanicPlotlySetting(Symbols.Diamond, Colors.Red), "Fix.Verm.A", "Fixated Applied", "Fixated Applied", 0).UsingChecker((bae, log) => bae.CreditedBy.IsAnySpecies(new List<ArcDPSEnums.TargetID> { TargetID.PrototypeVermilion, TargetID.PrototypeVermilionCM })),
-                new PlayerDstBuffApplyMechanic(FixatedOldLionsCourt, "Fixated (Arsenite)", new MechanicPlotlySetting(Symbols.Diamond, Colors.Green), "Fix.Arse.A", "Fixated Applied", "Fixated Applied", 0).UsingChecker((bae, log) => bae.CreditedBy.IsAnySpecies(new List<ArcDPSEnums.TargetID> { TargetID.PrototypeArsenite, TargetID.PrototypeArseniteCM })),
-                new PlayerDstBuffApplyMechanic(FixatedOldLionsCourt, "Fixated (Indigo)", new MechanicPlotlySetting(Symbols.Diamond, Colors.Blue), "Fix.Indi.A", "Fixated Applied", "Fixated Applied", 0).UsingChecker((bae, log) => bae.CreditedBy.IsAnySpecies(new List<ArcDPSEnums.TargetID> { TargetID.PrototypeIndigo, TargetID.PrototypeIndigoCM })),
+                new PlayerDstBuffApplyMechanic(FixatedOldLionsCourt, "Fixated (Vermilion)", new MechanicPlotlySetting(Symbols.Diamond, Colors.Red), "Fix.Verm.A", "Fixated Applied", "Fixated Applied", 0).UsingChecker((bae, log) => bae.CreditedBy.IsAnySpecies(new List<TargetID> { TargetID.PrototypeVermilion, TargetID.PrototypeVermilionCM })),
+                new PlayerDstBuffApplyMechanic(FixatedOldLionsCourt, "Fixated (Arsenite)", new MechanicPlotlySetting(Symbols.Diamond, Colors.Green), "Fix.Arse.A", "Fixated Applied", "Fixated Applied", 0).UsingChecker((bae, log) => bae.CreditedBy.IsAnySpecies(new List<TargetID> { TargetID.PrototypeArsenite, TargetID.PrototypeArseniteCM })),
+                new PlayerDstBuffApplyMechanic(FixatedOldLionsCourt, "Fixated (Indigo)", new MechanicPlotlySetting(Symbols.Diamond, Colors.Blue), "Fix.Indi.A", "Fixated Applied", "Fixated Applied", 0).UsingChecker((bae, log) => bae.CreditedBy.IsAnySpecies(new List<TargetID> { TargetID.PrototypeIndigo, TargetID.PrototypeIndigoCM })),
+                new PlayerDstBuffApplyMechanic(NoxiousVaporBladeTargetBuff, "Noxious Vapor Blade", new MechanicPlotlySetting(Symbols.CircleCross, Colors.Green), "Blade.A", "Targetted for Noxious Vapor Blade", "Noxious Vapor Blade Target", 0),
                 new EnemyDstBuffApplyMechanic(EmpoweredWatchknightTriumverate, "Empowered", new MechanicPlotlySetting(Symbols.TriangleUp, Colors.Blue), "Empowered.A", "Knight gained Empowered", "Empowered Applied", 0),
                 new EnemyDstBuffApplyMechanic(PowerTransfer, "Power Transfer", new MechanicPlotlySetting(Symbols.TriangleRight, Colors.Blue), "PwrTrns.A", "Knight gained Power Transfer", "Power Transfer Applied", 0),
                 new EnemyDstBuffApplyMechanic(LeyWovenShielding, "Ley-Woven Shielding", new MechanicPlotlySetting(Symbols.Pentagon, Colors.Teal), "WovShld.A", "Knight gained Ley-Woven Shielding", "Ley-Woven Shielding Applied", 0),
                 new EnemyDstBuffApplyMechanic(MalfunctioningLeyWovenShielding, "Malfunctioning Ley-Woven Shielding", new MechanicPlotlySetting(Symbols.PentagonOpen, Colors.DarkTeal), "MalfWovShld.A", "Knight gained Malfunctioning Ley-Woven Shielding", "Malfunctioning Ley-Woven Shielding Applied", 0),
                 new EnemyDstBuffApplyMechanic(Exposed31589, "Exposed (Knight)", new MechanicPlotlySetting(Symbols.HexagonOpen, Colors.Purple), "Expo.A", "Exposed Applied to Knight", "Exposed Applied to Knight", 0),
                 new EnemyCastStartMechanic(new long [] { DualHorizon, DualHorizonCM }, "Dual Horizon", new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.Red), "DualHrz.C", "Casted Dual Horizon", "Dual Horizon Cast", 0),
-                //new EnemyCastStartMechanic(new long [] { GravitationalWave, GravitationalWaveCM }, "Gravitational Wave", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.Red), "GravWave.C", "Casted Gravitational Wave", "Gravitational Wave", 0), // TODO: Find effect event
-                //new EnemyCastStartMechanic(new long [] { PerniciousVortex, PerniciousVortexCM }, "Pernicious Vortex", new MechanicPlotlySetting(Symbols.TriangleUp, Colors.Green), "PrnVrx.C", "Casted Pernicious Vortex", "Pernicious Vortex Cast", 0), // TODO: Find effect event
-                //new EnemyCastStartMechanic(new long [] { CracklingWind, CracklingWindCM }, "Crackling Wind", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Blue), "CrckWind.C", "Casted Crackling Wind", "Cracking Wind Cast", 0), // TODO: Find effect event
+                new EnemyCastStartMechanic(new long [] { PerniciousVortexSkillNM, PerniciousVortexSkillCM }, "Pernicious Vortex", new MechanicPlotlySetting(Symbols.TriangleUp, Colors.Green), "PrnVrx.C", "Casted Pernicious Vortex", "Pernicious Vortex Cast", 0),
+                new EnemyCastStartMechanic(new long [] { CracklingWindSkillNM, CracklingWindSkillCM }, "Crackling Wind", new MechanicPlotlySetting(Symbols.Star, Colors.Blue), "CrckWind.C", "Casted Crackling Wind", "Cracking Wind Cast", 0),
+                new EnemySrcEffectMechanic(EffectGUIDs.OldLionsCourtGravitationalWave, "Gravitational Wave", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.Red), "GravWave.C", "Casted Gravitational Wave", "Gravitational Wave", 0),
             }
             );
             Icon = EncounterIconOldLionsCourt;
@@ -473,9 +476,9 @@ namespace GW2EIEvtcParser.EncounterLogic
                         foreach (EffectEvent effect in leftSemiCircle)
                         {
                             (long start, long end) lifespan = effect.HasDynamicEndTime ? effect.ComputeDynamicLifespan(log, 30000) : effect.ComputeLifespan(log, 1500);
-                            var rotation = new AngleConnector(effect.Rotation.Z);
+                            var rotation = new AngleConnector(effect.Rotation.Z); // Position incorrect
                             var pie = (PieDecoration)new PieDecoration(3000, 180, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position)).UsingRotationConnector(rotation);
-                            replay.Decorations.Add(pie);
+                            //replay.Decorations.Add(pie);
                         }
                     }
 
@@ -500,6 +503,7 @@ namespace GW2EIEvtcParser.EncounterLogic
                             replay.AddContrenticRings(0, 120, lifespan, effect.Position, Colors.LightOrange);
                         }
                     }
+                    
                     // Pernicious Vortex - Second Indicator - Red Ring
                     if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.OldLionsCourtPerniciousVortexWarning2, out IReadOnlyList<EffectEvent> vortexWarnings2))
                     {

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -990,6 +990,8 @@ namespace GW2EIEvtcParser
             TheMindbladeCM = 25280,
             SpiritOfPain = 23793,
             SpiritOfDestruction = 23961,
+            // Old Lion's Court
+            Tribocharge = 25424,
             // Cosmic Observatory
             TheTormented = 26016,
             VeteranTheTormented = 25829,

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -717,6 +717,30 @@
         public const string HarvestTempleVoidObliteratorFirebomb = "D2E7228A6225FB44911507A45EF2CCEC"; // duration 21000
         public const string HarvestTempleVoidObliteratorShockwave = "4254DCF4AF72FF4A83847908DA98E427"; // duration 0, should probably be 2900
         // Old Lion's Court
+        public const string OldLionsCourtExhaustPlumeAoE = "E273E005F90E3041939C6235FF9CADBA"; // All Knights Src - Duration 5000 - AoE
+        public const string OldLionsCourtBoilingAetherExpanding = "CBD8C6AE14B69A43A9596B94C402B9F3"; // All Knights Src - Duration 10000
+        public const string OldLionsCourtBoilingAetherFullyExpanded1 = "77D73A835CEE5446ACD9D8C5BDF99BB0"; // All Knights Src - Duration 590000 - Has End Event
+        public const string OldLionsCourtBoilingAetherFullyExpanded2 = "6BA3A84984190042A31400D52637B141"; // All Knights Src - Duration 590000 - Has End Event
+        public const string OldLionsCourtSpaghettificationDoughnutStart = "40A9EFF40B532140A615020A6419EBE4"; // Red Knight Src - Duration 1500 or 30000 - Doughnut AoE - Has End Event if 30000
+        public const string OldLionsCourtSpaghettificationCircleFlipped = "9306700A06F4B14EBC91318C24535280"; // Red Knight Src - Duration 1500 or 30000 - Circle AoE - Has End Event if 30000
+        public const string OldLionsCourtSpaghettificationCircleDetonation = "549A02C94E642B45BF35EBEE84CF72CC"; // Red Knight Src - Duration 1500 - Circle AoE - Has End Event
+        public const string OldLionsCourtSpaghettificationDoughnutDetonation = "B7FB4A5607D3284EBAA649A39861EE5C"; // Red Knight Src - Duration 0 - Doughnut AoE
+        public const string OldLionsCourtSpaghettificationSafeZoneSemiCircle = "A9544AB8A84EED468817138BAFB79551"; // Red Knight Src - Duration 30000 - Safe Zone Semi Circle AoE - Has End Event
+        public const string OldLionsCourtSpaghettificationSafeZoneFullCircle = "5718748DF0A13B438ACBBD156BADCFEE"; // Red Knight Src - Duration 30000 - Safe Zone FUll Circle AoE - Has End Event
+        public const string OldLionsCourtDualHorizonOrange = "533D8FC0542C2F41ADC6515141E38501"; // Red Knight Src - Duration 4100 - AoE Doughnut
+        public const string OldLionsCourtDualHorizonWhiteOuter = "182666D5B4B6E64AAE8423D76012E9B0"; // Red Knight Src - Duration 4000 - White Outer
+        public const string OldLionsCourtDualHorizonWhiteInner = "F51B10029E0537488BAE346558A22F02"; // Red Knight Src - Duration 4000 - White Inner
+        public const string OldLionsCourtThunderingUltimatumFrontalCone = "687C781108ED664DB17B7B501C942ADC"; // Blue Knight Src - Duration 1500 or 30000 - Frontal Cone AoE - Has End Event if 30000
+        public const string OldLionsCourtThunderingUltimatumFlipCone = "DFD5DF9B331D9C45A5E592EA2E39695D"; // Blue Knight Src - Duration 1500 or 30000 - Flip Cone AoE - Has End Event if 30000
+        public const string OldLionsCourtThunderingUltimatumDetonation = "676C0B284588FC40829C2F09F07BCDFD"; // Blue Knight Src - Duration 0 - Detonation AoE
+        public const string OldLionsCourtThunderingUltimatumSafeZone = "8119770118A16243BAE86724E575753A"; // Blue Knight Src - Duration 30000 - Safe Zone AoE - Has End Event
+        public const string OldLionsCourtDysapoptosisIndicator = "49BD1C09B29DEC49AFE85E15D070108F"; // Green Knight Src - Duration 1500 or 30000 - Incorrect logged position - Has End Event if 30000
+        public const string OldLionsCourtDysapoptosisDetonation = "909CBB96C7FA0A47A7AFB7764457786F"; // Green Knight Src - Duration 0 - Semi Circle AoE
+        public const string OldLionsCourtTriBoltSpread = "740D0839AD1AD749A92B06E40765BBF2"; // Blue Knight Src - Player Dst - Duration 2000 - Triple Spread AoE
+        public const string OldLionsCourtTribocharge = "CB4C61AE8EF4FC468B185E126FD42C81"; // Tribocharge Src - No Dst - Duration 5000
+        public const string OldLionsCourtGravitationalWave = "B329CFB6B354C148A537E114DC14CED6"; // Red Knight Src - No Dst - Duration 0 - Safe effect as Harvest Temple Orb Explosion
+        public const string OldLionsCourtGravityHammer = "D11320204E28E643A48469AA8E4845BA"; // Red Knight Src - Duration 1000 - Third Autoattack Indicator AoE
+        public const string OldLionsCourtBoilingAetherSpawnIndicator = "34724E94CD4E974C95A8D9D1D1162658"; // Red Knight Src - Duration 1190
         // Cosmic Observatory
         public const string CosmicObservatoryDemonicBlastSliceIndicator = "A21A92783688A847963B86E96B8CC9BE";
         public const string CosmicObservatoryDemonicBlastDagdaEffect1 = "D03CDF37E0AC8246ABD4E741ADD61427"; // 0 duration no effect end

--- a/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/EffectGUIDs.cs
@@ -741,6 +741,11 @@
         public const string OldLionsCourtGravitationalWave = "B329CFB6B354C148A537E114DC14CED6"; // Red Knight Src - No Dst - Duration 0 - Safe effect as Harvest Temple Orb Explosion
         public const string OldLionsCourtGravityHammer = "D11320204E28E643A48469AA8E4845BA"; // Red Knight Src - Duration 1000 - Third Autoattack Indicator AoE
         public const string OldLionsCourtBoilingAetherSpawnIndicator = "34724E94CD4E974C95A8D9D1D1162658"; // Red Knight Src - Duration 1190
+        public const string OldLionsCourtPerniciousVortexWarning1 = "6BDC9DB69C2BD643828419CB58957901"; // Green Knight Src - Duration 4000
+        public const string OldLionsCourtPerniciousVortexWarning2 = "E10DD1D759499749B880B99945C823B5"; // Green Knight Src - Duration 4000
+        public const string OldLionsCourtPerniciousVortexActive = "A4F4B2C3DA211040B9BFAAA8DA801807"; // Green Knight Src - Duration 5000
+        public const string OldLionsCourtCracklingWindIndicator = "4B569B684D489B4592AF8285A3A4B401"; // Blue Knight Src - Duration 4000
+        public const string OldLionsCourtRuptureIndicator = "2A42D5E57617DF46A22B34485D6F3831"; // Green Knight Src - Duration 2000
         // Cosmic Observatory
         public const string CosmicObservatoryDemonicBlastSliceIndicator = "A21A92783688A847963B86E96B8CC9BE";
         public const string CosmicObservatoryDemonicBlastDagdaEffect1 = "D03CDF37E0AC8246ABD4E741ADD61427"; // 0 duration no effect end

--- a/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserIcons.cs
@@ -399,6 +399,7 @@ namespace GW2EIEvtcParser.ParserHelpers
         private const string TrashAngeredSpirit = "https://i.imgur.com/5cjAJN8.png";
         private const string TrashEnragedSpirit = "https://i.imgur.com/6gbEvy3.png";
         private const string TrashDerangedSpirit = "https://i.imgur.com/lLx4SGw.png";
+        private const string TrashTribocharge = "https://i.imgur.com/6RAiqQT.png";
         #endregion
 
         #region Minion
@@ -1272,6 +1273,7 @@ namespace GW2EIEvtcParser.ParserHelpers
             { TrashID.EnragedSpiritSR, TrashEnragedSpirit },
             { TrashID.DerangedSpiritSR, TrashDerangedSpirit },
             { TrashID.DerangedSpiritSR2, TrashDerangedSpirit },
+            { TrashID.Tribocharge, TrashTribocharge },
         };
 
         /// <summary>

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -3944,6 +3944,7 @@
         public const long ToxicSlice = 68308;
         public const long TriBoltCM = 68318;
         public const long NakedSingularity = 68319;
+        public const long PerniciousVortexSkillNM = 68326;
         public const long TidalTorment = 68330;
         public const long TidalTormentCM = 68332;
         public const long DualHorizon = 68336;
@@ -3957,11 +3958,14 @@
         public const long AchievementEligibilityFearNotThisKnight = 68378;
         public const long NoxiousReturn = 68382;
         public const long ThunderingUltimatum = 68393;
+        public const long NoxiousVaporBladeTargetBuff = 68401;
         public const long MassDriver = 68402;
+        public const long PerniciousVortexSkillCM = 68407;
         public const long AchievementEligibilityAetherAversion = 68412;
         public const long NoxiousVaporBladeCM = 68414;
         public const long GravityHammer = 68415;
         public const long ExhaustPlume = 68316;
+        public const long CracklingWindSkillCM = 68419;
         public const long Rupture = 68420;
         public const long NoxiousReturnCM = 68425;
         public const long DualHorizonCM = 68435;
@@ -3987,6 +3991,7 @@
         public const long Relapse = 68544;
         public const long ErgoShear = 68546;
         public const long GravityHammerCM = 68556;
+        public const long CracklingWindSkillNM = 68560;
         public const long FixatedOldLionsCourt = 68562;
         public const long BoilingAetherRedBlueCM = 68580;
         public const long DormantCourage = 68585;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -3947,6 +3947,7 @@
         public const long TidalTorment = 68330;
         public const long TidalTormentCM = 68332;
         public const long DualHorizon = 68336;
+        public const long TribochargePlayerToNPCBuff = 68342;
         public const long NoxiousVaporBlade = 68346;
         public const long GravitationalWaveCM = 68352;
         public const long GravitationalWave = 68354;


### PR DESCRIPTION
# Every Knight
- [x] Exhaust Plume (Knight Fall AoE)
- [x] Boiling Aether Expanding (Normal Mode and Challenge Mode)
- [x] Boiling Aether Expanded (Normal Mode and Challenge Mode)

# Red Knight
- [x] Spaghettification Doughnut
- [x] Spaghettification Circle (Flip)
- [x] Spaghettification Doughnut Detonation
- [x] Spaghettification Circle Detonation (Flip)
- [x] Safe Zone - Semi Circle
- [x] Safe Zone - Full Circle
- [x] Dual Horizon - Orange Doughnut
- [x] Dual Horizon - Inner White (PoV)
- [x] Dual Horizon - Outer White (PoV)
- [x] Gravity Hammer
- [x] Gravitational Wave
- [x] Boiling Aether Spawn

# Green Knight
- [ ] Dysapoptosis Semi Circle Indicator (WIP - Not correctly positioned)
- [x] Dysapoptosis Semi Circle Detonation
- [x] Pernicious Vortex Orange Doughnuts
- [x] Pernicious Vortex Red Ring
- [x] Pernicious Vortex Red AoE
- [x] Rupture Indicator
- [x] ~Noxious Vapor Blade (The blade can curve to follow the player)~
- [x] ~Noxious Return~

# Blue Knight
- [x] Thundering Ultimatum Frontal Cone
- [x] Thundering Ultimatum Flip Cone
- [ ] Thundering Ultimatum Detonation (WIP - Not correctly positioned)
- [x] Safe Zone
- [x] Crackling Wind

# Tribocharge
- [x] Added NPC ID and decoration.

# Buffs
- [x] Noxious Vapor Blade Target
- [x] Tribocharge

# Mechanics
- [x] Hit by Crackling Wind
- [x] Hit by Pernicious Vortex
- [x] Casted Crackling Wind
- [x] Casted Pernicious Vortex
- [x] Casted Gravitational Wave

# Misc
- Moved Harvest Temple Orb Explosion to be using the AddShockwave API.
- Moved Harvest Temple Gravity Crush to be using the new AddConcentricRings API.
- Moved Harvest Temple Puddles to be using Colors.Red.