### PR TITLE
Various Greer, Decima and Ura improvements

### DIFF
--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayAnimationControl.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayAnimationControl.html
@@ -4,7 +4,7 @@
             <ul class="nav nav-pills d-flex flex-row justify-content-center" style="max-width: 700px;">
                 <li class="nav-item" v-for="(phase, id) in reactivePhases"
                     v-show="!getPhaseData(id).breakbarPhase"
-                    :data-original-title="getPhaseData(id).durationS + ' seconds'">
+                    :data-original-title="getPhaseData(id).durationS + ' seconds <br /> Start: ' + getPhaseData(id).start + '<br /> End: ' + getPhaseData(id).end">
                     <a class="nav-link" @click="updatePhaseTime(id)">{{getPhaseData(id).name}}</a>
                 </li>
             </ul>

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStats.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStats.html
@@ -9,7 +9,7 @@
             <ul class="nav nav-pills d-flex flex-row flex-wrap justify-content-center">
                 <li class="nav-item" v-for="(phase, id) in breakbarPhases"
                     @click="updatePhaseTime(phase.start * 1000, phase.end * 1000, phase.name)"
-                    :data-original-title="phase.durationS + ' seconds'">
+                    :data-original-title="phase.durationS + ' seconds <br /> Start: ' + phase.start + '<br /> End: ' + phase.end">
                     <a class="nav-link">{{id + 1}} </a>
                 </li>
             </ul>

--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -444,6 +444,7 @@ internal static class EncounterBuffs
             new Buff("Pressure Blast Target", PressureBlastTargetBuff, Source.FightSpecific, BuffClassification.Other, BuffImages.Unknown),
             new Buff("Sulfuric Acid", SulfuricAcid, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.SulfuricAcid),
             new Buff("Titanic Resistance", TitanicResistance, Source.FightSpecific, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.Unknown),
+            new Buff("Subsided", Subsided, Source.FightSpecific, BuffClassification.Other, BuffImages.SonicOverload),
             new Buff("Deterrence", Deterrence, Source.FightSpecific, BuffClassification.Other, BuffImages.Deterrence),
             new Buff("Bloodstone Saturation", BloodstoneSaturation, Source.FightSpecific, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.BloodstoneSaturation),
             new Buff("Rising Pressure", RisingPressure, Source.FightSpecific, BuffStackType.Stacking, 20, BuffClassification.Other, BuffImages.RisingPressure),

--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -50,6 +50,7 @@ internal static class Colors
     public static Color RedSkin = new(198, 101, 94);
     public static Color Orange = new(255, 100, 0);
     public static Color LightOrange = new(250, 120, 0);
+    public static Color BreakbarRecoveringOrange = new(168, 104, 61);
     public static Color Sand = new(177, 157, 111);
     public static Color Yellow = new(255, 220, 0);
     public static Color LightBrown = new(196, 164, 132);
@@ -67,7 +68,7 @@ internal static class Colors
     public static Color Teal = new(0, 255, 255);
     public static Color DarkTeal = new(0, 160, 150);
     public static Color LightBlue = new(0, 140, 255);
-    public static Color BreakbarBlue = new(75, 173, 168);
+    public static Color BreakbarActiveBlue = new(75, 173, 168);
     public static Color DarkPurpleBlue = new(25, 25, 112);
     public static Color Purple = new(150, 0, 255);
     public static Color DarkPurple = new(50, 0, 150);
@@ -85,6 +86,7 @@ internal static class Colors
     public static Color DarkWhite = new(180, 180, 180);
     public static Color Grey = new(60, 60, 60);
     public static Color LightGrey = new(120, 120, 120);
+    public static Color BreakbarImmuneGrey = new(44, 45, 54);
     public static Color Black = new(0, 0, 0);
 
     public static Color Guardian = new(0x3399cc);

--- a/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/EncounterDamageModifiers.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/EncounterDamageModifiers.cs
@@ -139,6 +139,8 @@ internal static class EncounterDamageModifiers
             {
                 return !VulnerabilityAdditiveChecker(ahde, log, RisingPressure, 5);
             }),
