### PR TITLE
Vale Guardian, Gorseval and Sabetha improvements and cleanup

### DIFF
--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -55,6 +55,7 @@ internal static class Colors
     public static Color LightBrown = new(196, 164, 132);
     public static Color Brown = new(120, 100, 0);
     public static Color Chocolate = new(123, 63, 0);
+    public static Color Lime = new(200, 255, 100);
     public static Color Green = new(0, 255, 0);
     public static Color GreenishYellow = new(220, 255, 0);
     public static Color MilitaryGreen = new(69, 75, 27);
@@ -66,6 +67,7 @@ internal static class Colors
     public static Color Teal = new(0, 255, 255);
     public static Color DarkTeal = new(0, 160, 150);
     public static Color LightBlue = new(0, 140, 255);
+    public static Color DarkPurpleBlue = new(25, 25, 112);
     public static Color Purple = new(150, 0, 255);
     public static Color DarkPurple = new(50, 0, 150);
     public static Color LightPurple = new(200, 140, 255);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Gorseval.cs
@@ -133,7 +133,7 @@ internal class Gorseval : SpiritVale
         var eggs = p.GetBuffStatus(log, GhastlyPrison, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
         foreach (var seg in eggs)
         {
-            replay.Decorations.Add(new CircleDecoration(180, seg, "rgba(255, 160, 0, 0.3)", new AgentConnector(p)));
+            replay.Decorations.Add(new CircleDecoration(180, seg, Colors.LightOrange, 0.2, new AgentConnector(p)));
         }
 
         // Spectral Darkness - Orbs Debuff Overhead
@@ -235,7 +235,6 @@ internal class Gorseval : SpiritVale
                         {
                             byte pattern = patterns[i];
                             var connector = new PositionConnector(pos);
-                            var color = "rgba(25,25,112, 0.25)";
                             //
                             var nonFullDecorations = new List<FormDecoration>();
                             int tickStartNonFull = start + 4000 * i;
@@ -244,23 +243,23 @@ internal class Gorseval : SpiritVale
                             (int, int) lifespanRampageNonFull = (tickStartNonFull, tickEndNonFull);
                             if ((pattern & first) > 0)
                             {
-                                nonFullDecorations.Add(new CircleDecoration(360, lifespanRampageNonFull, color, connector));
+                                nonFullDecorations.Add(new CircleDecoration(360, lifespanRampageNonFull, Colors.DarkPurpleBlue, 0.25, connector));
                             }
                             if ((pattern & second) > 0)
                             {
-                                nonFullDecorations.Add(new DoughnutDecoration(360, 720, lifespanRampageNonFull, color, connector));
+                                nonFullDecorations.Add(new DoughnutDecoration(360, 720, lifespanRampageNonFull, Colors.DarkPurpleBlue, 0.25, connector));
                             }
                             if ((pattern & third) > 0)
                             {
-                                nonFullDecorations.Add(new DoughnutDecoration(720, 1080, lifespanRampageNonFull, color, connector));
+                                nonFullDecorations.Add(new DoughnutDecoration(720, 1080, lifespanRampageNonFull, Colors.DarkPurpleBlue, 0.25, connector));
                             }
                             if ((pattern & fourth) > 0)
                             {
-                                nonFullDecorations.Add(new DoughnutDecoration(1080, 1440, lifespanRampageNonFull, color, connector));
+                                nonFullDecorations.Add(new DoughnutDecoration(1080, 1440, lifespanRampageNonFull, Colors.DarkPurpleBlue, 0.25, connector));
                             }
                             if ((pattern & fifth) > 0)
                             {
-                                nonFullDecorations.Add(new DoughnutDecoration(1440, 1800, lifespanRampageNonFull, color, connector));
+                                nonFullDecorations.Add(new DoughnutDecoration(1440, 1800, lifespanRampageNonFull, Colors.DarkPurpleBlue, 0.25, connector));
                             }
                             foreach (FormDecoration decoration in nonFullDecorations)
                             {
@@ -271,7 +270,7 @@ internal class Gorseval : SpiritVale
                             {
                                 (int, int) fullLifespanRampage = (tickStartNonFull - 1000, tickEndNonFull - 1000);
                                 int fullExplosion = explosionNonFull - 1000;
-                                replay.Decorations.AddWithGrowing(new CircleDecoration(1800, fullLifespanRampage, color, connector), fullExplosion);
+                                replay.Decorations.AddWithGrowing(new CircleDecoration(1800, fullLifespanRampage, Colors.DarkPurpleBlue, 0.25, connector), fullExplosion);
                             }
                         }
                     }
@@ -290,7 +289,7 @@ internal class Gorseval : SpiritVale
                 var protection = target.GetBuffStatus(log, ProtectiveShadow, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (var seg in protection)
                 {
-                    replay.Decorations.Add(new CircleDecoration(300, seg, "rgba(0, 180, 255, 0.5)", new AgentConnector(target)));
+                    replay.Decorations.Add(new CircleDecoration(300, seg, Colors.LightBlue, 0.5, new AgentConnector(target)));
                 }
                 break;
             case (int)ArcDPSEnums.TrashID.ChargedSoul:
@@ -299,6 +298,21 @@ internal class Gorseval : SpiritVale
                 break;
             default:
                 break;
+        }
+    }
+
+    internal override void ComputeEnvironmentCombatReplayDecorations(ParsedEvtcLog log)
+    {
+        base.ComputeEnvironmentCombatReplayDecorations(log);
+
+        if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.GorsevalGhastlyPrison, out var ghstlyPrison))
+        {
+            foreach (EffectEvent effect in ghstlyPrison)
+            {
+                (long start, long end) lifespan = effect.ComputeLifespan(log, 2000);
+                var circle = new CircleDecoration(80, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position));
+                EnvironmentDecorations.AddWithGrowing(circle, lifespan.end);
+            }
         }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -154,8 +154,8 @@ internal class ValeGuardian : SpiritVale
             foreach (EffectEvent distributedMagic in distributedMagicEvents)
             {
                 // Effect duration is 6000, added 700 for the damage.
-                (long start, long end) lifespan = distributedMagic.ComputeLifespan(log, 6700);
-                lifespan.end = Math.Min(lifespan.end, distributedMagic.Src.LastAware);
+                (long start, long end) lifespan = distributedMagic.ComputeLifespan(log, 6000);
+                lifespan.end = Math.Min(lifespan.end + 700, distributedMagic.Src.LastAware);
                 var circle = new CircleDecoration(180, lifespan, Colors.DarkGreen, 0.2, new PositionConnector(distributedMagic.Position));
                 EnvironmentDecorations.AddWithGrowing(circle, lifespan.end);
             }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/ValeGuardian.cs
