### PR TITLE
Deimos Combat Replay improvements

### DIFF
--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Deimos.cs
@@ -676,6 +676,8 @@ internal class Deimos : BastionOfThePenitent
 
     internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
     {
+        base.ComputeEnvironmentCombatReplayDecorations(log);
+
         // Rapid Decay - Orange Indicator - Oil
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.DeimosRapidDecayIndicator, out var rapidDecayIndicator))
         {

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -561,6 +561,20 @@ public static class EffectGUIDs
     public static readonly GUID MursaarOverseerProtectBubble = new("17BC358A51ED2D43BF2ABE8AB642B86B"); // Src player
     public static readonly GUID MursaarOverseerClaimMarker = new("94F3501D777FAC439E78E143CE756B0A"); // No Src - No Dst
     public static readonly GUID MursaarOverseerShockwave = new("0F62A1315A00FC438B2F1273E6BC4054");
+    // Deimos
+    public static readonly GUID DeimosRapidDecayIndicator = new("DF5BD0F43A4EDE4D85E54766D6769446"); // No Src - 3500 duration - oil indicator
+    public static readonly GUID DeimosRapidDecay200Radius = new("9339317532713741AA623C0799C55792"); // No Src - 1500 duration - oil - reapplied every 1000ms for 1500ms, leaving 500ms for "pulsing animation"
+    public static readonly GUID DeimosRapidDecay300Radius = new("6640E1F1CD53954D83ACE816ECE6B7DC"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosRapidDecay400Radius = new("91D84AE4AEA30243807F3530AE27B8DE"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosRapidDecay500Radius = new("85526642B1DB2A4BB0AD16AE42F1BB80"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosRapidDecay600Radius = new("1C200007E46EA8479039CF826B05F867"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosRapidDecay700Radius = new("B8A2BEBEF2EBC84A80AD73C9CDE5BD87"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosRapidDecay800Radius = new("A7D9114A6CB9634FB15CDCD6E659FF22"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosRapidDecay900Radius = new("0D9D89CB5D81634493B57CBA36DC4697"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosRapidDecay1000Radius = new("468942D42A459B438D6388859C589D60"); // No src - 1500 duration - oil
+    public static readonly GUID DeimosSoulFeast = new("1BBF189B7174604F822656C5A85FC0D6"); // Src Hands - 2000 duration - hand - reapplied each animation
+    public static readonly GUID DeimosAnnihilateSliceIndicator = new("F5B44356708C9243BE2D67986FDD0CF4"); // Src Deimos - 1500 duration - Pizza slice indicator
+    public static readonly GUID DeimosAnnihilateHit = new("D94547E5FC797B458BF25D06C8E32C68"); // Src Deimos - 1000 duration - Pizza slice hit
     // Broken King
     public static readonly GUID BrokenKingNumbingBreachIndicator = new("5341E83B29B534408E90DBE7BE6F452D");
     public static readonly GUID BrokenKingNumbingBreachDamage = new("1BF014091BFD1E40A11ED36B92601342");


### PR DESCRIPTION
- Added expanding Rapid Decay through effects
- Added spawning Rapid Decay indicator
- Added Soul Feast effects
- Locked old Rapid Decay and Soul Feast to be used only for logs without effect data
- Fixed the animation of Rapid Decay spawning for old logs
- Added a red border for Rapid Decay for old logs

Logs used for testing
[deimosLogs.zip](https://github.com/user-attachments/files/18982499/deimosLogs.zip)