+        new BuffOnFoeDamageModifier(Mod_UnstrippableProtection, ProtectionUnstrippable, "Protection (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Strike, DamageType.All, Source.Common, ByPresence, BuffImages.Protection, DamageModifierMode.All),
+        new BuffOnFoeDamageModifier(Mod_UnstrippableResolution, ResolutionGreer, "Resolution (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Condition, DamageType.All, Source.Common, ByPresence, BuffImages.Resolution, DamageModifierMode.All),
         // Enrages
         new BuffOnFoeDamageModifier(Mod_Enraged_inc25, Enraged_100_strike_25_reduc, "Enraged (-25%)", "-25%, stacks additively with Vulnerability", DamageSource.All, -25, DamageType.StrikeAndCondition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Enraged, DamageModifierMode.PvE).UsingGainAdjuster(VulnerabilityAdjuster),
         new BuffOnFoeDamageModifier(Mod_Enraged_inc50, Enraged_200_strike_50_reduc, "Enraged (-50%)", "-50%, stacks additively with Vulnerability", DamageSource.All, -50, DamageType.StrikeAndCondition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Enraged, DamageModifierMode.PvE).UsingGainAdjuster(VulnerabilityAdjuster),

--- a/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/EncounterDamageModifiers.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/EncounterDamageModifiers.cs
@@ -139,8 +139,8 @@ internal static class EncounterDamageModifiers
             {
                 return !VulnerabilityAdditiveChecker(ahde, log, RisingPressure, 5);
             }),
-        new BuffOnFoeDamageModifier(Mod_UnstrippableProtection, ProtectionUnstrippable, "Protection (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Strike, DamageType.All, Source.Common, ByPresence, BuffImages.Protection, DamageModifierMode.All),
-        new BuffOnFoeDamageModifier(Mod_UnstrippableResolution, ResolutionGreer, "Resolution (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Condition, DamageType.All, Source.Common, ByPresence, BuffImages.Resolution, DamageModifierMode.All),
+        new BuffOnFoeDamageModifier(Mod_UnstrippableProtection, ProtectionUnstrippable, "Protection (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Strike, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Protection, DamageModifierMode.PvE),
+        new BuffOnFoeDamageModifier(Mod_UnstrippableResolution, ResolutionGreer, "Resolution (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Condition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Resolution, DamageModifierMode.PvE),
         // Enrages
         new BuffOnFoeDamageModifier(Mod_Enraged_inc25, Enraged_100_strike_25_reduc, "Enraged (-25%)", "-25%, stacks additively with Vulnerability", DamageSource.All, -25, DamageType.StrikeAndCondition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Enraged, DamageModifierMode.PvE).UsingGainAdjuster(VulnerabilityAdjuster),
         new BuffOnFoeDamageModifier(Mod_Enraged_inc50, Enraged_200_strike_50_reduc, "Enraged (-50%)", "-50%, stacks additively with Vulnerability", DamageSource.All, -50, DamageType.StrikeAndCondition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Enraged, DamageModifierMode.PvE).UsingGainAdjuster(VulnerabilityAdjuster),

--- a/GW2EIEvtcParser/EIData/Mechanics/IDBasedMechanics/SkillMechanics/SkillMechanic.cs
+++ b/GW2EIEvtcParser/EIData/Mechanics/IDBasedMechanics/SkillMechanics/SkillMechanic.cs
@@ -42,12 +42,8 @@ internal abstract class SkillMechanic : IDBasedMechanic<HealthDamageEvent>
         {
             foreach (HealthDamageEvent ahde in log.CombatData.GetDamageData(skillID))
             {
-                SingleActor? amp = null;
-                if (Keep(ahde, log))
-                {
-                    amp = GetActor(log, GetCreditedAgentItem(ahde), regroupedMobs);
-                }
-                if (amp != null)
+                SingleActor? amp = GetActor(log, GetCreditedAgentItem(ahde), regroupedMobs);
+                if (amp != null && Keep(ahde, log))
                 {
                     InsertMechanic(log, mechanicLogs, ahde.Time, amp);
                 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -24,6 +24,7 @@ internal class DecimaTheStormsinger : MountBalrior
         MechanicList.AddRange(new List<Mechanic>()
         {
             new PlayerDstHitMechanic([ChorusOfThunderDamage, ChorusOfThunderCM], "Chorus of Thunder", new MechanicPlotlySetting(Symbols.Circle, Colors.LightOrange), "ChorThun.H", "Hit by Chorus of Thunder (Spreads AoE / Conduit AoE)", "Chorus of Thunder Hit", 0),
+            new PlayerDstHitMechanic([DiscordantThunderCM], "Discordant Thunder", new MechanicPlotlySetting(Symbols.Circle, Colors.Orange), "DiscThun.H", "Hit by Discordant Thunder", "Discordant Thunder Hit", 0),
             new PlayerDstEffectMechanic(EffectGUIDs.DecimaChorusOfThunderAoE, "Chorus of Thunder", new MechanicPlotlySetting(Symbols.Circle, Colors.LightGrey), "ChorThun.T", "Targeted by Chorus of Thunder (Spreads)", "Chorus of Thunder Target", 0),
 
             new PlayerDstHitMechanic([SeismicCrashDamage, SeismicCrashDamageCM, SeismicCrashDamageCM2], "Seismic Crash", new MechanicPlotlySetting(Symbols.Hourglass, Colors.White), "SeisCrash.H", "Hit by Seismic Crash (Concentric Rings)", "Seismic Crash Hit", 0),
@@ -69,6 +70,57 @@ internal class DecimaTheStormsinger : MountBalrior
             new PlayerDstHitMechanic(Earthfall, "Earthfall", new MechanicPlotlySetting(Symbols.YUp, Colors.LightPink), "Earthfall.H", "Hit by Earthfall (Transcendent Boudlers Jump)", "Earthfall Hit", 0),
             new PlayerDstHitMechanic(Sparkwave, "Sparkwave", new MechanicPlotlySetting(Symbols.TriangleDown, Colors.LightOrange), "Sparkwave.H", "Hit by Sparkwave (Transcendent Boulders Cone)", "Sparkwave Hit", 0),
             new PlayerDstHitMechanic(ChargedGround, "Charged Ground", new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.CobaltBlue), "CharGrnd.H", "Hit by Charged Ground (Transcendent Boulders AoEs)", "Charged Ground Hit", 0),
+
+            new PlayerDstHitMechanic([FulgentFenceCM, FluxlanceFusilladeCM, FluxlanceSalvoCM1, FluxlanceSalvoCM2, FluxlanceSalvoCM3, FluxlanceSalvoCM4, FluxlanceSalvoCM5, ChorusOfThunderCM, DiscordantThunderCM], "This Bug Can Dance", new MechanicPlotlySetting(Symbols.Pentagon, Colors.Lime), "BugDance.Achiv", "Achievement Elibigility: This Bug Can Dance", "Achiv: This Bug Can Dance", 0).UsingChecker((adhe, log) =>
+            {
+                // Only available in CM
+                if (!isCM)
+                {
+                    return true;
+                }
+
+                // If you are dead, lose the achievement
+                if (adhe.To.IsDead(log, log.FightData.FightStart, log.FightData.FightEnd))
+                {
+                    return true;
+                }
+
+                // If you get hit by Fulgent Fence, lose the achievement
+                if (adhe.SkillId == FulgentFenceCM && adhe.HasHit)
+                {
+                    return true;
+                }
+
+                var damageTaken = log.CombatData.GetDamageTakenData(adhe.To);
+                bool hasExposed = log.CombatData.GetBuffData(ExposedPlayer).Any(x => x is BuffApplyEvent && x.To == adhe.To && Math.Abs(x.Time - adhe.Time) < ServerDelayConstant);
+
+                // If you get hit by your own Fluxlance only during the current sequence, keep the achievement
+                // If you get hit by 2 Fluxlance in the current sequence, lose the achievement
+                long[] fluxlanceIds = [FluxlanceFusilladeCM, FluxlanceSalvoCM1, FluxlanceSalvoCM2, FluxlanceSalvoCM3, FluxlanceSalvoCM4, FluxlanceSalvoCM5];
+                var fluxlanceTimes = damageTaken.Where(x => (fluxlanceIds.Contains(x.SkillId)) && x.HasHit).Select(x => x.Time).OrderBy(x => x);
+                foreach (long fluxlanceTime in fluxlanceTimes)
+                {
+                    // Fluxlance sequence lasts about 5 seconds, giving it 7 as margin
+                    if (Math.Abs(fluxlanceTime - adhe.Time) < 7000 && fluxlanceIds.Contains(adhe.SkillId) && hasExposed)
+                    {
+                        return true;
+                    }
+                }
+
+                // If you get hit by your own thunder, keep the achievement
+                // If you get hit by a thunder on another player or on a conduit, lose the achievement
+                long[] thunderIds = [ChorusOfThunderCM, DiscordantThunderCM];
+                var thunderTimes = damageTaken.Where(x => (thunderIds.Contains(x.SkillId)) && x.HasHit).Select(x => x.Time).OrderBy(x => x);
+                foreach (long thunderTime in thunderTimes)
+                {
+                    if (Math.Abs(thunderTime - adhe.Time) < ServerDelayConstant && thunderIds.Contains(adhe.SkillId) && hasExposed)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }).UsingAchievementEligibility(true),
 
             new EnemyDstBuffApplyMechanic(ChargeDecima, "Charge", new MechanicPlotlySetting(Symbols.BowtieOpen, Colors.DarkMagenta), "Charge", "Charge Stacks", "Charge Stack", 0),
 
@@ -763,5 +815,18 @@ internal class DecimaTheStormsinger : MountBalrior
     internal override FightData.EncounterMode GetEncounterMode(CombatData combatData, AgentData agentData, FightData fightData)
     {
         return isCM ? FightData.EncounterMode.CMNoName : FightData.EncounterMode.Normal;
+    }
+
+    protected override void SetInstanceBuffs(ParsedEvtcLog log)
+    {
+        base.SetInstanceBuffs(log);
+
+        if (log.FightData.Success && isCM)
+        {
+            if (Decima != null && !Decima.GetBuffStatus(log, ChargeDecima, log.FightData.FightStart, log.FightData.FightEnd).Any(x => x.Value > 0))
+            {
+                InstanceBuffs.Add((log.Buffs.BuffsByIds[AchievementEligibilityCalmBeforeTheStorm], 1));
+            }
+        }
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -73,12 +73,6 @@ internal class DecimaTheStormsinger : MountBalrior
 
             new PlayerDstHitMechanic([FulgentFenceCM, FluxlanceFusilladeCM, FluxlanceSalvoCM1, FluxlanceSalvoCM2, FluxlanceSalvoCM3, FluxlanceSalvoCM4, FluxlanceSalvoCM5, ChorusOfThunderCM, DiscordantThunderCM], "This Bug Can Dance", new MechanicPlotlySetting(Symbols.Pentagon, Colors.Lime), "BugDance.Achiv", "Achievement Elibigility: This Bug Can Dance", "Achiv: This Bug Can Dance", 0).UsingChecker((adhe, log) =>
             {
-                // Only available in CM
-                if (!isCM)
-                {
-                    return true;
-                }
-
                 // If you are dead, lose the achievement
                 if (adhe.To.IsDead(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -120,7 +120,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 }
 
                 return false;
-            }).UsingAchievementEligibility(true),
+            }).UsingEnable(log => log.FightData.IsCM).UsingAchievementEligibility(true),
 
             new EnemyDstBuffApplyMechanic(ChargeDecima, "Charge", new MechanicPlotlySetting(Symbols.BowtieOpen, Colors.DarkMagenta), "Charge", "Charge Stacks", "Charge Stack", 0),
 
@@ -506,20 +506,11 @@ internal class DecimaTheStormsinger : MountBalrior
                 }
 
                 // Flux Nova - Breakbar
-                var fluxNovaCasts = casts.Where(x => x.SkillId == FluxNova || x.SkillId == FluxNovaCM_70 || x.SkillId == FluxNovaCM_40);
-                var fractureArmorCasts = casts.Where(x => x.SkillId == FractureArmor || x.SkillId== FractureArmorCM);
                 var breakbarUpdates = target.GetBreakbarPercentUpdates(log);
-                foreach (CastEvent fluxNova in fluxNovaCasts)
+                var (breakbarNones, breakbarActives, breakbarImmunes, breakbarRecoverings) = target.GetBreakbarStatus(log);
+                foreach (var segment in breakbarActives)
                 {
-                    var fractureArmor = fractureArmorCasts.FirstOrDefault(x => x.Time > fluxNova.Time);
-                    var endCast = fractureArmor != null ? fractureArmor.Time : fluxNova.EndTime;
-                    (long start, long end) lifespanFlux = (fluxNova.Time, endCast);
-
-                    var bar = new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, lifespanFlux, Colors.BreakbarBlue, 0.8, Colors.Black, 0.6,
-                        breakbarUpdates.Select(x => (x.Start, x.Value)).ToList(), new AgentConnector(target))
-                        .UsingInterpolationMethod(Connector.InterpolationMethod.Step)
-                        .UsingRotationConnector(new AngleConnector(180));
-                    replay.Decorations.Add(bar);
+                    replay.Decorations.AddActiveBreakbar(segment.TimeSpan, target, breakbarUpdates);
                 }
                 break;
             case (int)TrashID.GreenOrb1Player:

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -685,13 +685,24 @@ internal class DecimaTheStormsinger : MountBalrior
                 }
 
                 // Charged Ground - AoEs from Sparkwave
-                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.DecimaChargedGround, out var chargedGround))
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.DecimaChargedGroundBorder, out var chargedGround))
                 {
                     foreach (var effect in chargedGround)
                     {
-                        (long start, long end) lifespanChargedGround = effect.ComputeLifespan(log, 5500);
+                        (long start, long end) lifespanChargedGround = (effect.Time, effect.Time + effect.Duration);
                         var circle = new CircleDecoration(400, lifespanChargedGround, Colors.CobaltBlue, 0.2, new PositionConnector(effect.Position));
                         replay.Decorations.AddWithBorder(circle, Colors.Red, 0.2);
+                    }
+                }
+
+                // Charged Ground - AoEs from Sparkwave - Max Charge
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.DecimaChargedGroundMax, out var chargedGroundMax))
+                {
+                    foreach (var effect in chargedGroundMax)
+                    {
+                        (long start, long end) lifespanChargedGround = effect.ComputeLifespan(log, 600000);
+                        var circle = new CircleDecoration(400, lifespanChargedGround, Colors.Red, 0.4, new PositionConnector(effect.Position));
+                        replay.Decorations.Add(circle);
                     }
                 }
                 break;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
@@ -27,7 +27,7 @@ internal class UraTheSteamshrieker : MountBalrior
             new PlayerDstHitMechanic(CreateTitanspawnGeyser, "Create Titanspawn Geyser", new MechanicPlotlySetting(Symbols.CircleXOpen, Colors.LightOrange), "UraJump.CC", "CC by Create Titanspawn Geyser AoE (Ura jump in place)", "Create Titanspawn Geyser CC", 0)
                 .UsingChecker((hde, log) => hde.To.HasBuff(log, Stability, hde.Time, ServerDelayConstant)),
 
-            new PlayerDstHitMechanic([ToxicGeyser1, ToxicGeyser2], "Toxic Geyser", new MechanicPlotlySetting(Symbols.StarSquare, Colors.GreenishYellow), "ToxGeyser.H", "Hit by Toxic Geyser", "Toxic Geyser Hit", 0),
+            new PlayerDstHitMechanic([ToxicGeyser1, ToxicGeyser2, ToxicGeyserCM], "Toxic Geyser", new MechanicPlotlySetting(Symbols.StarSquare, Colors.GreenishYellow), "ToxGeyser.H", "Hit by Toxic Geyser", "Toxic Geyser Hit", 0),
 
             new PlayerDstEffectMechanic(EffectGUIDs.UraSulfuricGeyserTarget, "Sulfuric Geyser", new MechanicPlotlySetting(Symbols.Hexagon, Colors.Blue), "SulfGey.T", "Targeted by Sulfuric Geyser (Spawn)", "Sulfuric Geyser Spawn Target", 0),
             new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, "Hardened Crust", new MechanicPlotlySetting(Symbols.Hourglass, Colors.LightOrange), "Dispel.G", "Dispelled Sulfuric Geyser (Removed Hardened Crust)", "Dispelled Sulfuric Geyser", 0)
