### PR TITLE
Fix some autoattacks and Necromancer Shroud labeling

### DIFF
--- a/GW2EIBuilders/HtmlModels/HtmlMetaData/SkillDto.cs
+++ b/GW2EIBuilders/HtmlModels/HtmlMetaData/SkillDto.cs
@@ -48,7 +48,7 @@ internal class SkillDto : IDItemDto
 
     public SkillDto(SkillItem skill, ParsedEvtcLog log) : base(skill, log)
     {
-        Aa = skill.AA;
+        Aa = skill.IsAutoAttack(log);
         IsSwap = skill.IsSwap;
         NotAccurate = log.SkillData.IsNotAccurate(skill.ID);
         GearProc = log.SkillData.IsGearProc(skill.ID);

--- a/GW2EIBuilders/JsonModels/JsonLogBuilder.cs
+++ b/GW2EIBuilders/JsonModels/JsonLogBuilder.cs
@@ -16,7 +16,7 @@ internal static class JsonLogBuilder
         var skillDesc = new SkillDesc
         {
             Name = skill.Name,
-            AutoAttack = skill.AA,
+            AutoAttack = skill.IsAutoAttack(log),
             Icon = skill.Icon,
             CanCrit = SkillItem.CanCrit(skill.ID, log.LogData.GW2Build),
             IsSwap = skill.IsSwap,

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/FirebrandHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/FirebrandHelper.cs
@@ -106,6 +106,15 @@ internal static class FirebrandHelper
         return _firebrandTomes.Contains(id);
     }
 
+    public static bool IsAutoAttack(ParsedEvtcLog log, long id)
+    {
+        var build = log.CombatData.GetGW2BuildEvent().Build;
+        var skillIds = new List<long>
+        {
+            Chapter1SearingSpell, Chapter1DesertBloomHeal, Chapter1UnflinchingCharge
+        };
+        return build >= GW2Builds.September2017PathOfFireRelease && skillIds.Contains(id);
+    }
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers = [];
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -123,9 +123,7 @@ internal static class NecromancerHelper
 
     public static bool IsShroudTransform(long id)
     {
-        return _shroudTransform.Contains(id)
-            || ReaperHelper.IsReaperShroudTransform(id)
-            || HarbingerHelper.IsHarbingerShroudTransform(id);
+        return _shroudTransform.Contains(id);
     }
 
     private static HashSet<int> Minions =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -121,9 +121,16 @@ internal static class NecromancerHelper
         EnterDeathShroud, ExitDeathShroud,
     ];
 
-    public static bool IsShroudTransform(long id)
+    public static bool IsDeathShroudTransform(long id)
     {
         return _shroudTransform.Contains(id);
+    }
+
+    public static bool IsShroudTransform(long id)
+    {
+        return IsDeathShroudTransform(id)
+            || ReaperHelper.IsReaperShroudTransform(id)
+            || HarbingerHelper.IsHarbingerShroudTransform(id);
     }
 
     private static HashSet<int> Minions =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BladeswornHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BladeswornHelper.cs
@@ -35,6 +35,16 @@ internal static class BladeswornHelper
         return _gunsaberForm.Contains(id);
     }
 
+    public static bool IsAutoAttack(ParsedEvtcLog log, long id)
+    {
+        var build = log.CombatData.GetGW2BuildEvent().Build;
+        var skillIds = new List<long>
+        {
+            SwiftCut, SteelDivide, ExplosiveThrust
+        };
+        return build >= GW2Builds.EODBeta1 && skillIds.Contains(id);
+    }
+
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
         new BuffOnActorDamageModifier(Mod_FierceAsFire, FierceAsFire, "Fierce as Fire", "1%", DamageSource.NoPets, 1.0, DamageType.Strike, DamageType.All, Source.Bladesworn, ByStack, TraitImages.FierceAsFire, DamageModifierMode.All).WithBuilds(GW2Builds.EODBeta4),

--- a/GW2EIEvtcParser/EIData/Statistics/FinalGameplayStats.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/FinalGameplayStats.cs
@@ -89,7 +89,7 @@ public class FinalGameplayStats
             }
             long value = Math.Min(cl.EndTime, end) - Math.Max(cl.Time, start);
             SkillCastUptime += value;
-            if (!cl.Skill.AA)
+            if (!cl.Skill.IsAutoAttack(log))
             {
                 SkillCastUptimeNoAA += value;
             }

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -1336,11 +1336,12 @@ public class SkillItem
     // Fields
     public readonly long ID;
     //public int Range { get; private set; } = 0;
-    public readonly bool AA;
+    private readonly bool AA;
 
-    public bool IsSwap => ID == WeaponSwap || ElementalistHelper.IsElementalSwap(ID) || RevenantHelper.IsLegendSwap(ID) || HarbingerHelper.IsHarbingerShroudTransform(ID);
+    public bool IsSwap => ID == WeaponSwap || ElementalistHelper.IsElementalSwap(ID) || RevenantHelper.IsLegendSwap(ID) || NecromancerHelper.IsShroudTransform(ID) || HarbingerHelper.IsHarbingerShroudTransform(ID);
     public bool IsDodge(SkillData skillData) => IsAnimatedDodge(skillData) || ID == MirageCloakDodge;
     public bool IsAnimatedDodge(SkillData skillData) => ID == skillData.DodgeId || VindicatorHelper.IsVindicatorDodge(ID);
+    public bool IsAutoAttack(ParsedEvtcLog log) => AA || FirebrandHelper.IsAutoAttack(log, ID) || BladeswornHelper.IsAutoAttack(log, ID);
     public readonly string Name = "";
     public readonly string Icon = "";
     private readonly WeaponDescriptor? _weaponDescriptor;

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -1338,7 +1338,7 @@ public class SkillItem
     //public int Range { get; private set; } = 0;
     private readonly bool AA;
 
-    public bool IsSwap => ID == WeaponSwap || ElementalistHelper.IsElementalSwap(ID) || RevenantHelper.IsLegendSwap(ID) || NecromancerHelper.IsShroudTransform(ID) || HarbingerHelper.IsHarbingerShroudTransform(ID);
+    public bool IsSwap => ID == WeaponSwap || ElementalistHelper.IsElementalSwap(ID) || RevenantHelper.IsLegendSwap(ID) || NecromancerHelper.IsDeathShroudTransform(ID) || HarbingerHelper.IsHarbingerShroudTransform(ID);
     public bool IsDodge(SkillData skillData) => IsAnimatedDodge(skillData) || ID == MirageCloakDodge;
     public bool IsAnimatedDodge(SkillData skillData) => ID == skillData.DodgeId || VindicatorHelper.IsVindicatorDodge(ID);
     public bool IsAutoAttack(ParsedEvtcLog log) => AA || FirebrandHelper.IsAutoAttack(log, ID) || BladeswornHelper.IsAutoAttack(log, ID);

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -14,6 +14,7 @@ public static class ArcDPSEnums
         internal const ulong February2017Balance = 72781;
         internal const ulong May2017Balance = 76706;
         internal const ulong July2017ShatteredObservatoryRelease = 79873;
+        internal const ulong September2017PathOfFireRelease = 82356;
         internal const ulong December2017Balance = 84832;
         internal const ulong February2018Balance = 86181;
         internal const ulong May2018Balance = 88541;


### PR DESCRIPTION
Gunsaber autoattack chain and Firebrand Chapter 1 skills are now categorised as autoattacks.
Necromancer shroud is now categorised as a weapon swap.
Separated Reaper Shroud and Harbinger Shroud from IsShroudTransform, Reaper Shroud is already a weapon swap.
Added Path of Fire release build number.