@@ -151,28 +151,23 @@ internal class ValeGuardian : SpiritVale
 
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ValeGuardianDistributedMagic, out var distributedMagicEvents))
         {
-            int distributedMagicDuration = 6700;
-            //knownEffectsIDs.Add(distributedMagicGUIDEvent.ContentID);
             foreach (EffectEvent distributedMagic in distributedMagicEvents)
             {
-                int start = (int)distributedMagic.Time;
-                int expectedEnd = start + distributedMagicDuration;
-                int end = Math.Min(expectedEnd, (int)distributedMagic.Src.LastAware);
-                var circle = new CircleDecoration(180, (start, end), Colors.Green, 0.2, new PositionConnector(distributedMagic.Position));
-                EnvironmentDecorations.Add(circle);
-                EnvironmentDecorations.Add(circle.Copy().UsingGrowingEnd(expectedEnd));
+                // Effect duration is 6000, added 700 for the damage.
+                (long start, long end) lifespan = distributedMagic.ComputeLifespan(log, 6700);
+                lifespan.end = Math.Min(lifespan.end, distributedMagic.Src.LastAware);
+                var circle = new CircleDecoration(180, lifespan, Colors.DarkGreen, 0.2, new PositionConnector(distributedMagic.Position));
+                EnvironmentDecorations.AddWithGrowing(circle, lifespan.end);
             }
         }
+
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ValeGuardianMagicSpike, out var magicSpikeEvents))
         {
-            //knownEffectsIDs.Add(magicSpikeGUIDEvent.ContentID);
             foreach (EffectEvent magicSpike in magicSpikeEvents)
             {
-                int start = (int)magicSpike.Time;
-                int end = start + 2000;
-                var circle = new CircleDecoration(90, (start, end), Colors.Blue, 0.2, new PositionConnector(magicSpike.Position));
-                EnvironmentDecorations.Add(circle);
-                EnvironmentDecorations.Add(circle.Copy().UsingGrowingEnd(end));
+                (long start, long end) lifespan = magicSpike.ComputeLifespan(log, 2000);
+                var circle = new CircleDecoration(90, lifespan, Colors.Blue, 0.2, new PositionConnector(magicSpike.Position));
+                EnvironmentDecorations.AddWithGrowing(circle, lifespan.end);
             }
         }
     }