@@ -59,7 +59,7 @@ internal class UraTheSteamshrieker : MountBalrior
             new PlayerSrcBuffRemoveFromMechanic(PressureBlastBubbleBuff, "Pressure Blast", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.White), "Dispel.P", "Dispelled Player (Removed Pressure Blast)", "Dispelled Player", 0)
                 .UsingChecker((brae, log) => brae.To.IsPlayer),
 
-            new EnemySrcSkillMechanic(Return, "Return", new MechanicPlotlySetting(Symbols.TriangleRightOpen, Colors.White), "Return", "Ura returned to the center", "Return", 0),
+            new EnemySrcSkillMechanic(Return, "Return", new MechanicPlotlySetting(Symbols.TriangleRightOpen, Colors.White), "Return", "Ura returned to the center", "Return", 100),
 
             new EnemyDstBuffApplyMechanic(Exposed31589, "Exposed", new MechanicPlotlySetting(Symbols.BowtieOpen, Colors.LightPurple), "Exposed", "Got Exposed (Broke Breakbar)", "Exposed", 0),
 

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
@@ -85,7 +85,7 @@ internal class UraTheSteamshrieker : MountBalrior
 
     protected override List<TrashID> GetTrashMobsIDs()
     {
-        return
+        return 
         [
             TrashID.SulfuricGeyser,
             TrashID.TitanspawnGeyser,
@@ -353,6 +353,14 @@ internal class UraTheSteamshrieker : MountBalrior
                             counter++;
                         }
                     }
