### PR TITLE
Progressbar decoration

### DIFF
--- a/GW2EIBuilders/Resources/JS/CR-JS/animator.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/animator.js
@@ -232,6 +232,9 @@ class Animator {
                 case "Rectangle":
                     MetadataClass = RectangleDecorationMetadata;
                     break;
+                case "ProgressBar":
+                    MetadataClass = ProgressBarDecorationMetadata;
+                    break;
                 case "BackgroundIconDecoration":
                     MetadataClass = IconDecorationMetadata;
                     break;
@@ -240,6 +243,9 @@ class Animator {
                     break;
                 case "IconOverheadDecoration":
                     MetadataClass = IconOverheadDecorationMetadata;
+                    break;
+                case "OverheadProgressBar":
+                    MetadataClass = OverheadProgressBarDecorationMetadata;
                     break;
                 case "MovingPlatform":
                     MetadataClass = MovingPlatformDecorationMetadata;
@@ -314,6 +320,9 @@ class Animator {
                     case "Rectangle":
                         DecorationClass = RectangleMechanicDrawable;
                         break;
+                    case "ProgressBar":
+                        DecorationClass = ProgressBarMechanicDrawable;
+                        break;
                     case "Doughnut":
                         DecorationClass = DoughnutMechanicDrawable;
                         break;
@@ -328,6 +337,9 @@ class Animator {
                         break;
                     case "IconOverheadDecoration":
                         this.overheadActorData.push(new IconOverheadMechanicDrawable(decorationRendering));
+                        continue;
+                    case "OverheadProgressBar":
+                        this.overheadActorData.push(new OverheadProgressBarMechanicDrawable(decorationRendering));
                         continue;
                     case "SquadMarkerDecoration":
                         this.squadMarkerData.push(new IconMechanicDrawable(decorationRendering));

--- a/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
@@ -759,21 +759,21 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
             ctx.lineWidth = (2 / animator.scale).toString();
             ctx.strokeStyle = this.color;
             ctx.stroke();
-        }
-        if (progressPercent < 1) {
-            const reverseProgressPercent = 1.0 - progressPercent;
-            ctx.beginPath();
-            ctx.rect((- 0.5 + progressPercent) * size.w, - 0.5 * size.h, reverseProgressPercent * size.w, size.h);
-            ctx.closePath();
-            ctx.fillStyle = this.secondaryColor;
-            ctx.fill();
-            //
-            ctx.beginPath();
-            ctx.rect((- 0.5 + progressPercent) * size.w, - 0.5 * size.h, reverseProgressPercent * size.w, size.h);
-            ctx.closePath();
-            ctx.lineWidth = (2 / animator.scale).toString();
-            ctx.strokeStyle = this.secondaryColor;
-            ctx.stroke();
+            if (progressPercent < 1) {
+                const reverseProgressPercent = 1.0 - progressPercent;
+                ctx.beginPath();
+                ctx.rect((- 0.5 + progressPercent) * size.w, - 0.5 * size.h, reverseProgressPercent * size.w, size.h);
+                ctx.closePath();
+                ctx.fillStyle = this.secondaryColor;
+                ctx.fill();
+                //
+                ctx.beginPath();
+                ctx.rect((- 0.5 + progressPercent) * size.w, - 0.5 * size.h, reverseProgressPercent * size.w, size.h);
+                ctx.closePath();
+                ctx.lineWidth = (2 / animator.scale).toString();
+                ctx.strokeStyle = this.secondaryColor;
+                ctx.stroke();
+            }
         }
         ctx.restore();
     }

--- a/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
@@ -741,7 +741,7 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
         if (secondaryOffset) {
             ctx.translate(secondaryOffset.x, secondaryOffset.y);
         }
-        const normalizedRot = Math.abs(((rot + this.rotationOffset) / Math.PI) % 2);
+        const normalizedRot = Math.abs((ToRadians(rot + this.rotationOffset) / Math.PI) % 2);
         if (0.5 < normalizedRot && normalizedRot < 1.5) {
             // make sure the progress bar remains upright
             ctx.rotate(-ToRadians(180));
@@ -800,7 +800,7 @@ class OverheadProgressBarMechanicDrawable extends ProgressBarMechanicDrawable {
             x: 0,
             y: 0,
         };
-        offset.y -= masterSize / 4 + this.getSize().h / 2;
+        offset.y -= masterSize / 4 + this.getSize().h;
         return offset;
     }
 

--- a/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
@@ -754,6 +754,13 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
             ctx.fill();     
             //
             ctx.beginPath();
+            ctx.rect(- 0.5 * size.w, - 0.5 * size.h, progressPercent * size.w, size.h);
+            ctx.closePath();
+            ctx.lineWidth = (3 / animator.scale).toString();
+            ctx.strokeStyle = this.color;
+            ctx.stroke();
+            //
+            ctx.beginPath();
             ctx.rect(- 0.5 * size.w, - 0.5 * size.h, size.w, size.h);
             ctx.closePath();
             ctx.lineWidth = (2 / animator.scale).toString();

--- a/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
@@ -766,13 +766,6 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
                 ctx.closePath();
                 ctx.fillStyle = this.secondaryColor;
                 ctx.fill();
-                //
-                ctx.beginPath();
-                ctx.rect((- 0.5 + progressPercent) * size.w, - 0.5 * size.h, reverseProgressPercent * size.w, size.h);
-                ctx.closePath();
-                ctx.lineWidth = (2 / animator.scale).toString();
-                ctx.strokeStyle = this.secondaryColor;
-                ctx.stroke();
             }
         }
         ctx.restore();