@@ -180,7 +175,7 @@ internal class ValeGuardian : SpiritVale
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
         var lifespan = ((int)replay.TimeOffsets.start, (int)replay.TimeOffsets.end);
-        //var knownEffectsIDs = new HashSet<long>();
+
         switch (target.ID)
         {
             case (int)ArcDPSEnums.TargetID.ValeGuardian:

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -242,6 +242,7 @@ public class SkillItem
         { GhastlyRampageBegin,"Ghastly Rampage (Begin)" },
         // Sabetha
         { ShadowStepSabetha, "Shadow Step" },
+        { KickHeavyBomb, "Kick Heavy Bomb" },
         // Slothasor
         { TantrumSkill, "Tantrum Start" },
         { NarcolepsySkill, "Sleeping" },
@@ -980,8 +981,9 @@ public class SkillItem
             { SpearmarshalsSupportBombard, SkillImages.SpearmarshalsSupport },
             { ShrugItOffHeal, TraitImages.ShrugItOff },
             { BerserkEndSkill, SkillImages.BerserkerEnd },
-            #endregion WarriorIcons
+        #endregion WarriorIcons
             #region EncounterIcons
+            { KickHeavyBomb, SkillImages.Kick },
             // Slothasor
             { Toss, SkillImages.TossSlubling },
             // River of Souls

--- a/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ArcDPSEnums.cs
@@ -568,7 +568,7 @@ public static class ArcDPSEnums
     private const int PyreGuardianResolution = -13;
     private const int CASword = -14;
     private const int SubArtsariiv = -15;
-
+    private const int Cannon = -16;
     private const int TheDragonVoidZhaitan = -17;
     private const int TheDragonVoidSooWon = -18;
     private const int TheDragonVoidKralkatorrik = -19;
@@ -612,7 +612,7 @@ public static class ArcDPSEnums
     private const int PermanentEmbodimentOfEnvy = -57;
     private const int PermanentEmbodimentOfMalice = -58;
     private const int KryptisRift = -59;
-
+    private const int HeavyBomb = -60;
     private const int EtherealBarrier = -61;
     private const int ToxicGeyser = -62;
     private const int SulfuricGeyser = -63;
@@ -667,6 +667,8 @@ public static class ArcDPSEnums
         BanditSapper = 15423,
         BanditThug = 15397,
         BanditArsonist = 15421,
+        Cannon = ArcDPSEnums.Cannon,
+        HeavyBomb = ArcDPSEnums.HeavyBomb,
         // Slothasor
         Slubling1 = 16064,
         Slubling2 = 16071,
@@ -1225,7 +1227,6 @@ public static class ArcDPSEnums
         Nikare = 21105,
         Kenut = 21089,
         Qadim = 20934,
-        Freezie = 21333,
         Adina = 22006,
         Sabir = 21964,
         PeerlessQadim = 22000,
@@ -1233,6 +1234,7 @@ public static class ArcDPSEnums
         Decima = 26774,
         Ura = 26712,
         // Strike Missions
+        Freezie = 21333,
         IcebroodConstruct = 22154,
         VoiceOfTheFallen = 22343,
         ClawOfTheFallen = 22481,

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -546,8 +546,16 @@ public static class EffectGUIDs
       
     #region Raids
     // Vale Guardian
-    public static readonly GUID ValeGuardianDistributedMagic = new("43FD739499BB6040BBF9EEF37781B2CE");
-    public static readonly GUID ValeGuardianMagicSpike = new("55364633145D264A934935C3F026B19F");
+    public static readonly GUID ValeGuardianDistributedMagic = new("43FD739499BB6040BBF9EEF37781B2CE"); // 6000 duration
+    public static readonly GUID ValeGuardianMagicSpike = new("55364633145D264A934935C3F026B19F"); // 2000 duration
+    // Gorseval
+    public static readonly GUID GorsevalGhastlyPrison = new("16BBFDBEC55958419CC5564CB1FEED04"); // 2000 duration
+    // Sabetha
+    public static readonly GUID SabethaCannonBarrier = new("3C4BADFCD8987D449715C9A72FDC2149"); // 600.000 duration - Src Cannon Dst Cannon
+    public static readonly GUID SabethaCannonBarrage = new("3ED61C8A1C2E594A8AD2E2E69AF16322"); // 3500 duration - Src Cannon
+    public static readonly GUID SabethaPlatformCrush = new("1EAC8EDCB57CDC4DB19DA7F2D37D25E8"); // 1000 duration - No Src - Platform debris falling
+    public static readonly GUID SabethaFlakShot = new("1D17794F2428F344A5D9755AB8899633"); // 25000 duration - Src Sabetha
+    public static readonly GUID SabethaSapperBombGroundAoE = new("09D5D14BE3AFEA48958B1A8D7634B08A"); // 1000 duration - No Src
     // Escort Glenna
     public static readonly GUID EscortOverHere = new("64CD79C1A121EC42B1278DEF9280ED35");
     // Xera

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/MarkerGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/MarkerGUIDs.cs
@@ -74,6 +74,8 @@ public static class MarkerGUIDs
         XOverhead
     };
 