+
+                    // Hardened Crust - Overhead
+                    replay.Decorations.AddOverheadIcons(target.GetBuffStatus(log, HardenedCrust, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), target, BuffImages.HardenedCrust);
+
+                    // Breakbar
+                    var toxicPercentUpdates = target.GetBreakbarPercentUpdates(log);
+                    var toxicStates = target.GetBreakbarStatus(log);
+                    replay.Decorations.AddBreakbar(target, toxicPercentUpdates, toxicStates);
                 }
                 else
                 {
@@ -360,10 +368,19 @@ internal class UraTheSteamshrieker : MountBalrior
                 }
                 break;
             case (int)TrashID.SulfuricGeyser:
+                // Hardened Crust - Overhead
+                replay.Decorations.AddOverheadIcons(target.GetBuffStatus(log, HardenedCrust, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), target, BuffImages.HardenedCrust);
+
                 replay.Decorations.Add(new CircleDecoration(580, (target.FirstAware, target.LastAware), Colors.Red, 0.2, new AgentConnector(target)).UsingFilled(false));
                 break;
             case (int)TrashID.TitanspawnGeyser:
+                // Hardened Crust - Overhead
+                replay.Decorations.AddOverheadIcons(target.GetBuffStatus(log, HardenedCrust, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), target, BuffImages.HardenedCrust);
 
