### PR TITLE
Fix Sabetha phases & targets

### DIFF
--- a/GW2EIEvtcParser/EIData/PhaseData.cs
+++ b/GW2EIEvtcParser/EIData/PhaseData.cs
@@ -58,6 +58,7 @@ public class PhaseData
         {
             return;
         }
+        _secondaryTargets.Remove(target); // promote to target, all targets stays unchanged
         _targets.Add(target);
     }
 
@@ -74,7 +75,7 @@ public class PhaseData
 
     internal void AddSecondaryTarget(SingleActor? target)
     {
-        if (target == null || _secondaryTargets.Contains(target))
+        if (target == null || AllTargets.Contains(target))
         {
             return;
         }


### PR DESCRIPTION
This fixes incorrect mini boss phases on Sabetha and their targets. The "latest" mini boss is prioritized as main target and any other mini bosses are added as secondary targets.

It also changes behavior of adding phase targets to help prevent duplicate primary & secondary targets:
- Adding a new primary target removes the same actor from the list of secondary targets (if present)
- Adding a new secondary target is skipped if the same actor is already present as primary target