-    // Other
+    // Sabetha
+    internal static readonly GUID SabethaCannonRedCrossSwordsMarker = new("09C2D6DFE68B004D928B1C76EF77D47E");
+    // Ura
     internal static readonly GUID UraTitanspawnGeyserMarker = new("2818A92C67388940B74D627979000D39");
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -1602,11 +1602,12 @@ public static class SkillIDs
     public const long BiteSmokescale = 31312;
     public const long PylonAttunementBlue = 31317;
     public const long WingBuffetWyvern = 31321;
+    public const long TimeBombDamage = 31324; // First Bomb
     public const long Firestorm = 31332;
     public const long Rebound = 31337;
     public const long DistributedMagicBlue = 31340;
     public const long GlyphOfAlignmentCA = 31348;
-    public const long HarmoniousConduit = 31353;
+    public const long HarmoniousConduit = 31353; // Historical
     public const long TranscendentTempest = 31353;
     public const long AuguryOfDeath = 31354;
     public const long SolarBeam = 31371;
@@ -1624,6 +1625,7 @@ public static class SkillIDs
     public const long BluePylonPower = 31413;
     public const long MagicStorm = 31419;
     public const long TakedownSmokescale = 31430;
+    public const long KickHeavyBomb = 31435;
     public const long BlackHoleMinion = 31436;
     public const long Determined31450 = 31450;
     public const long MagicAuraRedGuardian = 31462;
@@ -1859,6 +1861,7 @@ public static class SkillIDs
     public const long ShellShocked = 34108;
     public const long SpawnProtection = 34113;
     public const long SoothingBastion = 34136;
+    public const long TimeBombDamage2 = 34152; // Second Bomb, below 50% Sabetha HP
     public const long CallOfTheMists = 34164;
     public const long PeppermintOil = 34187;
     public const long PeppermintOmnomberryBar = 34188;

--- a/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
@@ -408,6 +408,7 @@ internal static class ParserIcons
     private const string TrashBloodstoneShard = "https://i.imgur.com/fEp6wEj.png";
     private const string TrashGree = "https://i.imgur.com/fk9cmiH.png";
     private const string TrashReeg = "https://i.imgur.com/cJIIZu3.png";
+    private const string TrashCannon = "https://i.imgur.com/aNe6JUJ.png";
     #endregion
 
     #region Minion
@@ -621,6 +622,7 @@ internal static class ParserIcons
     internal const string EyeOverhead = "https://i.imgur.com/OBfLywE.png";
     internal const string CallTarget = "https://wiki.guildwars2.com/images/e/e9/Call_Target.png";
     internal const string TargetOverhead = "https://wiki.guildwars2.com/images/9/96/Targeted_%28Vishen_Steelshot%29.png";
+    internal const string RedCrossSwordsMarker = "https://i.imgur.com/b7Jxx9C.png";
     // - Bomb Timer
     internal const string BombTimerEmptyOverhead = "https://wiki.guildwars2.com/images/a/a0/Timer_empty_%28overhead_icon%29.png";
     internal const string BombTimerFullOverhead = "https://wiki.guildwars2.com/images/d/d9/Timer_full_%28overhead_icon%29.png";