+                // Breakbar
+                var titanspawnPercentUpdates = target.GetBreakbarPercentUpdates(log);
+                var titanspawnStates = target.GetBreakbarStatus(log);
+                replay.Decorations.AddBreakbar(target, titanspawnPercentUpdates, titanspawnStates);
                 break;
             case (int)TrashID.ChampionFumaroller:
                 // Breaking Ground - 8 pointed star

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
@@ -353,8 +353,26 @@ internal class UraTheSteamshrieker : MountBalrior
                         uint initialRadius = 480;
                         uint radiusIncrease = 12; // Aprox
                         uint counter = 0;
+
+                        // Find the first effect appearing after the breakbar has started to recover.
+                        var (breakbarNones, breakbarActives, breakbarImmunes, breakbarRecoverings) = target.GetBreakbarStatus(log);
+                        List<long> resetTimes = [];
+                        foreach (var segment in breakbarRecoverings)
+                        {
+                            var effect = effects.FirstOrDefault(x => x.Time > segment.Start);
+                            if (effect != null)
+                            {
+                                resetTimes.Add(effect.Time);
+                            }
+                        }
+
                         foreach (var effect in effects)
                         {
+                            // If the breakbar has been broken, reset the effect radius.
+                            if (resetTimes.Contains(effect.Time))
+                            {
+                                counter = 0;
+                            }
                             (long start, long end) lifespan = effect.ComputeDynamicLifespan(log, 1200);
                             uint radius = initialRadius + (radiusIncrease * counter);
                             replay.Decorations.Add(new CircleDecoration(radius, lifespan, Colors.Red, 0.2, new AgentConnector(target)).UsingFilled(false));

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
@@ -44,11 +44,18 @@ internal class UraTheSteamshrieker : MountBalrior
 
             new PlayerDstHitMechanic(BreakingGround, "Breaking Ground", new MechanicPlotlySetting(Symbols.Star, Colors.Red), "BreGround.H", "Hit by Breaking Ground (8 pointed star)", "Breaking Ground Hit", 0),
 
+            new PlayerDstBuffApplyMechanic(PressureBlastTargetBuff, "Pressure Blast", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.LightBlue), "Pres.Blast.T", "Targeted by Pressure Blast (Bubbles)", "Pressure Blast Target", 0),
+            new PlayerDstBuffApplyMechanic(PressureBlastBubbleBuff, "Pressure Blast", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.Blue), "Pres.Blast.Up", "Lifted in a bubble by Pressure Blast", "Pressure Blast Bubble", 0),
+
             new PlayerDstBuffApplyMechanic(Deterrence, "Deterrence", new MechanicPlotlySetting(Symbols.Diamond, Colors.LightRed), "Pick-up Shard", "Picked up the Bloodstone Shard", "Bloodstone Shard Pick-up", 0),
             new PlayerDstBuffApplyMechanic(BloodstoneSaturation, "Bloodstone Saturation", new MechanicPlotlySetting(Symbols.Diamond, Colors.DarkPurple), "Dispel", "Used Dispel (SAK)", "Used Dispel", 0),
 