--- a/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
@@ -686,26 +686,26 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
     computeProgress() {
         const progress = this.progress;
         var index = -1;
-        var totalPoints = progress.length / 2;
+        var totalPoints = progress.length;
         var time = animator.reactiveDataStatus.time;
         for (var i = 0; i < totalPoints; i++) {
-            var posTime = progress[2 * i];
+            var posTime = progress[i][0];
             if (time < posTime) {
                 break;
             }
             index = i;
         }
         if (index === -1) {
-            return progress[1];
+            return progress[0][1];
         } else if (index === totalPoints - 1) {
-            return progress[2 * index + 1];
+            return progress[index][1];
         } else {
-            var cur = progress[2 * index + 1];
-            switch (connection.interpolationMethod) {
+            var cur = progress[index][1];
+            switch (this.interpolationMethod) {
                 case InterpolationMethod.LINEAR:
-                    var curTime = progress[2 * index];
-                    var next = progress[2 * (index + 1) + 1];
-                    var nextTime = progress[2 * (index + 1)];
+                    var curTime = progress[index][0];
+                    var next = progress[index + 1][1];
+                    var nextTime = progress[index + 1][0];
                     var interpolated = cur + (time - curTime) / (nextTime - curTime) * (next - cur);
                     return interpolated;
                 case InterpolationMethod.STEP:
@@ -742,7 +742,7 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
             ctx.translate(secondaryOffset.x, secondaryOffset.y);
         }
         const normalizedRot = Math.abs(((rot + this.rotationOffset) / Math.PI) % 2);
-        if (0.5 < normalizedRot < 1.5) {
+        if (0.5 < normalizedRot && normalizedRot < 1.5) {
             // make sure the progress bar remains upright
             ctx.rotate(-ToRadians(180));
         }
@@ -751,7 +751,14 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
             ctx.rect(- 0.5 * size.w, - 0.5 * size.h, progressPercent * size.w, size.h);
             ctx.closePath();
             ctx.fillStyle = this.color;
-            ctx.fill();
+            ctx.fill();     
+            //
+            ctx.beginPath();
+            ctx.rect(- 0.5 * size.w, - 0.5 * size.h, progressPercent * size.w, size.h);
+            ctx.closePath();
+            ctx.lineWidth = (2 / animator.scale).toString();
+            ctx.strokeStyle = this.color;
+            ctx.stroke();
         }
         if (progressPercent < 1) {
             const reverseProgressPercent = 1.0 - progressPercent;
@@ -760,6 +767,13 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
             ctx.closePath();
             ctx.fillStyle = this.secondaryColor;
             ctx.fill();
+            //
+            ctx.beginPath();
+            ctx.rect((- 0.5 + progressPercent) * size.w, - 0.5 * size.h, reverseProgressPercent * size.w, size.h);
+            ctx.closePath();
+            ctx.lineWidth = (2 / animator.scale).toString();
+            ctx.strokeStyle = this.secondaryColor;
+            ctx.stroke();
         }
         ctx.restore();
     }

--- a/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/decorations.js
@@ -754,7 +754,7 @@ class ProgressBarMechanicDrawable extends RectangleMechanicDrawable {
             ctx.fill();     
             //
             ctx.beginPath();
-            ctx.rect(- 0.5 * size.w, - 0.5 * size.h, progressPercent * size.w, size.h);
+            ctx.rect(- 0.5 * size.w, - 0.5 * size.h, size.w, size.h);
             ctx.closePath();
             ctx.lineWidth = (2 / animator.scale).toString();
             ctx.strokeStyle = this.color;

--- a/GW2EIEvtcParser/EIData/Buffs/BuffSimulators/BuffSimulatorID/BuffSimulatorID.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffSimulators/BuffSimulatorID/BuffSimulatorID.cs
@@ -38,7 +38,7 @@ internal abstract class BuffSimulatorID : AbstractBuffSimulator
         int toRemoveIdx = -1;
         switch (removeType)
         {
-            case ArcDPSEnums.BuffRemove.All:
+            case BuffRemove.All:
                 // remove all due to despawn event
                 if (removedStacks == BuffRemoveAllEvent.FullRemoval)
                 {
@@ -71,7 +71,7 @@ internal abstract class BuffSimulatorID : AbstractBuffSimulator
                 }
                 toRemoveIdx = 0;
                 break;
-            case ArcDPSEnums.BuffRemove.Single:
+            case BuffRemove.Single:
                 toRemoveIdx = BuffStack.FindIndex(x => x.StackID == stackID);
                 break;
             default:

--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -60,6 +60,7 @@ internal static class Colors
     public static Color MilitaryGreen = new(69, 75, 27);
     public static Color LightMilitaryGreen = new(49, 71, 0);
     public static Color GreyishGreen = new(40, 57, 54);
+    public static Color SligthlyDarkGreen = new(0, 180, 0);
     public static Color DarkGreen = new(0, 128, 0);
     public static Color DarkBlue = new(0, 0, 128);
     public static Color Teal = new(0, 255, 255);

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/CombatReplayDecorationMetadataDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/CombatReplayDecorationMetadataDescription.cs
@@ -13,6 +13,8 @@ namespace GW2EIEvtcParser.EIData;
 [JsonDerivedType(typeof(LineDecorationMetadataDescription))]
 [JsonDerivedType(typeof(PieDecorationMetadataDescription))]
 [JsonDerivedType(typeof(RectangleDecorationMetadataDescription))]
+[JsonDerivedType(typeof(ProgressBarDecorationMetadataDescription))]
+[JsonDerivedType(typeof(OverheadProgressBarDecorationMetadataDescription))]
 public abstract class CombatReplayDecorationMetadataDescription : CombatReplayDescription
 {
     internal CombatReplayDecorationMetadataDescription() 

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/Decorations/Forms/OverheadProgressBarDecorationMetadataDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/Decorations/Forms/OverheadProgressBarDecorationMetadataDescription.cs
@@ -1,0 +1,15 @@
+﻿using static GW2EIEvtcParser.EIData.OverheadProgressBarDecoration;
+
+namespace GW2EIEvtcParser.EIData;
+
+public class OverheadProgressBarDecorationMetadataDescription : ProgressBarDecorationMetadataDescription
+{
+    public readonly uint PixelWidth;
+    public readonly uint PixelHeight;
+    internal OverheadProgressBarDecorationMetadataDescription(OverheadProgressBarDecorationMetadata decoration) : base(decoration)
+    {
+        Type = "ProgressBar";
+        PixelWidth = decoration.PixelWidth;
+        PixelHeight = decoration.PixelHeight;
+    }
+}

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/Decorations/Forms/OverheadProgressBarDecorationMetadataDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/Decorations/Forms/OverheadProgressBarDecorationMetadataDescription.cs
@@ -8,7 +8,7 @@ public class OverheadProgressBarDecorationMetadataDescription : ProgressBarDecor
     public readonly uint PixelHeight;
     internal OverheadProgressBarDecorationMetadataDescription(OverheadProgressBarDecorationMetadata decoration) : base(decoration)
     {
-        Type = "ProgressBar";
+        Type = "OverheadProgressBar";
         PixelWidth = decoration.PixelWidth;
         PixelHeight = decoration.PixelHeight;
     }

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/Decorations/Forms/ProgressBarDecorationMetadataDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Metadata/Decorations/Forms/ProgressBarDecorationMetadataDescription.cs
@@ -1,0 +1,14 @@
+﻿using static GW2EIEvtcParser.EIData.ProgressBarDecoration;
+
+namespace GW2EIEvtcParser.EIData;
+
+public class ProgressBarDecorationMetadataDescription : RectangleDecorationMetadataDescription
+{
+
+    public readonly string SecondaryColor;
+    internal ProgressBarDecorationMetadataDescription(ProgressBarDecorationMetadata decoration) : base(decoration)
+    {
+        Type = "ProgressBar";
+        SecondaryColor = decoration.SecondaryColor;
+    }
+}

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/CombatReplayRenderingDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/CombatReplayRenderingDescription.cs
@@ -13,6 +13,8 @@ namespace GW2EIEvtcParser.EIData;
 [JsonDerivedType(typeof(PieDecorationRenderingDescription))]
 [JsonDerivedType(typeof(RectangleDecorationRenderingDescription))]
 [JsonDerivedType(typeof(CircleDecorationRenderingDescription))]
+[JsonDerivedType(typeof(ProgressBarDecorationRenderingDescription))]
+[JsonDerivedType(typeof(OverheadProgressBarDecorationRenderingDescription))]
 public abstract class CombatReplayRenderingDescription : CombatReplayDescription
 {
     public long Start { get; protected set; }

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Forms/OverheadProgressBarDecorationRenderingDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Forms/OverheadProgressBarDecorationRenderingDescription.cs
@@ -1,0 +1,13 @@
+﻿using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.EIData.OverheadProgressBarDecoration;
+
+namespace GW2EIEvtcParser.EIData;
+
+public class OverheadProgressBarDecorationRenderingDescription : ProgressBarDecorationRenderingDescription
+{
+
+    internal OverheadProgressBarDecorationRenderingDescription(ParsedEvtcLog log, OverheadProgressBarDecorationRenderingData decoration, CombatReplayMap map, Dictionary<long, SkillItem> usedSkills, Dictionary<long, Buff> usedBuffs, string metadataSignature) : base(log, decoration, map, usedSkills, usedBuffs, metadataSignature)
+    {
+        Type = "OverheadProgressBar";
+    }
+}

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Forms/ProgressBarDecorationRenderingDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Forms/ProgressBarDecorationRenderingDescription.cs
@@ -7,9 +7,11 @@ public class ProgressBarDecorationRenderingDescription : RectangleDecorationRend
 {
 
     public readonly IReadOnlyList<(long, double)> Progress;
+    public int InterpolationMethod { get; private set; }
     internal ProgressBarDecorationRenderingDescription(ParsedEvtcLog log, ProgressBarDecorationRenderingData decoration, CombatReplayMap map, Dictionary<long, SkillItem> usedSkills, Dictionary<long, Buff> usedBuffs, string metadataSignature) : base(log, decoration, map, usedSkills, usedBuffs, metadataSignature)
     {
         Type = "ProgressBar";
         Progress = decoration.Progress;
+        InterpolationMethod = (int)decoration.Method;
     }
 }

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Forms/ProgressBarDecorationRenderingDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Forms/ProgressBarDecorationRenderingDescription.cs
@@ -1,0 +1,15 @@
+﻿using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.EIData.ProgressBarDecoration;
+
+namespace GW2EIEvtcParser.EIData;
+
+public class ProgressBarDecorationRenderingDescription : RectangleDecorationRenderingDescription
+{
+
+    public readonly IReadOnlyList<(long, double)> Progress;
+    internal ProgressBarDecorationRenderingDescription(ParsedEvtcLog log, ProgressBarDecorationRenderingData decoration, CombatReplayMap map, Dictionary<long, SkillItem> usedSkills, Dictionary<long, Buff> usedBuffs, string metadataSignature) : base(log, decoration, map, usedSkills, usedBuffs, metadataSignature)
+    {
+        Type = "ProgressBar";
+        Progress = decoration.Progress;
+    }
+}

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Images/BackgroundIconDecorationRenderingDescription.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDescription/Rendering/Decorations/Images/BackgroundIconDecorationRenderingDescription.cs
@@ -6,8 +6,8 @@ namespace GW2EIEvtcParser.EIData;
 public class BackgroundIconDecorationRenderingDescription : ImageDecorationRenderingDescription
 {
 
-    public IReadOnlyList<float> Opacities { get; private set; }
-    public IReadOnlyList<float> Heights { get; private set; }
+    public readonly IReadOnlyList<float> Opacities;
+    public readonly IReadOnlyList<float> Heights;
     internal BackgroundIconDecorationRenderingDescription(ParsedEvtcLog log, BackgroundIconDecorationRenderingData decoration, CombatReplayMap map, Dictionary<long, SkillItem> usedSkills, Dictionary<long, Buff> usedBuffs, string metadataSignature) : base(log, decoration, map, usedSkills, usedBuffs, metadataSignature)
     {
         Type = "BackgroundIconDecoration"; //TODO(Rennorb) @cleanup: enum

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Connector/Connector.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Connector/Connector.cs
@@ -5,7 +5,8 @@ public abstract class Connector
 
     public enum InterpolationMethod
     {
-        Linear = 0
+        Linear = 0,
+        Step = 1,
     }
     public abstract ConnectorDescription GetConnectedTo(CombatReplayMap map, ParsedEvtcLog log);
 }

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
@@ -54,7 +54,7 @@ internal class OverheadProgressBarDecoration : ProgressBarDecoration
             new OverheadProgressBarDecorationMetadata(
                 color, 
                 secondaryColor, 
-                Math.Min(Math.Max((uint)(1.5 * connectedTo.Agent.HitboxWidth), 80), 500),
+                Math.Min(Math.Max((uint)(connectedTo.Agent.HitboxWidth), 80), 500),
                 pixelWidth),
             new OverheadProgressBarDecorationRenderingData(lifespan, progress, connectedTo)
             )

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
@@ -8,15 +8,16 @@ internal class OverheadProgressBarDecoration : ProgressBarDecoration
     public class OverheadProgressBarDecorationMetadata : ProgressBarDecorationMetadata
     {
         public readonly uint PixelWidth;
-        public uint PixelHeight => PixelWidth / 5;
+        public readonly uint PixelHeight;
         public OverheadProgressBarDecorationMetadata(string color, string secondaryColor, uint width, uint pixelWidth) : base(color, secondaryColor, width, width / 5)
         {
             PixelWidth = pixelWidth;
+            PixelHeight = PixelWidth / 5;
         }
 
         public override string GetSignature()
         {
-            return "OProg"  + Color + Width + SecondaryColor + PixelWidth;
+            return "OProg" + Color + Width + Height.ToString()  + SecondaryColor + PixelWidth + PixelHeight.ToString();
         }
         public override DecorationMetadataDescription GetCombatReplayMetadataDescription()
         {

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
@@ -1,0 +1,95 @@
+﻿using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.EIData.Connector;
+
+namespace GW2EIEvtcParser.EIData;
+
+internal class OverheadProgressBarDecoration : ProgressBarDecoration
+{
+    public class OverheadProgressBarDecorationMetadata : ProgressBarDecorationMetadata
+    {
+        public readonly uint PixelWidth;
+        public readonly uint PixelHeight;
+        public OverheadProgressBarDecorationMetadata(string color, string secondaryColor, uint width, uint height, uint pixelWidth, uint pixelHeight) : base(color, secondaryColor, width, height)
+        {
+            PixelWidth = pixelWidth;
+            PixelHeight = pixelHeight;
+        }
+
+        public override string GetSignature()
+        {
+            return "OProg" + Height + Color + Width + SecondaryColor + PixelWidth + PixelHeight.ToString();
+        }
+        public override DecorationMetadataDescription GetCombatReplayMetadataDescription()
+        {
+            return new OverheadProgressBarDecorationMetadataDescription(this);
+        }
+    }
+    public class OverheadProgressBarDecorationRenderingData : ProgressBarDecorationRenderingData
+    {
+        public OverheadProgressBarDecorationRenderingData((long, long) lifespan, IReadOnlyList<(long, double)> progress, GeographicalConnector connector) : base(lifespan, progress, connector)
+        {
+        }
+
+        public override DecorationRenderingDescription GetCombatReplayRenderingDescription(CombatReplayMap map, ParsedEvtcLog log, Dictionary<long, SkillItem> usedSkills, Dictionary<long, Buff> usedBuffs, string metadataSignature)
+        {
+            return new OverheadProgressBarDecorationRenderingDescription(log, this, map, usedSkills, usedBuffs, metadataSignature);
+        }
+    }
+    private new OverheadProgressBarDecorationMetadata DecorationMetadata => (OverheadProgressBarDecorationMetadata)base.DecorationMetadata;
+    private OverheadProgressBarDecorationRenderingData RenderingMetadata => (OverheadProgressBarDecorationRenderingData)DecorationRenderingData;
+
+    public uint PixelWidth => DecorationMetadata.PixelWidth;
+    public uint PixelHeight => DecorationMetadata.PixelHeight;
+
+    protected OverheadProgressBarDecoration(OverheadProgressBarDecorationMetadata metadata, OverheadProgressBarDecorationRenderingData renderingData) : base(metadata, renderingData)
+    {
+    }
+
+    public OverheadProgressBarDecoration(
+        uint width, uint height, 
+        uint pixelWidth, uint pixelHeight,
+        (long start, long end) lifespan,
+        string color, string secondaryColor,
+        IReadOnlyList<(long, double)> progress, GeographicalConnector connector
+        ) : base(
+            new OverheadProgressBarDecorationMetadata(color, secondaryColor, width, height, pixelWidth, pixelHeight),
+            new OverheadProgressBarDecorationRenderingData(lifespan, progress, connector)
+            )
+    {
+    }
+    public OverheadProgressBarDecoration(
+        uint width, uint height,
+        uint pixelWidth, uint pixelHeight,
+        (long start, long end) lifespan,
+        Color color, double opacity,
+        Color secondaryColor, double secondaryOpacity,
+        IReadOnlyList<(long, double)> progress, GeographicalConnector connector
+        ) : this(
+            width, height, 
+            pixelWidth, pixelHeight,
+            lifespan,
+            color.WithAlpha(opacity).ToString(true),
+            secondaryColor.WithAlpha(secondaryOpacity).ToString(true),
+            progress, connector
+            )
+    {
+    }
+
+    public override FormDecoration Copy(string? color = null)
+    {
+        return (FormDecoration)new OverheadProgressBarDecoration(Width, Height, PixelWidth, PixelHeight, Lifespan, color ?? Color, SecondaryColor, Progress, ConnectedTo)
+            .UsingFilled(Filled)
+            .UsingGrowingEnd(GrowingEnd, GrowingReverse)
+            .UsingRotationConnector(RotationConnectedTo)
+            .UsingSkillMode(SkillMode);
+    }
+
+    public override FormDecoration Copy(string? color = null, string? secondaryColor = null)
+    {
+        return (FormDecoration)new OverheadProgressBarDecoration(Width, Height, PixelWidth, PixelHeight, Lifespan, color ?? Color, secondaryColor ?? SecondaryColor, Progress, ConnectedTo)
+            .UsingFilled(Filled)
+            .UsingGrowingEnd(GrowingEnd, GrowingReverse)
+            .UsingRotationConnector(RotationConnectedTo)
+            .UsingSkillMode(SkillMode);
+    }
+}

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
@@ -53,7 +53,7 @@ internal class OverheadProgressBarDecoration : ProgressBarDecoration
             new OverheadProgressBarDecorationMetadata(
                 color, 
                 secondaryColor, 
-                Math.Max(Math.Min((uint)(1.5 * connectedTo.Agent.HitboxWidth), 80), 500),
+                Math.Min(Math.Max((uint)(1.5 * connectedTo.Agent.HitboxWidth), 80), 500),
                 pixelWidth),
             new OverheadProgressBarDecorationRenderingData(lifespan, progress, connectedTo)
             )

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/OverheadProgressBarDecoration.cs
@@ -8,16 +8,15 @@ internal class OverheadProgressBarDecoration : ProgressBarDecoration
     public class OverheadProgressBarDecorationMetadata : ProgressBarDecorationMetadata
     {
         public readonly uint PixelWidth;
-        public readonly uint PixelHeight;
-        public OverheadProgressBarDecorationMetadata(string color, string secondaryColor, uint width, uint height, uint pixelWidth, uint pixelHeight) : base(color, secondaryColor, width, height)
+        public uint PixelHeight => PixelWidth / 5;
+        public OverheadProgressBarDecorationMetadata(string color, string secondaryColor, uint width, uint pixelWidth) : base(color, secondaryColor, width, width / 5)
         {
             PixelWidth = pixelWidth;
-            PixelHeight = pixelHeight;
         }
 
         public override string GetSignature()
         {
-            return "OProg" + Height + Color + Width + SecondaryColor + PixelWidth + PixelHeight.ToString();
+            return "OProg"  + Color + Width + SecondaryColor + PixelWidth;
         }
         public override DecorationMetadataDescription GetCombatReplayMetadataDescription()
         {
@@ -46,38 +45,39 @@ internal class OverheadProgressBarDecoration : ProgressBarDecoration
     }
 
     public OverheadProgressBarDecoration(
-        uint width, uint height, 
-        uint pixelWidth, uint pixelHeight,
+        uint pixelWidth,
         (long start, long end) lifespan,
         string color, string secondaryColor,
-        IReadOnlyList<(long, double)> progress, GeographicalConnector connector
+        IReadOnlyList<(long, double)> progress, AgentConnector connectedTo
         ) : base(
-            new OverheadProgressBarDecorationMetadata(color, secondaryColor, width, height, pixelWidth, pixelHeight),
-            new OverheadProgressBarDecorationRenderingData(lifespan, progress, connector)
+            new OverheadProgressBarDecorationMetadata(
+                color, 
+                secondaryColor, 
+                Math.Max(Math.Min((uint)(1.5 * connectedTo.Agent.HitboxWidth), 80), 500),
+                pixelWidth),
+            new OverheadProgressBarDecorationRenderingData(lifespan, progress, connectedTo)
             )
     {
     }
     public OverheadProgressBarDecoration(
-        uint width, uint height,
-        uint pixelWidth, uint pixelHeight,
+        uint pixelWidth,
         (long start, long end) lifespan,
         Color color, double opacity,
         Color secondaryColor, double secondaryOpacity,
-        IReadOnlyList<(long, double)> progress, GeographicalConnector connector
+        IReadOnlyList<(long, double)> progress, AgentConnector connectedTo
         ) : this(
-            width, height, 
-            pixelWidth, pixelHeight,
+            pixelWidth,
             lifespan,
             color.WithAlpha(opacity).ToString(true),
             secondaryColor.WithAlpha(secondaryOpacity).ToString(true),
-            progress, connector
+            progress, connectedTo
             )
     {
     }
 
     public override FormDecoration Copy(string? color = null)
     {
-        return (FormDecoration)new OverheadProgressBarDecoration(Width, Height, PixelWidth, PixelHeight, Lifespan, color ?? Color, SecondaryColor, Progress, ConnectedTo)
+        return (FormDecoration)new OverheadProgressBarDecoration(PixelWidth, Lifespan, color ?? Color, SecondaryColor, Progress, (AgentConnector)ConnectedTo)
             .UsingFilled(Filled)
             .UsingGrowingEnd(GrowingEnd, GrowingReverse)
             .UsingRotationConnector(RotationConnectedTo)
@@ -86,7 +86,7 @@ internal class OverheadProgressBarDecoration : ProgressBarDecoration
 
     public override FormDecoration Copy(string? color = null, string? secondaryColor = null)
     {
-        return (FormDecoration)new OverheadProgressBarDecoration(Width, Height, PixelWidth, PixelHeight, Lifespan, color ?? Color, secondaryColor ?? SecondaryColor, Progress, ConnectedTo)
+        return (FormDecoration)new OverheadProgressBarDecoration(PixelWidth, Lifespan, color ?? Color, secondaryColor ?? SecondaryColor, Progress, (AgentConnector)ConnectedTo)
             .UsingFilled(Filled)
             .UsingGrowingEnd(GrowingEnd, GrowingReverse)
             .UsingRotationConnector(RotationConnectedTo)

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/ProgressBarDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/ProgressBarDecoration.cs
@@ -1,0 +1,104 @@
+﻿using GW2EIEvtcParser.ParsedData;
+
+namespace GW2EIEvtcParser.EIData;
+
+internal class ProgressBarDecoration : RectangleDecoration
+{
+    public class ProgressBarDecorationMetadata : RectangleDecorationMetadata
+    {
+        public readonly string SecondaryColor;
+        public ProgressBarDecorationMetadata(string color, string secondaryColor, uint width, uint height) : base(color, width, height)
+        {
+            SecondaryColor = secondaryColor;
+        }
+
+        public override string GetSignature()
+        {
+            return "Prog" + Height + Color + Width + SecondaryColor;
+        }
+        public override DecorationMetadataDescription GetCombatReplayMetadataDescription()
+        {
+            return new ProgressBarDecorationMetadataDescription(this);
+        }
+    }
+    public class ProgressBarDecorationRenderingData : RectangleDecorationRenderingData
+    {
+        public readonly IReadOnlyList<(long, double)> Progress;
+        public ProgressBarDecorationRenderingData((long, long) lifespan, IReadOnlyList<(long, double)> progress, GeographicalConnector connector) : base(lifespan, connector)
+        {
+            Progress = progress;
+        }
+
+        public override DecorationRenderingDescription GetCombatReplayRenderingDescription(CombatReplayMap map, ParsedEvtcLog log, Dictionary<long, SkillItem> usedSkills, Dictionary<long, Buff> usedBuffs, string metadataSignature)
+        {
+            return new ProgressBarDecorationRenderingDescription(log, this, map, usedSkills, usedBuffs, metadataSignature);
+        }
+    }
+    private new ProgressBarDecorationMetadata DecorationMetadata => (ProgressBarDecorationMetadata)base.DecorationMetadata;
+    private ProgressBarDecorationRenderingData RenderingMetadata => (ProgressBarDecorationRenderingData)DecorationRenderingData;
+
+    public string SecondaryColor => DecorationMetadata.SecondaryColor;
+    public IReadOnlyList<(long, double)> Progress => RenderingMetadata.Progress;
+
+    protected ProgressBarDecoration(ProgressBarDecorationMetadata metadata, ProgressBarDecorationRenderingData renderingData) : base(metadata, renderingData)
+    {
+    }
+
+    public ProgressBarDecoration(
+        uint width, uint height, (long start, long end) lifespan,
+        string color, string secondaryColor,
+        IReadOnlyList<(long, double)> progress, GeographicalConnector connector
+        ) : base(
+            new ProgressBarDecorationMetadata(color, secondaryColor, width, height),
+            new ProgressBarDecorationRenderingData(lifespan, progress, connector)
+            )
+    {
+    }
+    public ProgressBarDecoration(
+        uint width, uint height, (long start, long end) lifespan,
+        Color color, double opacity,
+        Color secondaryColor, double secondaryOpacity,
+        IReadOnlyList<(long, double)> progress, GeographicalConnector connector
+        ) : this(
+            width, height, lifespan,
+            color.WithAlpha(opacity).ToString(true),
+            secondaryColor.WithAlpha(secondaryOpacity).ToString(true),
+            progress, connector
+            )
+    {
+    }
+
+    public override FormDecoration Copy(string? color = null)
+    {
+        return (FormDecoration)new ProgressBarDecoration(Width, Height, Lifespan, color ?? Color, SecondaryColor, Progress, ConnectedTo)
+            .UsingFilled(Filled)
+            .UsingGrowingEnd(GrowingEnd, GrowingReverse)
+            .UsingRotationConnector(RotationConnectedTo)
+            .UsingSkillMode(SkillMode);
+    }
+
+    public FormDecoration Copy(string? color = null, string? secondaryColor = null)
+    {
+        return (FormDecoration)new ProgressBarDecoration(Width, Height, Lifespan, color ?? Color, secondaryColor ?? SecondaryColor, Progress, ConnectedTo)
+            .UsingFilled(Filled)
+            .UsingGrowingEnd(GrowingEnd, GrowingReverse)
+            .UsingRotationConnector(RotationConnectedTo)
+            .UsingSkillMode(SkillMode);
+    }
+
+
+    public override FormDecoration UsingFilled(bool filled)
+    {
+        return this;
+    }
+
+    public override FormDecoration UsingGrowingEnd(long growingEnd, bool reverse = false)
+    {
+        return this;
+    }
+
+    public override FormDecoration GetBorderDecoration(string? borderColor = null)
+    {
+        throw new InvalidOperationException("Progress bars can't have borders");
+    }
+}

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/ProgressBarDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/ProgressBarDecoration.cs
@@ -1,4 +1,5 @@
 ﻿using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.EIData.Connector;
 
 namespace GW2EIEvtcParser.EIData;
 
@@ -24,6 +25,7 @@ internal class ProgressBarDecoration : RectangleDecoration
     public class ProgressBarDecorationRenderingData : RectangleDecorationRenderingData
     {
         public readonly IReadOnlyList<(long, double)> Progress;
+        public InterpolationMethod Method { get; private set; } = InterpolationMethod.Linear;
         public ProgressBarDecorationRenderingData((long, long) lifespan, IReadOnlyList<(long, double)> progress, GeographicalConnector connector) : base(lifespan, connector)
         {
             Progress = progress;
@@ -32,6 +34,11 @@ internal class ProgressBarDecoration : RectangleDecoration
         public override DecorationRenderingDescription GetCombatReplayRenderingDescription(CombatReplayMap map, ParsedEvtcLog log, Dictionary<long, SkillItem> usedSkills, Dictionary<long, Buff> usedBuffs, string metadataSignature)
         {
             return new ProgressBarDecorationRenderingDescription(log, this, map, usedSkills, usedBuffs, metadataSignature);
+        }
+
+        public void UsingInterpolationMethod(InterpolationMethod method)
+        {
+            Method = method;
         }
     }
     private new ProgressBarDecorationMetadata DecorationMetadata => (ProgressBarDecorationMetadata)base.DecorationMetadata;
@@ -77,7 +84,7 @@ internal class ProgressBarDecoration : RectangleDecoration
             .UsingSkillMode(SkillMode);
     }
 
-    public FormDecoration Copy(string? color = null, string? secondaryColor = null)
+    public virtual FormDecoration Copy(string? color = null, string? secondaryColor = null)
     {
         return (FormDecoration)new ProgressBarDecoration(Width, Height, Lifespan, color ?? Color, secondaryColor ?? SecondaryColor, Progress, ConnectedTo)
             .UsingFilled(Filled)
@@ -86,6 +93,11 @@ internal class ProgressBarDecoration : RectangleDecoration
             .UsingSkillMode(SkillMode);
     }
 
+    public ProgressBarDecoration UsingInterpolationMethod(InterpolationMethod method)
+    {
+        RenderingMetadata.UsingInterpolationMethod(method);
+        return this;
+    }
 
     public override FormDecoration UsingFilled(bool filled)
     {

--- a/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/RectangleDecoration.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/Decorations/Forms/RectangleDecoration.cs
@@ -1,4 +1,5 @@
 ﻿using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.EIData.CircleDecoration;
 
 namespace GW2EIEvtcParser.EIData;
 
@@ -38,6 +39,10 @@ internal class RectangleDecoration : FormDecoration
     private new RectangleDecorationMetadata DecorationMetadata => (RectangleDecorationMetadata)base.DecorationMetadata;
     public uint Height => DecorationMetadata.Height;
     public uint Width => DecorationMetadata.Width;
+
+    protected RectangleDecoration(RectangleDecorationMetadata metadata, RectangleDecorationRenderingData renderingData) : base(metadata, renderingData)
+    {
+    }
 
     public RectangleDecoration(uint width, uint height, (long start, long end) lifespan, string color, GeographicalConnector connector) : base(new RectangleDecorationMetadata(color, width, height), new RectangleDecorationRenderingData(lifespan, connector))
     {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
@@ -147,8 +147,8 @@ internal class Gorseval : SpiritVale
         {
             case (int)ArcDPSEnums.TargetID.Gorseval:
                 var cls = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
-                var blooms = cls.Where(x => x.SkillId == GorsevalBloom);
-                foreach (CastEvent c in blooms)
+                var worldEaters = cls.Where(x => x.SkillId == GorsevalWorldEater);
+                foreach (CastEvent c in worldEaters)
                 {
                     int start = (int)c.Time;
                     int end = (int)c.EndTime;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -238,11 +238,7 @@ internal class Sabetha : SpiritVale
         }
                 // Sapper bombs
         var sapperBombs = p.GetBuffStatus(log, SapperBombBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-        foreach (var seg in sapperBombs)
-        {
-            replay.Decorations.AddWithFilledWithGrowing(new CircleDecoration(180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(p)).UsingFilled(false), true, seg.Start + 5000);
-            replay.Decorations.AddOverheadIcon(seg, p, ParserIcons.BombOverhead);
-        }
+        replay.Decorations.AddOverheadIcons(sapperBombs, p, ParserIcons.BombOverhead);
     }
 
     protected override ReadOnlySpan<int> GetUniqueNPCIDs()

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -238,7 +238,11 @@ internal class Sabetha : SpiritVale
         }
                 // Sapper bombs
         var sapperBombs = p.GetBuffStatus(log, SapperBombBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-        replay.Decorations.AddOverheadIcons(sapperBombs, p, ParserIcons.BombOverhead);
+        foreach (var seg in sapperBombs)
+        {
+            replay.Decorations.AddWithFilledWithGrowing(new CircleDecoration(180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(p)).UsingFilled(false), true, seg.Start + 5000);
+            replay.Decorations.AddOverheadIcon(seg, p, ParserIcons.BombOverhead);
+        }
     }
 
     protected override ReadOnlySpan<int> GetUniqueNPCIDs()

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -190,7 +190,7 @@ internal class ValeGuardian : SpiritVale
                 {
                     int start = (int)c.Time;
                     int end = (int)c.EndTime;
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.LightBlue, 0.8, Colors.Black, 0.2, [(start, 0), (start + 30000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + 30000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 if (!log.CombatData.HasEffectData)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -190,7 +190,7 @@ internal class ValeGuardian : SpiritVale
                 {
                     int start = (int)c.Time;
                     int end = (int)c.EndTime;
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.LightBlue, 0.8, Colors.Black, 0.4, [(start, 0), (start + 30000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.LightBlue, 0.8, Colors.Black, 0.2, [(start, 0), (start + 30000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 if (!log.CombatData.HasEffectData)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -190,7 +190,7 @@ internal class ValeGuardian : SpiritVale
                 {
                     int start = (int)c.Time;
                     int end = (int)c.EndTime;
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + 30000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (start, end), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + 30000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 if (!log.CombatData.HasEffectData)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -190,7 +190,8 @@ internal class ValeGuardian : SpiritVale
                 {
                     int start = (int)c.Time;
                     int end = (int)c.EndTime;
-                    replay.Decorations.AddWithGrowing(new CircleDecoration(180, (start, end), Colors.LightBlue, 0.3, new AgentConnector(target)), start + c.ExpectedDuration);
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.LightBlue, 0.8, Colors.Black, 0.4, [(start, 0), (start + 30000, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 if (!log.CombatData.HasEffectData)
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
@@ -328,12 +328,7 @@ internal class BanditTrio : SalvationPass
         base.ComputePlayerCombatReplayActors(player, log, replay);
         // Sapper bombs
         var sapperBombs = player.GetBuffStatus(log, SapperBombBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-        foreach (var seg in sapperBombs)
-        {
-            var circle = new CircleDecoration(180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(player));
-            replay.Decorations.AddWithFilledWithGrowing(circle.UsingFilled(false), true, seg.Start + 5000);
-            replay.Decorations.AddOverheadIcon(seg, player, ParserIcons.BombOverhead);
-        }
+        replay.Decorations.AddOverheadIcons(sapperBombs, player, ParserIcons.BombOverhead);
     }
 
     protected override void SetInstanceBuffs(ParsedEvtcLog log)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/BanditTrio.cs
@@ -328,7 +328,12 @@ internal class BanditTrio : SalvationPass
         base.ComputePlayerCombatReplayActors(player, log, replay);
         // Sapper bombs
         var sapperBombs = player.GetBuffStatus(log, SapperBombBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-        replay.Decorations.AddOverheadIcons(sapperBombs, player, ParserIcons.BombOverhead);
+        foreach (var seg in sapperBombs)
+        {
+            var circle = new CircleDecoration(180, seg, "rgba(200, 255, 100, 0.5)", new AgentConnector(player));
+            replay.Decorations.AddWithFilledWithGrowing(circle.UsingFilled(false), true, seg.Start + 5000);
+            replay.Decorations.AddOverheadIcon(seg, player, ParserIcons.BombOverhead);
+        }
     }
 
     protected override void SetInstanceBuffs(ParsedEvtcLog log)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
@@ -317,7 +317,8 @@ internal class Matthias : SalvationPass
             replay.Decorations.Add(new CircleDecoration(180, seg, Colors.LightOrange, 0.5, new AgentConnector(p)));
             if (p.TryGetCurrentInterpolatedPosition(log, corruptedMatthiasEnd, out var position))
             {
-                replay.Decorations.AddWithGrowing(new CircleDecoration(180, (corruptedMatthiasEnd, corruptedMatthiasEnd + 100000), Colors.Black, 0.3, new PositionConnector(position)), corruptedMatthiasEnd + 100000);
+                var fountainActiveTime = corruptedMatthiasEnd + 100000;
+                replay.Decorations.Add(new ProgressBarDecoration(240, 48, (corruptedMatthiasEnd, fountainActiveTime), Colors.Black, 0.8, Colors.Black, 0.2, [(corruptedMatthiasEnd, 0), (fountainActiveTime, 100)], new PositionConnector(position)));
             }
             replay.Decorations.AddOverheadIcon(seg, p, ParserIcons.CorruptionOverhead);
         }
@@ -340,7 +341,8 @@ internal class Matthias : SalvationPass
         var sacrificeMatthias = p.GetBuffStatus(log, MatthiasSacrifice, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (var seg in sacrificeMatthias)
         {
-            replay.Decorations.AddWithGrowing(new CircleDecoration(120, seg, "rgba(0, 150, 250, 0.2)", new AgentConnector(p)), seg.Start + 10000);
+            replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.8, Colors.Black, 0.4, [(seg.Start, 0), (seg.Start + 10000, 100)], new AgentConnector(p))
+                .UsingRotationConnector(new AngleConnector(90)));
         }
                 // Bombs
         var zealousBenediction = log.CombatData.GetBuffDataByIDByDst(ZealousBenediction, p.AgentItem).Where(x => x is BuffApplyEvent);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
@@ -341,7 +341,7 @@ internal class Matthias : SalvationPass
         var sacrificeMatthias = p.GetBuffStatus(log, MatthiasSacrifice, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (var seg in sacrificeMatthias)
         {
-            replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 10000, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 10000, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(90)));
         }
                 // Bombs

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
@@ -318,7 +318,7 @@ internal class Matthias : SalvationPass
             if (p.TryGetCurrentInterpolatedPosition(log, corruptedMatthiasEnd, out var position))
             {
                 var fountainActiveTime = corruptedMatthiasEnd + 100000;
-                replay.Decorations.Add(new ProgressBarDecoration(240, 48, (corruptedMatthiasEnd, fountainActiveTime), Colors.Black, 0.8, Colors.Black, 0.2, [(corruptedMatthiasEnd, 0), (fountainActiveTime, 100)], new PositionConnector(position)));
+                replay.Decorations.Add(new ProgressBarDecoration(240, 48, (corruptedMatthiasEnd, fountainActiveTime), Colors.Black, 0.6, Colors.Black, 0.2, [(corruptedMatthiasEnd, 0), (fountainActiveTime, 100)], new PositionConnector(position)));
             }
             replay.Decorations.AddOverheadIcon(seg, p, ParserIcons.CorruptionOverhead);
         }
@@ -341,7 +341,7 @@ internal class Matthias : SalvationPass
         var sacrificeMatthias = p.GetBuffStatus(log, MatthiasSacrifice, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (var seg in sacrificeMatthias)
         {
-            replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.8, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 10000, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 10000, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(90)));
         }
                 // Bombs

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Matthias.cs
@@ -341,7 +341,7 @@ internal class Matthias : SalvationPass
         var sacrificeMatthias = p.GetBuffStatus(log, MatthiasSacrifice, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (var seg in sacrificeMatthias)
         {
-            replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.8, Colors.Black, 0.4, [(seg.Start, 0), (seg.Start + 10000, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.8, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 10000, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(90)));
         }
                 // Bombs

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -157,7 +157,7 @@ internal class Slothasor : SalvationPass
                 var narcolepsies = target.GetBuffStatus(log, NarcolepsyBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (var narcolepsy in narcolepsies)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.8, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var breath = cls.Where(x => x.SkillId == Halitosis);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -1,4 +1,5 @@
-﻿using GW2EIEvtcParser.EIData;
+﻿using System.Numerics;
+using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
@@ -152,10 +153,12 @@ internal class Slothasor : SalvationPass
         {
             case (int)ArcDPSEnums.TargetID.Slothasor:
                 var cls = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
-                var sleepy = cls.Where(x => x.SkillId == NarcolepsySkill);
-                foreach (CastEvent c in sleepy)
+
+                var narcolepsies = target.GetBuffStatus(log, NarcolepsyBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
+                foreach (var narcolepsy in narcolepsies)
                 {
-                    replay.Decorations.Add(new CircleDecoration(180, ((int)c.Time, (int)c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.8, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var breath = cls.Where(x => x.SkillId == Halitosis);
                 foreach (CastEvent c in breath)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -157,7 +157,7 @@ internal class Slothasor : SalvationPass
                 var narcolepsies = target.GetBuffStatus(log, NarcolepsyBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (var narcolepsy in narcolepsies)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var breath = cls.Where(x => x.SkillId == Halitosis);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -157,7 +157,7 @@ internal class Slothasor : SalvationPass
                 var narcolepsies = target.GetBuffStatus(log, NarcolepsyBuff, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (var narcolepsy in narcolepsies)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var breath = cls.Where(x => x.SkillId == Halitosis);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
@@ -287,7 +287,7 @@ internal class KeepConstruct : StrongholdOfTheFaithful
                 var kcOrbCollect = target.GetBuffStatus(log, XerasBoon, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (Segment seg in kcOrbCollect)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.End, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.End, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
@@ -287,7 +287,7 @@ internal class KeepConstruct : StrongholdOfTheFaithful
                 var kcOrbCollect = target.GetBuffStatus(log, XerasBoon, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (Segment seg in kcOrbCollect)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.End, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.End, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
@@ -287,7 +287,8 @@ internal class KeepConstruct : StrongholdOfTheFaithful
                 var kcOrbCollect = target.GetBuffStatus(log, XerasBoon, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (Segment seg in kcOrbCollect)
                 {
-                    replay.Decorations.AddWithFilledWithGrowing(new CircleDecoration(300, seg, Colors.Red, 0.3, new AgentConnector(target)).UsingFilled(false), true, seg.End);
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.End, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 
                 var towerDrop = cls.Where(x => x.SkillId == TowerDrop);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
@@ -534,7 +534,7 @@ internal class Deimos : BastionOfThePenitent
                 {
                     start = (int)c.Time;
                     end = start + 5000;
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.Red, 0.6, Colors.Black, 0.2, [(start, 0), (end, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (start, end), Colors.Red, 0.6, Colors.Black, 0.2, [(start, 0), (end, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                     if (!log.FightData.IsCM)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
@@ -534,7 +534,7 @@ internal class Deimos : BastionOfThePenitent
                 {
                     start = (int)c.Time;
                     end = start + 5000;
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (start, end), Colors.Red, 0.6, Colors.Black, 0.2, [(start, 0), (end, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (start, end), Colors.Red, 0.6, Colors.Black, 0.2, [(start, 0), (end, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                     if (!log.FightData.IsCM)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
@@ -534,8 +534,8 @@ internal class Deimos : BastionOfThePenitent
                 {
                     start = (int)c.Time;
                     end = start + 5000;
-                    var circle = new CircleDecoration(180, (start, end), Colors.Red, 0.5, new AgentConnector(target));
-                    replay.Decorations.AddWithFilledWithGrowing(circle.UsingFilled(false), true, end);
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (start, end), Colors.Red, 0.6, Colors.Black, 0.2, [(start, 0), (end, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                     if (!log.FightData.IsCM)
                     {
                         replay.Decorations.Add(new CircleDecoration(180, (start, end), Colors.Blue, 0.3, new PositionConnector(new Vector3(-8421.818f, 3091.72949f, -9.818082e8f))));
@@ -571,10 +571,7 @@ internal class Deimos : BastionOfThePenitent
                 }
 
                 var signets = target.GetBuffStatus(log, UnnaturalSignet, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-                foreach (Segment seg in signets)
-                {
-                    replay.Decorations.Add(new CircleDecoration(120, seg, Colors.Teal, 0.4, new AgentConnector(target)));
-                }
+                replay.Decorations.AddOverheadIcons(signets, target, BuffImages.UnnaturalSignet);
                 break;
             case (int)ArcDPSEnums.TrashID.Gambler:
             case (int)ArcDPSEnums.TrashID.Thief:

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
@@ -187,7 +187,7 @@ internal class Samarog : BastionOfThePenitent
                 var brutalize = target.GetBuffStatus(log, FanaticalResilience, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (Segment seg in brutalize)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 15000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 15000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 break;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
@@ -187,7 +187,8 @@ internal class Samarog : BastionOfThePenitent
                 var brutalize = target.GetBuffStatus(log, FanaticalResilience, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (Segment seg in brutalize)
                 {
-                    replay.Decorations.Add(new CircleDecoration(120, seg, Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 15000, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 break;
             case (int)ArcDPSEnums.TrashID.Rigom:
@@ -234,7 +235,6 @@ internal class Samarog : BastionOfThePenitent
         var fixatedSam = p.GetBuffStatus(log, FixatedSamarog, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (Segment seg in fixatedSam)
         {
-            replay.Decorations.Add(new CircleDecoration(80, seg, "rgba(255, 80, 255, 0.3)", new AgentConnector(p)));
             replay.Decorations.AddOverheadIcon(seg, p, ParserIcons.FixationPurpleOverhead);
         }
         var fixatedSamarog = GetFilteredList(log.CombatData, FixatedSamarog, p, true, true);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -539,10 +539,7 @@ internal class Dhuum : HallOfChains
                 break;
             case (int)TrashID.UnderworldReaper:
                 var stealths = target.GetBuffStatus(log, Stealth, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-                foreach (Segment seg in stealths)
-                {
-                    replay.Decorations.Add(new CircleDecoration(180, seg, "rgba(80, 80, 80, 0.3)", new AgentConnector(target)));
-                }
+                replay.Decorations.AddOverheadIcons(stealths, target, BuffImages.Stealth);
                 var underworldReaperHPs = target.GetHealthUpdates(log);
                 replay.Decorations.Add(new OverheadProgressBarDecoration(30, (start, end), Colors.Green, 0.6, Colors.Black, 0.2, underworldReaperHPs.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -410,7 +410,7 @@ internal class Dhuum : HallOfChains
                 {
                     var circle = new CircleDecoration(300, (c.Time, c.EndTime), Colors.LightOrange, 0.5, new AgentConnector(target));
                         replay.Decorations.Add(circle);
-                        replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Orange, 0.9, Colors.Black, 0.2, [(c.Time, 0), (c.EndTime, 100)], new AgentConnector(target))
+                        replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Orange, 0.9, Colors.Black, 0.2, [(c.Time, 0), (c.EndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
 
@@ -541,7 +541,7 @@ internal class Dhuum : HallOfChains
                 var stealths = target.GetBuffStatus(log, Stealth, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 replay.Decorations.AddOverheadIcons(stealths, target, BuffImages.Stealth);
                 var underworldReaperHPs = target.GetHealthUpdates(log);
-                replay.Decorations.Add(new OverheadProgressBarDecoration(30, (start, end), Colors.Green, 0.6, Colors.Black, 0.2, underworldReaperHPs.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (start, end), Colors.Green, 0.6, Colors.Black, 0.2, underworldReaperHPs.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180)));
                 if (_hasPrevent)
@@ -638,7 +638,7 @@ internal class Dhuum : HallOfChains
                 end = (int)removedBuff.Time;
             }
             var lifespan = new Segment(start, end, 1);
-            replay.Decorations.Add(new OverheadProgressBarDecoration(40, (start, end), Colors.CobaltBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + duration, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (start, end), Colors.CobaltBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + duration, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(130)));
             replay.Decorations.AddRotatedOverheadIcon(lifespan, p, ParserIcons.GenericGreenArrowUp, 40f);
         }
@@ -646,7 +646,7 @@ internal class Dhuum : HallOfChains
         var bombDhuum = p.GetBuffStatus(log, ArcingAffliction, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (Segment seg in bombDhuum)
         {
-            replay.Decorations.Add(new OverheadProgressBarDecoration(40, (seg.Start, seg.End), Colors.Orange, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 13000, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (seg.Start, seg.End), Colors.Orange, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 13000, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(-130)));
             replay.Decorations.AddRotatedOverheadIcon(seg, p, ParserIcons.BombTimerFullOverhead, -40f);
         }
@@ -675,7 +675,7 @@ internal class Dhuum : HallOfChains
         foreach (var seg in hastenedDemise)
         {
             long soulSplitDeathTime = seg.Start + 10000;
-            replay.Decorations.Add(new OverheadProgressBarDecoration(30, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (soulSplitDeathTime, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (soulSplitDeathTime, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(90)));
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -410,7 +410,7 @@ internal class Dhuum : HallOfChains
                 {
                     var circle = new CircleDecoration(300, (c.Time, c.EndTime), Colors.LightOrange, 0.5, new AgentConnector(target));
                         replay.Decorations.Add(circle);
-                        replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Orange, 0.9, Colors.Black, 0.2, [(c.Time, 0), (c.EndTime, 100)], new AgentConnector(target))
+                        replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Orange, 0.9, Colors.Black, 0.2, [(c.Time, 0), (c.EndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
 
@@ -541,7 +541,7 @@ internal class Dhuum : HallOfChains
                 var stealths = target.GetBuffStatus(log, Stealth, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 replay.Decorations.AddOverheadIcons(stealths, target, BuffImages.Stealth);
                 var underworldReaperHPs = target.GetHealthUpdates(log);
-                replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (start, end), Colors.Green, 0.6, Colors.Black, 0.2, underworldReaperHPs.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMinorSizeInPixel, (start, end), Colors.Green, 0.6, Colors.Black, 0.2, underworldReaperHPs.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180)));
                 if (_hasPrevent)
@@ -638,7 +638,7 @@ internal class Dhuum : HallOfChains
                 end = (int)removedBuff.Time;
             }
             var lifespan = new Segment(start, end, 1);
-            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (start, end), Colors.CobaltBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + duration, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMinorSizeInPixel, (start, end), Colors.CobaltBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + duration, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(130)));
             replay.Decorations.AddRotatedOverheadIcon(lifespan, p, ParserIcons.GenericGreenArrowUp, 40f);
         }
@@ -646,7 +646,7 @@ internal class Dhuum : HallOfChains
         var bombDhuum = p.GetBuffStatus(log, ArcingAffliction, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (Segment seg in bombDhuum)
         {
-            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (seg.Start, seg.End), Colors.Orange, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 13000, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMinorSizeInPixel, (seg.Start, seg.End), Colors.Orange, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 13000, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(-130)));
             replay.Decorations.AddRotatedOverheadIcon(seg, p, ParserIcons.BombTimerFullOverhead, -40f);
         }
@@ -675,7 +675,7 @@ internal class Dhuum : HallOfChains
         foreach (var seg in hastenedDemise)
         {
             long soulSplitDeathTime = seg.Start + 10000;
-            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (soulSplitDeathTime, 100)], new AgentConnector(p))
+            replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMinorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (soulSplitDeathTime, 100)], new AgentConnector(p))
                 .UsingRotationConnector(new AngleConnector(90)));
         }
     }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -409,7 +409,9 @@ internal class Dhuum : HallOfChains
                 foreach (CastEvent c in cataCycle)
                 {
                     var circle = new CircleDecoration(300, (c.Time, c.EndTime), Colors.LightOrange, 0.5, new AgentConnector(target));
-                    replay.Decorations.AddWithGrowing(circle, end);
+                        replay.Decorations.Add(circle);
+                        replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.LightOrange, 0.8, Colors.Black, 0.2, [(c.Time, 0), (c.EndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
 
                 // Cone Slash
@@ -541,6 +543,10 @@ internal class Dhuum : HallOfChains
                 {
                     replay.Decorations.Add(new CircleDecoration(180, seg, "rgba(80, 80, 80, 0.3)", new AgentConnector(target)));
                 }
+                var underworldReaperHPs = target.GetHealthUpdates(log);
+                replay.Decorations.Add(new OverheadProgressBarDecoration(30, (start, end), Colors.Green, 0.6, Colors.Black, 0.2, underworldReaperHPs.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
+                    .UsingRotationConnector(new AngleConnector(180)));
                 if (_hasPrevent)
                 {
                     if (_greenStart == 0)
@@ -560,9 +566,17 @@ internal class Dhuum : HallOfChains
                     if (replay.Positions.Count > 0) {
                         pos = replay.Positions[0];
 
-                        if (replay.Positions.Count > 1)
+                        if (pos.XYZ.X < 14000)
                         {
-                            replay.Trim(replay.Positions.LastOrDefault().Time, replay.TimeOffsets.end);
+                            // Outside reaper
+                            replay.Trim(target.FirstAware, target.FirstAware + CombatReplayPollingRate);
+                        } 
+                        else
+                        {
+                            if (replay.Positions.Count > 1)
+                            {
+                                replay.Trim(replay.Positions.LastOrDefault().Time, replay.TimeOffsets.end);
+                            }
                         }
                     }
                     else
@@ -627,16 +641,16 @@ internal class Dhuum : HallOfChains
                 end = (int)removedBuff.Time;
             }
             var lifespan = new Segment(start, end, 1);
-            var circle = new CircleDecoration(100, lifespan, "rgba(0, 50, 200, 0.3)", new AgentConnector(p));
-            replay.Decorations.AddWithGrowing(circle, duration);
+            replay.Decorations.Add(new OverheadProgressBarDecoration(40, (start, end), Colors.CobaltBlue, 0.6, Colors.Black, 0.2, [(start, 0), (start + duration, 100)], new AgentConnector(p))
+                .UsingRotationConnector(new AngleConnector(130)));
             replay.Decorations.AddRotatedOverheadIcon(lifespan, p, ParserIcons.GenericGreenArrowUp, 40f);
         }
         // bomb
         var bombDhuum = p.GetBuffStatus(log, ArcingAffliction, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (Segment seg in bombDhuum)
         {
-            var circle = new CircleDecoration(100, seg, "rgba(80, 180, 0, 0.3)", new AgentConnector(p));
-            replay.Decorations.AddWithGrowing(circle, seg.Start + 13000);
+            replay.Decorations.Add(new OverheadProgressBarDecoration(40, (seg.Start, seg.End), Colors.Orange, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.Start + 13000, 100)], new AgentConnector(p))
+                .UsingRotationConnector(new AngleConnector(-130)));
             replay.Decorations.AddRotatedOverheadIcon(seg, p, ParserIcons.BombTimerFullOverhead, -40f);
         }
         // shackles connection
@@ -651,15 +665,20 @@ internal class Dhuum : HallOfChains
 
         // Soul split
         var souls = log.AgentData.GetNPCsByID(TrashID.YourSoul).Where(x => x.GetFinalMaster() == p.AgentItem);
-
-        // check Hastened Demise
         foreach (AgentItem soul in souls)
         {
-            Segment? hastenedDemise = p.GetBuffStatus(log, HastenedDemise, soul.FirstAware, soul.LastAware).FirstOrNull(static (in Segment x) => x.Value == 1);
-            if (hastenedDemise != null && soul.TryGetCurrentPosition(log, soul.FirstAware, out var soulPosition, 1000))
+            if (soul.TryGetCurrentPosition(log, soul.FirstAware, out var soulPosition, 1000))
             {
-                AddSoulSplitDecorations(p, replay, soul, hastenedDemise.Value, soulPosition);
+                AddSoulSplitDecorations(p, replay, soul, soulPosition);
             }
+        }
+        // show the death trigger even if we don't have the souls
+        var hastenedDemise = p.GetBuffStatus(log, HastenedDemise, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value == 1);
+        foreach (var seg in hastenedDemise)
+        {
+            long soulSplitDeathTime = seg.Start + 10000;
+            replay.Decorations.Add(new OverheadProgressBarDecoration(30, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (soulSplitDeathTime, 100)], new AgentConnector(p))
+                .UsingRotationConnector(new AngleConnector(90)));
         }
     }
 
@@ -773,29 +792,24 @@ internal class Dhuum : HallOfChains
     /// <param name="p">The player.</param>
     /// <param name="replay">The Combat Replay.</param>
     /// <param name="soul">The Soul to tether to the player.</param>
-    /// <param name="hastenedDemise">The segment of the buff on the player.</param>
     /// <param name="soulPosition">The position of the Soul.</param>
-    private static void AddSoulSplitDecorations(PlayerActor p, CombatReplay replay, AgentItem soul, in Segment hastenedDemise, in Vector3 soulPosition)
+    private static void AddSoulSplitDecorations(PlayerActor p, CombatReplay replay, AgentItem soul, in Vector3 soulPosition)
     {
         (long, long) soulLifespan = (soul.FirstAware, soul.LastAware);
-        long soulSplitDeathTime = hastenedDemise.Start + 10000;
 
         uint radius = (soul.HitboxWidth / 2);
-        var positionConnector = new PositionConnector(soulPosition);
+        var soulConnector = new PositionConnector(soulPosition);
         var playerConnector = new AgentConnector(p);
 
         // Soul outer circle
-        var hitbox = (CircleDecoration)new CircleDecoration(radius, radius - 25, soulLifespan, Colors.White, 0.8, positionConnector).UsingFilled(false);
+        var hitbox = (CircleDecoration)new CircleDecoration(radius, radius - 25, soulLifespan, Colors.White, 0.8, soulConnector).UsingFilled(false);
         // Soul tether to player
-        var line = new LineDecoration(soulLifespan, Colors.White, 0.8, positionConnector, playerConnector);
+        var line = new LineDecoration(soulLifespan, Colors.White, 0.8, soulConnector, playerConnector);
         // Soul icon
-        var icon = new IconDecoration(ParserIcons.DhuumPlayerSoul, 16, 1, soulLifespan, positionConnector);
-        // Red circle indicating timer
-        var death = new CircleDecoration(radius, hastenedDemise, Colors.Red, 0.2, positionConnector);
+        var icon = new IconDecoration(ParserIcons.DhuumPlayerSoul, 16, 1, soulLifespan, soulConnector);
 
         replay.Decorations.Add(hitbox);
         replay.Decorations.Add(line);
         replay.Decorations.Add(icon);
-        replay.Decorations.AddWithFilledWithGrowing(death, true, soulSplitDeathTime);
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/Dhuum.cs
@@ -410,7 +410,7 @@ internal class Dhuum : HallOfChains
                 {
                     var circle = new CircleDecoration(300, (c.Time, c.EndTime), Colors.LightOrange, 0.5, new AgentConnector(target));
                         replay.Decorations.Add(circle);
-                        replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.LightOrange, 0.8, Colors.Black, 0.2, [(c.Time, 0), (c.EndTime, 100)], new AgentConnector(target))
+                        replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Orange, 0.9, Colors.Black, 0.2, [(c.Time, 0), (c.EndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
@@ -222,10 +222,8 @@ internal class SoullessHorror : HallOfChains
                 var howling = cls.Where(x => x.SkillId == HowlingDeath);
                 foreach (CastEvent c in howling)
                 {
-                    start = (int)c.Time;
-                    end = (int)c.EndTime;
-                    var circle = new CircleDecoration(180, (start, end), Colors.LightBlue, 0.3, new AgentConnector(target));
-                    replay.Decorations.AddWithGrowing(circle, start + c.ExpectedDuration);
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 
                 var vortex = cls.Where(x => x.SkillId == InnerVortexSlash);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
@@ -222,7 +222,7 @@ internal class SoullessHorror : HallOfChains
                 var howling = cls.Where(x => x.SkillId == HowlingDeath);
                 foreach (CastEvent c in howling)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/SoullessHorror.cs
@@ -222,7 +222,7 @@ internal class SoullessHorror : HallOfChains
                 var howling = cls.Where(x => x.SkillId == HowlingDeath);
                 foreach (CastEvent c in howling)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfDeath.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfDeath.cs
@@ -91,10 +91,8 @@ internal class StatueOfDeath : HallOfChains
                 var breakbar = cls.Where(x => x.SkillId == Imbibe);
                 foreach (CastEvent c in breakbar)
                 {
-                    start = (int)c.Time;
-                    end = (int)c.EndTime;
-                    var circle = new CircleDecoration(180, (start, end), Colors.LightBlue, 0.3, new AgentConnector(target));
-                    replay.Decorations.AddWithGrowing(circle, start + c.ExpectedDuration);
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var vomit = cls.Where(x => x.SkillId == HungeringMiasma);
                 foreach (CastEvent c in vomit)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfDeath.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W5/StatueOfDeath.cs
@@ -91,7 +91,7 @@ internal class StatueOfDeath : HallOfChains
                 var breakbar = cls.Where(x => x.SkillId == Imbibe);
                 foreach (CastEvent c in breakbar)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var vomit = cls.Where(x => x.SkillId == HungeringMiasma);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -508,7 +508,7 @@ internal class Qadim : MythwrightGambit
                 var breakbar = cls.Where(x => x.SkillId == QadimCC);
                 foreach (CastEvent c in breakbar)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Riposte
@@ -545,7 +545,7 @@ internal class Qadim : MythwrightGambit
                 var fieryMeteor = cls.Where(x => x.SkillId == FieryMeteor);
                 foreach (CastEvent c in fieryMeteor)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var eleBreath = cls.Where(x => x.SkillId == ElementalBreath);
@@ -626,7 +626,7 @@ internal class Qadim : MythwrightGambit
                 var patCC = cls.Where(x => x.SkillId == PatriarchCC);
                 foreach (CastEvent c in patCC)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Breath
@@ -702,7 +702,7 @@ internal class Qadim : MythwrightGambit
                 var summon = cls.Where(x => x.SkillId == SummonDestroyer);
                 foreach (CastEvent c in summon)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Pizza

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -508,7 +508,7 @@ internal class Qadim : MythwrightGambit
                 var breakbar = cls.Where(x => x.SkillId == QadimCC);
                 foreach (CastEvent c in breakbar)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Riposte
@@ -545,7 +545,7 @@ internal class Qadim : MythwrightGambit
                 var fieryMeteor = cls.Where(x => x.SkillId == FieryMeteor);
                 foreach (CastEvent c in fieryMeteor)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var eleBreath = cls.Where(x => x.SkillId == ElementalBreath);
@@ -626,7 +626,7 @@ internal class Qadim : MythwrightGambit
                 var patCC = cls.Where(x => x.SkillId == PatriarchCC);
                 foreach (CastEvent c in patCC)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Breath
@@ -702,7 +702,7 @@ internal class Qadim : MythwrightGambit
                 var summon = cls.Where(x => x.SkillId == SummonDestroyer);
                 foreach (CastEvent c in summon)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Pizza

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/Qadim.cs
@@ -508,7 +508,8 @@ internal class Qadim : MythwrightGambit
                 var breakbar = cls.Where(x => x.SkillId == QadimCC);
                 foreach (CastEvent c in breakbar)
                 {
-                    replay.Decorations.Add(new CircleDecoration(ccRadius, ((int)c.Time, (int)c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Riposte
                 var riposte = cls.Where(x => x.SkillId == QadimRiposte);
@@ -544,7 +545,8 @@ internal class Qadim : MythwrightGambit
                 var fieryMeteor = cls.Where(x => x.SkillId == FieryMeteor);
                 foreach (CastEvent c in fieryMeteor)
                 {
-                    replay.Decorations.Add(new CircleDecoration(ccRadius, ((int)c.Time, (int)c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 var eleBreath = cls.Where(x => x.SkillId == ElementalBreath);
                 foreach (CastEvent c in eleBreath)
@@ -624,7 +626,8 @@ internal class Qadim : MythwrightGambit
                 var patCC = cls.Where(x => x.SkillId == PatriarchCC);
                 foreach (CastEvent c in patCC)
                 {
-                    replay.Decorations.Add(new CircleDecoration(ccRadius, ((int)c.Time, (int)c.EndTime), "rgba(0, 180, 255, 0.4)", new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Breath
                 var patBreath = cls.Where(x => x.SkillId == FireBreath);
@@ -699,7 +702,8 @@ internal class Qadim : MythwrightGambit
                 var summon = cls.Where(x => x.SkillId == SummonDestroyer);
                 foreach (CastEvent c in summon)
                 {
-                    replay.Decorations.Add(new CircleDecoration(ccRadius, ((int)c.Time, (int)c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Pizza
                 var forceWave = cls.Where(x => x.SkillId == WaveOfForce);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
@@ -289,7 +289,7 @@ internal class TwinLargos : MythwrightGambit
                 var barrageN = cls.Where(x => x.SkillId == AquaticBarrage);
                 foreach (CastEvent c in barrageN)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Platform wipe (CM only)
@@ -307,7 +307,7 @@ internal class TwinLargos : MythwrightGambit
                 var barrageK = cls.Where(x => x.SkillId == AquaticBarrage);
                 foreach (CastEvent c in barrageK)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Platform wipe (CM only)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
@@ -289,7 +289,8 @@ internal class TwinLargos : MythwrightGambit
                 var barrageN = cls.Where(x => x.SkillId == AquaticBarrage);
                 foreach (CastEvent c in barrageN)
                 {
-                    replay.Decorations.Add(new CircleDecoration(250, ((int)c.Time, (int)c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Platform wipe (CM only)
                 var aquaticDomainN = cls.Where(x => x.SkillId == AquaticDomain);
@@ -306,7 +307,8 @@ internal class TwinLargos : MythwrightGambit
                 var barrageK = cls.Where(x => x.SkillId == AquaticBarrage);
                 foreach (CastEvent c in barrageK)
                 {
-                    replay.Decorations.Add(new CircleDecoration(250, ((int)c.Time, (int)c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 //Platform wipe (CM only)
                 var aquaticDomainK = cls.Where(x => x.SkillId == AquaticDomain);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Adina.cs
@@ -3,6 +3,7 @@ using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
@@ -162,10 +163,7 @@ internal class Adina : TheKeyOfAhdashim
     {
         base.ComputePlayerCombatReplayActors(p, log, replay);
         var radiantBlindnesses = p.GetBuffStatus(log, RadiantBlindness, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-        foreach (Segment seg in radiantBlindnesses)
-        {
-            replay.Decorations.Add(new CircleDecoration(90, seg, "rgba(200, 0, 200, 0.3)", new AgentConnector(p)));
-        }
+        replay.Decorations.AddOverheadIcons(radiantBlindnesses, p, BuffImages.PersistentlyBlinded);
     }
 
 
@@ -224,6 +222,7 @@ internal class Adina : TheKeyOfAhdashim
                 foreach (Segment seg in diamondPalisades)
                 {
                     replay.Decorations.Add(new CircleDecoration(90, seg, Colors.Red, 0.2, new AgentConnector(target)));
+                    replay.Decorations.AddOverheadIcon(seg, target, BuffImages.MonsterSkill);
                 }
                 //
                 var boulderBarrages = casts.Where(x => x.SkillId == BoulderBarrage);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/PeerlessQadim.cs
@@ -368,13 +368,13 @@ internal class PeerlessQadim : TheKeyOfAhdashim
         var chaosCorrosion = p.GetBuffStatus(log, ChaosCorrosion, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (Segment seg in chaosCorrosion)
         {
-            replay.Decorations.Add(new CircleDecoration(100, seg, "rgba(80, 80, 80, 0.3)", new AgentConnector(p)));
+            replay.Decorations.AddRotatedOverheadIcon(seg, p, BuffImages.Fractured, -40f);
         }
         // Critical Mass, debuff while carrying an orb
         var criticalMass = p.GetBuffStatus(log, CriticalMass, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (Segment seg in criticalMass)
         {
-            replay.Decorations.Add(new CircleDecoration(200, seg, Colors.Red, 0.3, new AgentConnector(p)).UsingFilled(false));
+            replay.Decorations.AddRotatedOverheadIcon(seg, p, BuffImages.OrbOfAscension, 40f);
         }
         // Magma drop
         var magmaDrop = p.GetBuffStatus(log, MagmaDrop, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W7/Sabir.cs
@@ -1,6 +1,7 @@
 ﻿using GW2EIEvtcParser.EIData;
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
+using GW2EIEvtcParser.ParserHelpers;
 using static GW2EIEvtcParser.EncounterLogic.EncounterImages;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicTimeUtils;
@@ -152,15 +153,9 @@ internal class Sabir : TheKeyOfAhdashim
             case (int)ArcDPSEnums.TargetID.Sabir:
                 var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
                 var repulsionFields = target.GetBuffStatus(log, RepulsionField, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-                foreach (Segment seg in repulsionFields)
-                {
-                    replay.Decorations.Add(new CircleDecoration(120, seg, "rgba(80, 0, 255, 0.3)", new AgentConnector(target)));
-                }
+                replay.Decorations.AddOverheadIcons(repulsionFields, target, BuffImages.TargetedLocust);
                 var ionShields = target.GetBuffStatus(log, IonShield, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-                foreach (Segment seg in ionShields)
-                {
-                    replay.Decorations.Add(new CircleDecoration(120, seg, "rgba(0, 80, 255, 0.3)", new AgentConnector(target)));
-                }
+                replay.Decorations.AddOverheadIcons(repulsionFields, target, BuffImages.IonShield);
                 //
                 var furyOfTheStorm = casts.Where(x => x.SkillId == FuryOfTheStorm);
                 foreach (CastEvent c in furyOfTheStorm)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -152,7 +152,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Add the Charge Bar on top right of the replay
                 var chargeSegments = target.GetBuffStatus(log, ChargeDecima, log.FightData.FightStart, log.FightData.FightEnd);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(50, lifespan, Colors.Red, 0.6, Colors.Black, 0.4, chargeSegments.Select(x => (x.Start, x.Value * 10)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, lifespan, Colors.Red, 0.6, Colors.Black, 0.4, chargeSegments.Select(x => (x.Start, x.Value * 10)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -321,7 +321,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb1 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(20, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb1.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb1.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -336,7 +336,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb2 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(20, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb2.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb2.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -351,7 +351,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb3 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(20, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb3.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb3.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -321,7 +321,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb1 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(40, lifespan, Colors.Green, 0.4, Colors.Black, 0.4, hpUpdatesOrb1.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(20, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb1.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -336,7 +336,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb2 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(40, lifespan, Colors.Green, 0.4, Colors.Black, 0.4, hpUpdatesOrb2.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(20, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb2.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -351,7 +351,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb3 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(40, lifespan, Colors.Green, 0.4, Colors.Black, 0.4, hpUpdatesOrb3.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(20, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb3.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -151,13 +151,11 @@ internal class DecimaTheStormsinger : MountBalrior
 
                 // Add the Charge Bar on top right of the replay
                 var chargeSegments = target.GetBuffStatus(log, ChargeDecima, log.FightData.FightStart, log.FightData.FightEnd);
-                ReadOnlySpan<(Color, double)> colors =
-                [
-                    (Colors.Red, 0.6),
-                    (Colors.Black, 0.4),
-                    (Colors.LightRed, 0.8),
-                ];
-                replay.Decorations.AddDynamicBar(target, chargeSegments, 10, 2500, -2850, 1000, 150, 0, colors);
+                replay.Decorations.Add(
+                    new OverheadProgressBarDecoration(50, lifespan, Colors.Red, 0.6, Colors.Black, 0.4, chargeSegments.Select(x => (x.Start, x.Value * 10)).ToList(), new AgentConnector(target))
+                    .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
+                    .UsingRotationConnector(new AngleConnector(180))
+                );
 
                 // Mainshock - Pizza Indicator
                 if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.DecimaMainshockIndicator, out var mainshockSlices))
@@ -321,14 +319,12 @@ internal class DecimaTheStormsinger : MountBalrior
                 replay.Decorations.AddOverheadIcon(lifespan, target, ParserIcons.TargetOrder1Overhead);
 
                 // Hp Bar
-                ReadOnlySpan<(Color, double)> colorsOrb1 =
-                [
-                    (Colors.Green, 0.4),
-                    (Colors.Black, 0.4),
-                    (Colors.Green, 0.5),
-                ];
-                var hpUpdates1 = target.GetHealthUpdates(log);
-                replay.Decorations.AddDynamicBar(target, hpUpdates1, 100, 0, 20, 100, 20, 0, colorsOrb1);
+                var hpUpdatesOrb1 = target.GetHealthUpdates(log);
+                replay.Decorations.Add(
+                    new OverheadProgressBarDecoration(40, lifespan, Colors.Green, 0.4, Colors.Black, 0.4, hpUpdatesOrb1.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
+                    .UsingRotationConnector(new AngleConnector(180))
+                );
                 break;
             case (int)ArcDPSEnums.TrashID.GreenOrb2Players:
                 // Green Circle
@@ -338,14 +334,12 @@ internal class DecimaTheStormsinger : MountBalrior
                 replay.Decorations.AddOverheadIcon(lifespan, target, ParserIcons.TargetOrder2Overhead);
 
                 // Hp Bar
-                ReadOnlySpan<(Color, double)> colorsOrb2 =
-                [
-                    (Colors.Green, 0.4),
-                    (Colors.Black, 0.4),
-                    (Colors.Green, 0.5),
-                ];
-                var hpUpdates2 = target.GetHealthUpdates(log);
-                replay.Decorations.AddDynamicBar(target, hpUpdates2, 200, 0, 20, 200, 20, 0, colorsOrb2, 2);
+                var hpUpdatesOrb2 = target.GetHealthUpdates(log);
+                replay.Decorations.Add(
+                    new OverheadProgressBarDecoration(40, lifespan, Colors.Green, 0.4, Colors.Black, 0.4, hpUpdatesOrb2.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
+                    .UsingRotationConnector(new AngleConnector(180))
+                );
                 break;
             case (int)ArcDPSEnums.TrashID.GreenOrb3Players:
                 // Green Circle
@@ -355,14 +349,12 @@ internal class DecimaTheStormsinger : MountBalrior
                 replay.Decorations.AddOverheadIcon(lifespan, target, ParserIcons.TargetOrder3Overhead);
 
                 // Hp Bar
-                ReadOnlySpan<(Color, double)> colorsOrb3 =
-                [
-                    (Colors.Green, 0.4),
-                    (Colors.Black, 0.4),
-                    (Colors.Green, 0.5),
-                ];
-                var hpUpdates3 = target.GetHealthUpdates(log);
-                replay.Decorations.AddDynamicBar(target, hpUpdates3, 300, 0, 20, 300, 20, 0, colorsOrb3, 3);
+                var hpUpdatesOrb3 = target.GetHealthUpdates(log);
+                replay.Decorations.Add(
+                    new OverheadProgressBarDecoration(40, lifespan, Colors.Green, 0.4, Colors.Black, 0.4, hpUpdatesOrb3.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
+                    .UsingRotationConnector(new AngleConnector(180))
+                );
                 break;
             case (int)ArcDPSEnums.TrashID.EnlightenedConduit:
                 // Chorus of Thunder / Discordant Thunder - Orange AoE

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -152,7 +152,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Add the Charge Bar on top right of the replay
                 var chargeSegments = target.GetBuffStatus(log, ChargeDecima, log.FightData.FightStart, log.FightData.FightEnd);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, lifespan, Colors.Red, 0.6, Colors.Black, 0.4, chargeSegments.Select(x => (x.Start, x.Value * 10)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, lifespan, Colors.Red, 0.6, Colors.Black, 0.4, chargeSegments.Select(x => (x.Start, x.Value * 10)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -321,7 +321,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb1 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb1.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb1.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -336,7 +336,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb2 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb2.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb2.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );
@@ -351,7 +351,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 // Hp Bar
                 var hpUpdatesOrb3 = target.GetHealthUpdates(log);
                 replay.Decorations.Add(
-                    new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb3.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
+                    new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMinorSizeInPixel, lifespan, Colors.SligthlyDarkGreen, 0.8, Colors.Black, 0.6, hpUpdatesOrb3.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
                     .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                     .UsingRotationConnector(new AngleConnector(180))
                 );

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -848,7 +848,7 @@ internal class HarvestTemple : EndOfDragonsStrike
                 if (breakbar != null)
                 {
                     var breakbarStates = log.CombatData.GetBreakbarPercentEvents(target.AgentItem).Where(x => x.Time >= breakbar.Time);
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (breakbar.Time, target.LastAware), Colors.LightBlue, 0.6, Colors.Black, 0.2, breakbarStates.Select(x => (x.Time, x.BreakbarPercent)).ToList(), new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (breakbar.Time, target.LastAware), Colors.LightBlue, 0.6, Colors.Black, 0.2, breakbarStates.Select(x => (x.Time, x.BreakbarPercent)).ToList(), new AgentConnector(target))
                         .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                         .UsingRotationConnector(new AngleConnector(180)));
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -848,7 +848,7 @@ internal class HarvestTemple : EndOfDragonsStrike
                 if (breakbar != null)
                 {
                     var breakbarStates = log.CombatData.GetBreakbarPercentEvents(target.AgentItem).Where(x => x.Time >= breakbar.Time);
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (breakbar.Time, target.LastAware), Colors.LightBlue, 0.6, Colors.Black, 0.2, breakbarStates.Select(x => (x.Time, x.BreakbarPercent)).ToList(), new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (breakbar.Time, target.LastAware), Colors.LightBlue, 0.6, Colors.Black, 0.2, breakbarStates.Select(x => (x.Time, x.BreakbarPercent)).ToList(), new AgentConnector(target))
                         .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
                         .UsingRotationConnector(new AngleConnector(180)));
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/HarvestTemple.cs
@@ -847,8 +847,10 @@ internal class HarvestTemple : EndOfDragonsStrike
                 BreakbarStateEvent? breakbar = log.CombatData.GetBreakbarStateEvents(target.AgentItem).FirstOrDefault(x => x.State == ArcDPSEnums.BreakbarState.Active);
                 if (breakbar != null)
                 {
-                    (long start, long end) lifespan = (breakbar.Time, target.LastAware);
-                    replay.Decorations.Add(new CircleDecoration(120, lifespan, Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    var breakbarStates = log.CombatData.GetBreakbarPercentEvents(target.AgentItem).Where(x => x.Time >= breakbar.Time);
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (breakbar.Time, target.LastAware), Colors.LightBlue, 0.6, Colors.Black, 0.2, breakbarStates.Select(x => (x.Time, x.BreakbarPercent)).ToList(), new AgentConnector(target))
+                        .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
+                        .UsingRotationConnector(new AngleConnector(180)));
                 }
                 break;
             case (int)ArcDPSEnums.TargetID.TheDragonVoidJormag:

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
@@ -86,7 +86,7 @@ internal class CosmicObservatory : SecretOfTheObscureStrike
                 var planetCrashes = casts.Where(x => x.SkillId == PlanetCrashSkill);
                 foreach (CastEvent c in planetCrashes)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.Time + 10000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.Time + 10000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
@@ -82,6 +82,14 @@ internal class CosmicObservatory : SecretOfTheObscureStrike
                     replay.Decorations.Add(circle);
                 }
 
+                //
+                var planetCrashes = casts.Where(x => x.SkillId == PlanetCrashSkill);
+                foreach (CastEvent c in planetCrashes)
+                {
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
+                }
+
                 // Spinning nebula
                 var spinningNebulas = casts.Where(x => x.SkillId == SpinningNebulaCentral || x.SkillId == SpinningNebulaWithTeleport);
                 foreach (CastEvent cast in spinningNebulas)

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
@@ -86,7 +86,7 @@ internal class CosmicObservatory : SecretOfTheObscureStrike
                 var planetCrashes = casts.Where(x => x.SkillId == PlanetCrashSkill);
                 foreach (CastEvent c in planetCrashes)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.Time + 10000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
 

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
@@ -378,7 +378,7 @@ internal class TempleOfFebe : SecretOfTheObscureStrike
                 var petrifies = casts.Where(x => x.SkillId == PetrifySkill);
                 foreach (CastEvent c in petrifies)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.Time + 10000, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.Time + 10000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 break;

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
@@ -375,6 +375,12 @@ internal class TempleOfFebe : SecretOfTheObscureStrike
                     var circle = new CircleDecoration(2500, lifespan, Colors.RedSkin, 0.1, new AgentConnector(target));
                     replay.Decorations.Add(circle);
                 }
+                var petrifies = casts.Where(x => x.SkillId == PetrifySkill);
+                foreach (CastEvent c in petrifies)
+                {
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                        .UsingRotationConnector(new AngleConnector(180)));
+                }
                 break;
             case (int)TrashID.EmbodimentOfDespair:
                 AddDeterminedOverhead(target, log, replay);

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/TempleOfFebe.cs
@@ -378,7 +378,7 @@ internal class TempleOfFebe : SecretOfTheObscureStrike
                 var petrifies = casts.Where(x => x.SkillId == PetrifySkill);
                 foreach (CastEvent c in petrifies)
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(50, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
+                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.Time + 10000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
                 }
                 break;

--- a/GW2EIEvtcParser/ParserHelpers/ParserHelper.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserHelper.cs
@@ -15,6 +15,8 @@ public static class ParserHelper
     internal const uint CombatReplaySkillDefaultSizeInPixel = 22;
     internal const uint CombatReplaySkillDefaultSizeInWorld = 90;
     internal const uint CombatReplayOverheadDefaultSizeInPixel = 20;
+    internal const uint CombatReplayOverheadProgressBarMinorSizeInPixel = 20;
+    internal const uint CombatReplayOverheadProgressBarMajorSizeInPixel = 35;
     internal const float CombatReplayOverheadDefaultOpacity = 0.8f;
 
     public const int MinionLimit = 1500;

--- a/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/SkillIDs.cs
@@ -1640,7 +1640,7 @@ public static class SkillIDs
     public const long Exposed31589 = 31589;
     public const long BoundHit = 31600;
     public const long TailLashWyvern = 31613;
-    public const long GorsevalBloom = 31616;
+    public const long GorsevalWorldEater = 31616;
     public const long GhastlyPrison = 31623;
     public const long YouWillJoinUs = 31624;
     public const long CultivatedSynergyPet = 31629;


### PR DESCRIPTION
- Added ProgressBar and OverheadProgressBar decorations.
- Introduced new InterpolationMethod: Step.
- Replaced the followings by progress bar decorations
  - VG magic storm
  - Matthias fountain disabled
  - Matthias sacrifice
  - Sloth narcolepsy
  - KC magic blast (orb collection)
  - Deimos mind crush
  - Samarog brutalize
  - Dhuum cata cycle (no more growing circle)
  - Hastened demise on Dhuum
  - Spirit Transform on Dhuum
  - Bomb on Dhuum
  - Howling on SH
  - Imbide on Soul Eater
  - Ripose loading up on Qadim
  - Fiery Meteor (Hydra), Destroyer Summon (Destroyer) and Platform Smash (Patriarch) on Qadim
  - Aquatic Barrage on Largos
  - Chaos corrosion and critical mass on Qtp
  - Void amalgamate breakbar on HT
- Replaced the followings by icon decorations
  - Deimos unnatural signet 
  - Reaper stealth indicator on Dhuum
  - Radiant Blindness on Adina
  - Repulsion field and ion shield on Sabir
- Added HP bars for reapers on Dhuum + hidden outside reapers from CR.
- Added Planet Crash on Dagda.
- Added Petrify on Cerus.
- Fixed Souls not disappearing on death on Dhuum.
- Hastened Demise trigger will now show up on Dhuum even on logs where soul positions are missing.