@@ -1196,6 +1198,8 @@ internal static class ParserIcons
         { TrashID.EnlightenedConduitGadget, NoImage },
         { TrashID.Gree, TrashGree },
         { TrashID.Reeg, TrashReeg },
+        { TrashID.Cannon, TrashCannon },
+        { TrashID.HeavyBomb, TrashFerrousBomb }, // Using Aetherblade Hideous image for better visual
     };
 
     /// <summary>

--- a/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
@@ -1199,7 +1199,7 @@ internal static class ParserIcons
         { TrashID.Gree, TrashGree },
         { TrashID.Reeg, TrashReeg },
         { TrashID.Cannon, TrashCannon },
-        { TrashID.HeavyBomb, TrashFerrousBomb }, // Using Aetherblade Hideous image for better visual
+        { TrashID.HeavyBomb, TrashFerrousBomb }, // Using Aetherblade Hideout image for better visual
     };
 
     /// <summary>

--- a/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
@@ -622,6 +622,7 @@ internal static class SkillImages
     public const string MightyThrow = "https://render.guildwars2.com/file/F02129C7049F590E00BB7B09EDC1B258655D9459/3379199.png";
     public const string WildThrow = "https://render.guildwars2.com/file/0B79EB6203654C703FF9DCBEDF2A4BDAB54D35FC/3379204.png";
     public const string SpearmarshalsSupport = "https://render.guildwars2.com/file/43132DEC934F072272F14B19FC03FB62111502FB/3379203.png";
+    public const string Kick = "https://render.guildwars2.com/file/E578C9070BCA270818F56304CBE2800CD4691350/103001.png";
     #endregion Warrior
     #region WvW
     public const string TurnLeft = "https://wiki.guildwars2.com/images/4/4c/Turn_Left.png";

--- a/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
@@ -7,7 +7,7 @@ internal static class TraitImages
 {
     // TODO: organize this
     #region Elementalist
-    public const string EarthenBlast = "https://render.guildwars2.com/file/2531DCAFAEAB452C90C4572E1ADCE8236DCF5636/1012304.pn";
+    public const string EarthenBlast = "https://render.guildwars2.com/file/2531DCAFAEAB452C90C4572E1ADCE8236DCF5636/1012304.png";
     public const string ElectricDischarge = "https://render.guildwars2.com/file/F4622EE8300028599369D4084EA7A2774D250DEA/1012280.png";
     public const string PersistingFlames = "https://render.guildwars2.com/file/38496307B7C27BCB08D6800F2A699B4998DD1935/1012312.png";
     public const string StoneFlesh = "https://render.guildwars2.com/file/9FACD0F31DF1DF1957C59DA67ED9F76ACB55BEB8/1012303.png";


### PR DESCRIPTION
# General
- Move some colors to the Colors class, updated coloring of some mechanics
- Fixed Earthen Blast image url typo
- Moved Freezie ID in ArcDPSEnums from the raids section to strikes

# Vale Guardian
- Updated visuals and code clean up for  Distributed Magic and Magic Spikes, using the internal decoration APIs

# Gorseval
- Added Ghastly Prison AoEs indicators

# Sabetha
- Improved visuals for Time Bomb and Sapper Bomb on players
- Added Time Bomb downed and killed mechanics
- Added Heavy Bomb kick mechanic (filtered out interrupted and unknown casts)
- Added Cannons and Heavy Bombs to TrashIDs with stabilized IDs
- Added Cannons to Targets to display their HP in the Combat Replay
- Added red cross swords GUID marker to cannons to display when active
- Added Cannon Barrage AoEs
- Added Flak Shot fires
- Added Platform Crush AoEs (falling debris)
- Added Sapper Bomb ground AoE (thrown to the ground)
- Added name and icon for the Kick Heavy Bomb skill cast
- Removed old commented mechanics that aren't trackable

# Notes
- Couldn't find what the flame turrets are in the Sabetha logs
- Cannons always show their health, so I've added the marker to display when they are active. When a cannon dies remains with 0.X HP and on respawn it regains health. Each cannon already has directional name in the log (north, south, east and west).
- For Cannons and Heavy Bombs I've used the -16 and -60 slots, not sure if those IDs were in use and got removed and it's fine to use them now.