-            new PlayerDstBuffApplyMechanic(PressureBlastTargetBuff, "Pressure Blast", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.LightBlue), "Pres.Blast.T", "Targeted by Pressure Blast (Bubbles)", "Pressure Blast Target", 0),
-            new PlayerDstBuffApplyMechanic(PressureBlastBubbleBuff, "Pressure Blast", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.Blue), "Pres.Blast.Up", "Lifted in a bubble by Pressure Blast", "Pressure Blast Bubble", 0),
+            new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, "Hardened Crust", new MechanicPlotlySetting(Symbols.CircleCross, Colors.White), "Dispel.Toxc", "Dispelled Toxic Geyser (Removed Hardened Crust)", "Dispelled Toxic Geyser", 0)
+                .UsingChecker((brae, log) => brae.To.IsSpecies(TrashID.ToxicGeyser)),
+            new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, "Hardened Crust", new MechanicPlotlySetting(Symbols.CircleCrossOpen, Colors.White), "Dispel.Sulf", "Dispelled Sulfuric Geyser (Removed Hardened Crust)", "Dispelled Sulfuric Geyser", 0)
+                .UsingChecker((brae, log) => brae.To.IsSpecies(TrashID.SulfuricGeyser)),
+            new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, "Hardened Crust", new MechanicPlotlySetting(Symbols.CircleX, Colors.White), "Dispel.Titn", "Dispelled Titanspawn Geyser (Removed Hardened Crust)", "Dispelled Titanspawn Geyser", 0)
+                .UsingChecker((brae, log) => brae.To.IsSpecies(TrashID.TitanspawnGeyser)),
             new PlayerSrcBuffRemoveFromMechanic(PressureBlastBubbleBuff, "Pressure Blast", new MechanicPlotlySetting(Symbols.CircleOpen, Colors.White), "Dispel.P", "Dispelled Player (Removed Pressure Blast)", "Dispelled Player", 0)
                 .UsingChecker((brae, log) => brae.To.IsPlayer),
 
@@ -57,7 +64,7 @@ internal class UraTheSteamshrieker : MountBalrior
             new EnemyDstBuffApplyMechanic(Exposed31589, "Exposed", new MechanicPlotlySetting(Symbols.BowtieOpen, Colors.LightPurple), "Exposed", "Got Exposed (Broke Breakbar)", "Exposed", 0),
 
             new EnemyDstBuffApplyMechanic(RisingPressure, "Rising Pressure", new MechanicPlotlySetting(Symbols.TriangleUp, Colors.LightOrange), "Rising Pressure", "Applied Rising Pressure", "Rising Pressure", 0),
-            new EnemyDstBuffApplyMechanic(TitanicResistance, "Titanic Resistance", new MechanicPlotlySetting(Symbols.TriangleUpOpen, Colors.LightOrange), "Titanic Resistance", "Applied Titanic Resistance", "Titanitc Resistance", 0),
+            new EnemyDstBuffApplyMechanic(TitanicResistance, "Titanic Resistance", new MechanicPlotlySetting(Symbols.TriangleUpOpen, Colors.LightOrange), "Titanic Resistance", "Applied Titanic Resistance", "Titanic Resistance", 0),
         });
         Extension = "ura";
         Icon = EncounterIconUra;
@@ -340,6 +347,7 @@ internal class UraTheSteamshrieker : MountBalrior
             case (int)TrashID.ToxicGeyser:
                 if (log.FightData.IsCM)
                 {
+                    // Damage field ring
                     if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.UraToxicGeyserGrowing, out var effects))
                     {
                         uint initialRadius = 480;
@@ -364,6 +372,7 @@ internal class UraTheSteamshrieker : MountBalrior
                 }
                 else
                 {
+                    // Damage field ring
                     replay.Decorations.Add(new CircleDecoration(480, (target.FirstAware, target.LastAware), Colors.Red, 0.2, new AgentConnector(target)).UsingFilled(false));
                 }
                 break;
@@ -371,6 +380,7 @@ internal class UraTheSteamshrieker : MountBalrior
                 // Hardened Crust - Overhead
                 replay.Decorations.AddOverheadIcons(target.GetBuffStatus(log, HardenedCrust, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0), target, BuffImages.HardenedCrust);
 
+                // Damage field ring
                 replay.Decorations.Add(new CircleDecoration(580, (target.FirstAware, target.LastAware), Colors.Red, 0.2, new AgentConnector(target)).UsingFilled(false));
                 break;
             case (int)TrashID.TitanspawnGeyser:

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
@@ -247,7 +247,7 @@ internal class UraTheSteamshrieker : MountBalrior
         // 40 - 1 CM / 40 - 0 NM
         if (hp40.Value > 0)
         {
-            var after40 = isCm && hp1 != null ? new PhaseData(hp40.Start, Math.Min(hp1.Time, end), "40-1%") : new PhaseData(hp40.Start, end, "40-0%");
+            var after40 = isCm ? new PhaseData(hp40.Start, hp1 != null ? Math.Min(hp1.Time, end) : end, "40-1%") : new PhaseData(hp40.Start, end, "40-0%");
             after40.AddTarget(ura);
             phases.Add(after40);
         }

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -695,7 +695,13 @@ public static class EffectGUIDs
     public static readonly GUID DecimaAftershockAoE = new("FBABC6679768DC439AD844BFB94D9C74"); // 1500 duration - Src Decima
     public static readonly GUID DecimaAftershockAoECM = new("B438122328E462488F5B1BD417653C42"); // 1500 duration - Src Godsquall Decima
     public static readonly GUID DecimaSparkingReverberation = new("9CF7F3E43A32774E82F650A2EE9BF756"); // 30000 duration - Has end event - Src Transcendent Boulder
