### PR TITLE
hopefully fixed a crash during paralell parsing caused by overzealous pool clrearing after stable sort

### DIFF
--- a/GW2EIEvtcParser/ListExtensions.cs
+++ b/GW2EIEvtcParser/ListExtensions.cs
@@ -130,7 +130,7 @@ public static partial class ListExt
         }
     }
 
-    /// Reserves space at least 'count' additional elements in the list should they not fit already.
+    /// <summary>Reserves space for at least 'count' additional elements in the list should they not fit already.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ReserveAdditional<T>(this List<T> list, int count)
     {
@@ -140,7 +140,7 @@ public static partial class ListExt
         }
     }
 
-    /// Reserves space at least 'count' additional elements in the list should they not fit already.
+    /// <summary>Reserves space for at least 'count' additional elements in the set should they not fit already.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ReserveAdditional<T>(this HashSet<T> set, int count)
     {
@@ -153,7 +153,7 @@ public static partial class ListExt
         StableSort<T>.fluxsort(span, cmp);
         if(!typeof(T).IsValueType)
         {
-            ClearableSharedArrayPool<T>.Shared.ClearAll();
+            ClearableSharedArrayPool<T>.Shared.ClearAllThreadLocal(); // make sure to not mess with other threads pools
         }
     }
 


### PR DESCRIPTION
Fix for an issue discussed on discord.  
[tracking] https://discord.com/channels/456611641526845473/1139667440465354752/1310615512643932180

Unfortunately I was not able to reproduce the issue, so do some more testing to see if it actually resolved the issue before you merge this.

As noted in the comment on the method this still isn't perfectly stable in Task contexts, as two separate tasks could use the same threadlocal storage which would cause the same issue.

If we want this to work with tasks we will have to get more creative. Not impossible, but more work.