-    public static readonly GUID DecimaChargedGround = new("FD07306664C7984C86A4D177CAD60FEC"); // 5500 duration - Has end event - Src Transcendent Boulder
+    public static readonly GUID DecimaChargedGroundBorder = new("B4CCDBD5D84B5841BB50FE2698E6F5DA"); // 5500 / 1500 duration - Has end event - Src Transcendent Boulder
+    public static readonly GUID DecimaChargedGroundFirstStage = new("FD07306664C7984C86A4D177CAD60FEC"); // 5500 / 1500 duration - Has end event - Src Transcendent Boulder
+    public static readonly GUID DecimaChargedGroundSecondStage = new("9CF7F3E43A32774E82F650A2EE9BF756"); // 1500 duration - CONFLICT with Sparking Reverberation
+    public static readonly GUID DecimaChargedGroundThirdStage = new("52E01771136E9A4883B55915083ED6A5"); // 1500 duration
+    public static readonly GUID DecimaChargedGroundFourthStage = new("EA821B503C238B419F4B5EFAF86FABD8"); // 1500 duration
+    public static readonly GUID DecimaChargedGroundFifthStage = new("75A457A4D6DBE942A9B12B8D63084410"); // 1500 duration
+    public static readonly GUID DecimaChargedGroundMax = new("51CB6C241DA8384F9FB2DA81B44E7E38"); // 600000 duration - Has end event - Src Transcendent Boulder
     // Ura
     public static readonly GUID UraToxicGeyserSpawn = new("6B95E7A99147644A990ACF34D04A98F1");
     public static readonly GUID UraToxicGeyserSpawnCM = new("4A69CA27E8B3684CA0E492B3E5C7512F"); // 800000 duration - Src Toxic Geyser - Has end event

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -698,7 +698,8 @@ public static class EffectGUIDs
     public static readonly GUID DecimaChargedGround = new("FD07306664C7984C86A4D177CAD60FEC"); // 5500 duration - Has end event - Src Transcendent Boulder
     // Ura
     public static readonly GUID UraToxicGeyserSpawn = new("6B95E7A99147644A990ACF34D04A98F1");
-    public static readonly GUID UraToxicGeyserSpawnCM = new("4A69CA27E8B3684CA0E492B3E5C7512F");
+    public static readonly GUID UraToxicGeyserSpawnCM = new("4A69CA27E8B3684CA0E492B3E5C7512F"); // 800000 duration - Src Toxic Geyser - Has end event
+    public static readonly GUID UraToxicGeyserGrowing = new("2FCF850597F4EE499ADB4F1253A6D250"); // 1200 duration - Src Toxic Geyser - Has end event
     public static readonly GUID UraSulfuricGeyserSpawn = new("413AF4D44B924B4399481047CBB2820C");
     public static readonly GUID UraSlamCone = new("BBA33A70B7D2A94589DE81B1F35D3D69");
     public static readonly GUID UraSteamPrisonIndicator = new("093D22A7DBFB0D4ABA9424225954DB68"); // 3000 duration - Src Ura - Dst Player

--- a/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
@@ -330,5 +330,7 @@ public static class DamageModifierIDs
     public const int Mod_AllForOne = 317;
     public const int Mod_RelicOfFire = 318;
     public const int Mod_RelicOfTheEagle = 319;
+    public const int Mod_UnstrippableProtection = 320;
+    public const int Mod_UnstrippableResolution = 321;
 }
 

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -4658,6 +4658,7 @@ public static class SkillIDs
     public const long RotEruption = 75251;
     public const long PressureBlastDamage = 75258;
     public const long ScatteringSporeblast2 = 75262;
+    public const long POV_WhirlpoolBuff = 75269;
     public const long SparkingAuraTier3 = 75270;
     public const long DeployTrebuchet_InfiniteTrebuchet = 75271;
     public const long DeployBallista_InfiniteBallista = 75278;
@@ -4712,7 +4713,9 @@ public static class SkillIDs
     public const long PealOfHarmonyCM = 75535;
     public const long ThrummingPresenceDamageCM = 75536;
     public const long CageOfDecay4 = 75554;
+    public const long DiscordantThunderCM = 75561;
     public const long FluxlanceSalvoCM2 = 75569;
+    public const long Subsided = 75570;
     public const long DecimaCMUngaBungaCast = 75585;
     public const long ThrummingPresenceBuffCM = 75588;
     public const long AuraOfCorruptionBuff_Ereg = 75592;
@@ -4758,8 +4761,10 @@ public static class SkillIDs
     public const long ChargedGround = 75899;
     public const long EnfeeblingMiasma4 = 75919;
     public const long AftershockDecimaCM = 75920;
+    public const long ToxicGeyserCM = 75923;
     public const long FluxlanceFusilladeCM = 75954;
     public const long DecimaBeamLoadingCM2 = 75956;
+    public const long FocusedFluxlanceBuffCM = 75957;
     public const long DecimaBeamLoadingCM1 = 75960;
     public const long EarthrendCM2 = 75961;
     public const long EnlightenedConduitGadgetChargeTier1BuffCM = 75963;

--- a/GW2EIEvtcParser/ParserHelpers/Images/BuffImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/BuffImages.cs
@@ -337,6 +337,7 @@ public static class BuffImages
     public const string HardenedCrust = "https://wiki.guildwars2.com/images/4/4e/Branded_Crystal_Shield.png";
     public const string FireEffect = "https://wiki.guildwars2.com/images/e/eb/Fire_%28effect%29.png";
     public const string SinisterThread = "https://wiki.guildwars2.com/images/d/d7/Sinister_Thread.png";
+    public const string SonicOverload = "https://wiki.guildwars2.com/images/2/29/Sonic_Overload.png";
     // Fractal
     public const string GambitExhausted = "https://wiki.guildwars2.com/images/4/41/Gambit_Exhausted.png";
     public const string ReflectiveShielding = "https://wiki.guildwars2.com/images/c/c6/Reflective_Shielding.png";

--- a/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
@@ -414,6 +414,7 @@ internal static class ParserIcons
     private const string TrashCannon = "https://i.imgur.com/aNe6JUJ.png";
     private const string TrashProtoGreerling = "https://i.imgur.com/B1v91mQ.png";
     private const string TrashEmpoweringBeast = "https://i.imgur.com/HRmRRq1.png";
+    private const string TrashLucidBoulder = "https://i.imgur.com/hcceqNq.png";
     #endregion
 
     #region Minion
@@ -1195,7 +1196,7 @@ internal static class ParserIcons
         { TrashID.EmpoweringBeast, TrashEmpoweringBeast },
         { TrashID.EnlightenedConduit, TrashEnlightenedConduit },
         { TrashID.EnlightenedConduitCM, TrashEnlightenedConduit },
-        { TrashID.TranscendentBoulder, TrashGenericRedEnemySkull },
+        { TrashID.TranscendentBoulder, TrashLucidBoulder },
         { TrashID.EliteVentshot, TrashVentshot },
         { TrashID.EliteFumaroller, TrashFumaroller },
         { TrashID.ChampionFumaroller, TrashFumaroller },

--- a/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
@@ -38,7 +38,7 @@ internal static class TraitImages
     #region Engineer
     public const string AdaptiveArmor = "https://wiki.guildwars2.com/images/b/b3/Adaptive_Armor.png";
     public const string LightDensityAmplifier = "https://render.guildwars2.com/file/3994F02CE07262B156C90E9143F2720ADF2DB0FD/1769927.png";
-    public const string GlassCannon = "https://render.guildwars2.com/file/63B2BD4FCDA047EA740E5DEA0EBF593308320713/1012344.pn";
+    public const string GlassCannon = "https://render.guildwars2.com/file/63B2BD4FCDA047EA740E5DEA0EBF593308320713/1012344.png";
     public const string ExplosivePowder = "https://render.guildwars2.com/file/6DA800E25FE446E734FAD0A6E81EB671F596AA79/1012353.png";
     public const string BigBoomer = "https://render.guildwars2.com/file/0122FE72473C12BA0661EABA18F5B83022066EDB/2261506.png";
     public const string ThermalVision = "https://render.guildwars2.com/file/F806ACB6130CED2DACC9DD804E4303327073385A/1012358.png";
@@ -104,7 +104,7 @@ internal static class TraitImages
     public const string ImprovedAlacrity = "https://render.guildwars2.com/file/C9BC67D77E3D959723393BF0EC9B212B53D8362D/1012478.png";
     public const string ConfoundingSuggestions = "https://render.guildwars2.com/file/E9CB4990C405C00D34DB07C5C5291FD5E90EF90C/1012486.png";
     public const string TemporalEnchanter = "https://render.guildwars2.com/file/1503DDC5B62526D71901E3A7F891A6F4445D80C8/1012527.png";
-    public const string Fragility = "https://render.guildwars2.com/file/DBA1050B30E4FBB4CEAFDF01217E7E07D4EF6459/1012497.pn";
+    public const string Fragility = "https://render.guildwars2.com/file/DBA1050B30E4FBB4CEAFDF01217E7E07D4EF6459/1012497.png";
     public const string CompoundingPower = "https://render.guildwars2.com/file/E9BA251055B444E693144A9AF5FD1CF8266BEFA6/1012520.png";
     public const string IllusionaryMembrane = "https://render.guildwars2.com/file/0DF6A27A24B01D069DCD7609ADD305C7C557A82A/1012472.png";
     public const string MirageMantle = "https://render.guildwars2.com/file/275DBDFD630099D49A76287DDD237709150C1D73/1769955.png";


### PR DESCRIPTION
## Greer

- Added Rot the World breakbar decoration
- Added Protection and Resolution damage modifiers

## Decima

- Updated Flux Nova breakbar decoration
- Added Discordant Thunder mechanic
- Added This Bug Can Dance achievement mechanic
- Added Calm Before The Storm achievement instance buff
- Adjusted Charged Ground decorations
- Added Transcendent Boulder icon

## Ura
- Added Subsided buff
- Added subphases for 100-70%, 70-40%, 40-0% NM, 40-1% CM, Healed CM
- Added No Geysers No Problems achievement instance buff
- Added Toxic Geysers growing aoe
- Added Hardened Crust overhead to geysers
- Added breakbar to Toxic and Titanspawn geysers
- Added Dispel geysers mechanics
- Added ICD to Return mechanic to prevent multi triggers
- Added missing Toxic Geyser ID to mechanic

## Combat Replay

- Added missing start and end to phases tooltips
- Added breakbar APIs