### PR TITLE
Combat Replay skill casts cleanup

### DIFF
--- a/GW2EIEvtcParser/EIData/Actors/Actor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/Actor.cs
@@ -197,6 +197,9 @@ public abstract class Actor
     // Cast logs
     public abstract IEnumerable<CastEvent> GetCastEvents(ParsedEvtcLog log, long start, long end);
     public abstract IEnumerable<CastEvent> GetIntersectingCastEvents(ParsedEvtcLog log, long start, long end);
+    public abstract IEnumerable<AnimatedCastEvent> GetAnimatedCastEvents(ParsedEvtcLog log, long start, long end);
+    public abstract IEnumerable<InstantCastEvent> GetInstantCastEvents(ParsedEvtcLog log, long start, long end);
+    public abstract IEnumerable<WeaponSwapEvent> GetWeaponSwapEvents(ParsedEvtcLog log, long start, long end);
     // privates
 
     protected static bool KeepIntersectingCastLog(CastEvent evt, long start, long end)

--- a/GW2EIEvtcParser/EIData/Actors/Actor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/Actor.cs
@@ -197,9 +197,6 @@ public abstract class Actor
     // Cast logs
     public abstract IEnumerable<CastEvent> GetCastEvents(ParsedEvtcLog log, long start, long end);
     public abstract IEnumerable<CastEvent> GetIntersectingCastEvents(ParsedEvtcLog log, long start, long end);
-    public abstract IEnumerable<AnimatedCastEvent> GetAnimatedCastEvents(ParsedEvtcLog log, long start, long end);
-    public abstract IEnumerable<InstantCastEvent> GetInstantCastEvents(ParsedEvtcLog log, long start, long end);
-    public abstract IEnumerable<WeaponSwapEvent> GetWeaponSwapEvents(ParsedEvtcLog log, long start, long end);
     // privates
 
     protected static bool KeepIntersectingCastLog(CastEvent evt, long start, long end)

--- a/GW2EIEvtcParser/EIData/Actors/Minions.cs
+++ b/GW2EIEvtcParser/EIData/Actors/Minions.cs
@@ -271,6 +271,21 @@ public class Minions : Actor
         }
         return CastEvents.Where(x => KeepIntersectingCastLog(x, start, end));
     }
+
+    public override IEnumerable<AnimatedCastEvent> GetAnimatedCastEvents(ParsedEvtcLog log, long start, long end)
+    {
+        return log.CombatData.GetAnimatedCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
+    }
+
+    public override IEnumerable<InstantCastEvent> GetInstantCastEvents(ParsedEvtcLog log, long start, long end)
+    {
+        return log.CombatData.GetInstantCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
+    }
+
+    public override IEnumerable<WeaponSwapEvent> GetWeaponSwapEvents(ParsedEvtcLog log, long start, long end)
+    {
+        return log.CombatData.GetWeaponSwapData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
+    }
     #endregion CAST
 
     internal bool IsActive(ParsedEvtcLog log)

--- a/GW2EIEvtcParser/EIData/Actors/Minions.cs
+++ b/GW2EIEvtcParser/EIData/Actors/Minions.cs
@@ -271,21 +271,6 @@ public class Minions : Actor
         }
         return CastEvents.Where(x => KeepIntersectingCastLog(x, start, end));
     }
-
-    public override IEnumerable<AnimatedCastEvent> GetAnimatedCastEvents(ParsedEvtcLog log, long start, long end)
-    {
-        return log.CombatData.GetAnimatedCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
-    }
-
-    public override IEnumerable<InstantCastEvent> GetInstantCastEvents(ParsedEvtcLog log, long start, long end)
-    {
-        return log.CombatData.GetInstantCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
-    }
-
-    public override IEnumerable<WeaponSwapEvent> GetWeaponSwapEvents(ParsedEvtcLog log, long start, long end)
-    {
-        return log.CombatData.GetWeaponSwapData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
-    }
     #endregion CAST
 
     internal bool IsActive(ParsedEvtcLog log)

--- a/GW2EIEvtcParser/EIData/Actors/SingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/SingleActor.cs
@@ -539,8 +539,8 @@ public abstract partial class SingleActor : Actor
     {
         var animationCastData = log.CombatData.GetAnimatedCastData(AgentItem);
         var instantCastData = log.CombatData.GetInstantCastData(AgentItem);
+        #pragma warning disable IDE0028 //NOTE(Rennorb): this is (likely) more efficient because of the list types
         CastEvents = new List<CastEvent>(animationCastData.Count + instantCastData.Count);
-        #pragma warning disable IDE0028 //NOTE(Rennorb): this is (liikely) mroe efficient because of the list tpes
         CastEvents.AddRange(animationCastData);
         CastEvents.AddRange(instantCastData);
         #pragma warning restore IDE0028 

--- a/GW2EIEvtcParser/EIData/Actors/SingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/SingleActor.cs
@@ -519,6 +519,22 @@ public abstract partial class SingleActor : Actor
         return CastEvents.Where(x => KeepIntersectingCastLog(x, start, end));
 
     }
+
+    public override IEnumerable<AnimatedCastEvent> GetAnimatedCastEvents(ParsedEvtcLog log, long start, long end)
+    {
+        return log.CombatData.GetAnimatedCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
+    }
+
+    public override IEnumerable<InstantCastEvent> GetInstantCastEvents(ParsedEvtcLog log, long start, long end)
+    {
+        return log.CombatData.GetInstantCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
+    }
+
+    public override IEnumerable<WeaponSwapEvent> GetWeaponSwapEvents(ParsedEvtcLog log, long start, long end)
+    {
+        return log.CombatData.GetWeaponSwapData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
+    }
+
     protected override void InitCastEvents(ParsedEvtcLog log)
     {
         var animationCastData = log.CombatData.GetAnimatedCastData(AgentItem);

--- a/GW2EIEvtcParser/EIData/Actors/SingleActor.cs
+++ b/GW2EIEvtcParser/EIData/Actors/SingleActor.cs
@@ -520,19 +520,14 @@ public abstract partial class SingleActor : Actor
 
     }
 
-    public override IEnumerable<AnimatedCastEvent> GetAnimatedCastEvents(ParsedEvtcLog log, long start, long end)
+    public IEnumerable<AnimatedCastEvent> GetAnimatedCastEvents(ParsedEvtcLog log, long start, long end)
     {
         return log.CombatData.GetAnimatedCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
     }
 
-    public override IEnumerable<InstantCastEvent> GetInstantCastEvents(ParsedEvtcLog log, long start, long end)
+    public IEnumerable<InstantCastEvent> GetInstantCastEvents(ParsedEvtcLog log, long start, long end)
     {
         return log.CombatData.GetInstantCastData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
-    }
-
-    public override IEnumerable<WeaponSwapEvent> GetWeaponSwapEvents(ParsedEvtcLog log, long start, long end)
-    {
-        return log.CombatData.GetWeaponSwapData(AgentItem).Where(x => x.Time >= start && x.Time <= end);
     }
 
     protected override void InitCastEvents(ParsedEvtcLog log)

--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -80,6 +80,7 @@ internal static class Colors
     public static Color DarkMagenta = new(128, 0, 128);
     public static Color Blue = new(0, 0, 255);
     public static Color CobaltBlue = new(0, 50, 180);
+    public static Color LightCobaltBlue = new(0, 80, 255);
     public static Color SkyBlue = new(69, 182, 254);
     public static Color Ice = new(200, 233, 233);
     public static Color White = new(255, 255, 255);

--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -87,6 +87,7 @@ internal static class Colors
     public static Color DarkWhite = new(180, 180, 180);
     public static Color Grey = new(60, 60, 60);
     public static Color LightGrey = new(120, 120, 120);
+    public static Color BlueishGrey = new(108, 122, 137);
     public static Color BreakbarImmuneGrey = new(44, 45, 54);
     public static Color Black = new(0, 0, 0);
 

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
@@ -268,16 +268,16 @@ internal class Ensolyss : Nightmare
                     }
                 }
 
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId) 
+                    switch (cast.SkillId) 
                     {
                         // Tail Lash - Cone Swipe
                         case TailLashEnsolyss:
                             castDuration = 1550;
-                            long expectedEndCast = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + castDuration, out var facing))
+                            long expectedEndCast = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + castDuration, out var facing))
                             {
                                 var rotation = new AngleConnector(facing);
                                 var cone = (PieDecoration)new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation);
@@ -291,10 +291,10 @@ internal class Ensolyss : Nightmare
                             int secondQuarterAoe = 900;
                             int firstQuarterHit = 1635;
                             int secondQuarterHit = 1900;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
 
                             // Facing point
-                            if (target.TryGetCurrentFacingDirection(log, c.Time, out var facingDirection, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time, out var facingDirection, castDuration))
                             {
                                 // Calculated points
                                 var frontalPoint = new Vector3(facingDirection.X, facingDirection.Y, 0);
@@ -307,16 +307,16 @@ internal class Ensolyss : Nightmare
                         // Caustic Grasp - AoE Pull
                         case CausticGrasp:
                             castDuration = 1500;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             replay.Decorations.AddWithGrowing(new CircleDecoration(1300, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)), growing);
                             break;
                         // Upswing
                         case UpswingEnsolyss:
                             castDuration = 1333;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            (long start, long end) lifespanShockwave = (lifespan.end, c.Time + 3100);
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            (long start, long end) lifespanShockwave = (lifespan.end, cast.Time + 3100);
                             GeographicalConnector connector = new AgentConnector(target);
                             replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.LightOrange, 0.2, connector), growing);
                             // Shockwave
@@ -325,9 +325,9 @@ internal class Ensolyss : Nightmare
                         // Caustic Explosion - 66% & 33% Breakbars
                         case CausticExplosionEnsolyss:
                             castDuration = 15000;
-                            growing = c.Time + castDuration;
+                            growing = cast.Time + castDuration;
                             int durationQuarter = 3000;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
 
                             // Circle going in
                             replay.Decorations.AddWithGrowing(new DoughnutDecoration(0, 2000, lifespan, Colors.Red, 0.2, new AgentConnector(target)), growing, true);
@@ -339,7 +339,7 @@ internal class Ensolyss : Nightmare
                             }
 
                             // Initial facing point
-                            if (target.TryGetCurrentFacingDirection(log, c.Time, out var facingCausticExplosion, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time, out var facingCausticExplosion, castDuration))
                             {
                                 // Calculated other quarters from initial point
                                 var frontalPoint = new Vector3(facingCausticExplosion.X, facingCausticExplosion.Y, 0);
@@ -347,7 +347,7 @@ internal class Ensolyss : Nightmare
                                 int initialDelay = 1500;
 
                                 // First quarters
-                                (long start, long end) lifespanFirst = (c.Time + initialDelay, Math.Min(c.Time + initialDelay + durationQuarter, lifespan.end));
+                                (long start, long end) lifespanFirst = (cast.Time + initialDelay, Math.Min(cast.Time + initialDelay + durationQuarter, lifespan.end));
                                 long growingFirst = lifespanFirst.start + durationQuarter;
                                 AddCausticExplosionDecoration(replay, target, frontalPoint, lifespan.end, lifespanFirst, growingFirst);
                                 // Second quarters
@@ -367,10 +367,10 @@ internal class Ensolyss : Nightmare
                         // Lunge - Dash
                         case LungeEnsolyss:
                             castDuration = 1000;
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + castDuration, out var facingLunge))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + castDuration, out var facingLunge))
                             {
                                 var rotation = new AngleConnector(facingLunge);
-                                lifespan = (c.Time, c.Time + castDuration);
+                                lifespan = (cast.Time, cast.Time + castDuration);
                                 replay.Decorations.Add(new RectangleDecoration(1700, target.HitboxWidth, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target).WithOffset(new Vector3(850, 0, 0), true)).UsingRotationConnector(rotation));
                             }
                             break;
@@ -380,9 +380,9 @@ internal class Ensolyss : Nightmare
                             castDuration = 4050;
                             int visualDuration = 4450;
                             int warningDuration = 1800;
-                            lifespan = (c.Time, c.Time + visualDuration);
-                            (long start, long end) lifespanWarning = (c.Time, c.Time + warningDuration);
-                            (long start, long end) lifespanShockwave2 = (c.Time, c.Time + castDuration);
+                            lifespan = (cast.Time, cast.Time + visualDuration);
+                            (long start, long end) lifespanWarning = (cast.Time, cast.Time + warningDuration);
+                            (long start, long end) lifespanShockwave2 = (cast.Time, cast.Time + castDuration);
                             // Red outline
                             var outline = (CircleDecoration)new CircleDecoration(380, lifespan, Colors.Red, 0.4, new AgentConnector(target)).UsingFilled(false);
                             replay.Decorations.Add(outline);
@@ -395,7 +395,7 @@ internal class Ensolyss : Nightmare
                             // 8 Arrows
                             if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.EnsolyssArrow, out var arrows))
                             {
-                                foreach (EffectEvent effect in arrows.Where(x => x.Time >= c.Time && x.Time < c.Time + visualDuration))
+                                foreach (EffectEvent effect in arrows.Where(x => x.Time >= cast.Time && x.Time < cast.Time + visualDuration))
                                 {
                                     if (effect is EffectEventCBTS51)
                                     {
@@ -413,24 +413,24 @@ internal class Ensolyss : Nightmare
                 }
                 break;
             case (int)TargetID.NightmareHallucination1:
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId)
+                    switch (cast.SkillId)
                     {
                         // Lunge - Dash
                         case LungeNightmareHallucination:
                             castDuration = 1000;
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + castDuration, out var facingLunge))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + castDuration, out var facingLunge))
                             {
                                 var rotation = new AngleConnector(facingLunge);
-                                lifespan = (c.Time, c.Time + castDuration);
+                                lifespan = (cast.Time, cast.Time + castDuration);
                                 replay.Decorations.Add(new RectangleDecoration(1700, target.HitboxWidth, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target).WithOffset(new(850, 0, 0), true)).UsingRotationConnector(rotation));
                             }
                             break;
                         // Upswing
                         case UpswingHallucination:
                             castDuration = 1333;
-                            lifespan = (c.Time, c.Time + castDuration);
+                            lifespan = (cast.Time, cast.Time + castDuration);
                             replay.Decorations.AddWithGrowing(new CircleDecoration(300, lifespan, Colors.LightOrange, 0.1, new AgentConnector(target)), lifespan.end);
                             break;
                         default:

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
@@ -163,6 +163,9 @@ internal class Ensolyss : Nightmare
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
         var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
+        long castDuration;
+        long growing;
+        (long start, long end) lifespan;
 
         switch (target.ID)
         {
@@ -265,10 +268,6 @@ internal class Ensolyss : Nightmare
                         }
                     }
                 }
-
-                long castDuration = 0;
-                long growing = 0;
-                (long start, long end) lifespan = (0, 0);
 
                 foreach (CastEvent cast in casts)
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Ensolyss.cs
@@ -268,20 +268,20 @@ internal class Ensolyss : Nightmare
                     }
                 }
 
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId) 
                     {
                         // Tail Lash - Cone Swipe
                         case TailLashEnsolyss:
                             castDuration = 1550;
-                            long expectedEndCast = cast.Time + castDuration;
+                            growing = cast.Time + castDuration;
                             lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             if (target.TryGetCurrentFacingDirection(log, cast.Time + castDuration, out var facing))
                             {
                                 var rotation = new AngleConnector(facing);
                                 var cone = (PieDecoration)new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation);
-                                replay.Decorations.AddWithGrowing(cone, expectedEndCast);
+                                replay.Decorations.AddWithGrowing(cone, growing);
                             }
                             break;
                         // Tormenting Blast - Quarter attacks
@@ -413,7 +413,7 @@ internal class Ensolyss : Nightmare
                 }
                 break;
             case (int)TargetID.NightmareHallucination1:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -149,7 +149,6 @@ internal class MAMA : Nightmare
 
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
-        var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
         long castDuration;
         long growing;
         (long start, long end) lifespan;
@@ -157,11 +156,12 @@ internal class MAMA : Nightmare
         switch (target.ID)
         {
             case (int)TargetID.MAMA:
-                foreach (CastEvent c in casts)
+                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (c.SkillId)
                     {
-                        case Blastwave1: // Blastwave - AoE Knockback
+                        // Blastwave - AoE Knockback
+                        case Blastwave1:
                             castDuration = 2750;
                             growing = c.Time + castDuration;
                             lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
@@ -173,7 +173,8 @@ internal class MAMA : Nightmare
                             lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
                             replay.Decorations.AddWithBorder(new CircleDecoration(480, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(growing), 0, Colors.Red, 0.2, false);
                             break;
-                        case Leap: // Leap with shockwaves
+                        // Leap with shockwaves
+                        case Leap:
                             castDuration = 2400;
                             growing = c.Time + castDuration;
                             lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
@@ -206,23 +207,26 @@ internal class MAMA : Nightmare
             case (int)TargetID.BlueKnight:
             case (int)TargetID.RedKnight:
             case (int)TargetID.GreenKnight:
-                foreach (CastEvent c in casts)
+                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (c.SkillId)
                     {
-                        case ExplosiveLaunch: // Explosive Launch - Knight Jump in air
+                        // Explosive Launch - Knight Jump in air
+                        case ExplosiveLaunch:
                             castDuration = 1714;
                             growing = c.Time + castDuration;
                             lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
                             replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing, true);
                             break;
-                        case ExplosiveImpact: // Explosive Impact - Knight fall and knockback AoE
+                        // Explosive Impact - Knight fall and knockback AoE
+                        case ExplosiveImpact:
                             castDuration = 533;
                             growing = c.Time + castDuration;
                             lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
                             replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing);
                             break;
-                        case Extraction: // Extraction - Pull AoE
+                        // Extraction - Pull AoE
+                        case Extraction:
                             castDuration = 3835;
                             growing = c.Time + castDuration;
                             lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -150,88 +150,87 @@ internal class MAMA : Nightmare
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
         var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
+        long castDuration;
+        long growing;
+        (long start, long end) lifespan;
 
         switch (target.ID)
         {
             case (int)TargetID.MAMA:
-                // Blastwave - AoE Knockback
-                var blastwave = casts.Where(x => x.SkillId == Blastwave1 || x.SkillId == Blastwave2);
-                foreach (CastEvent c in blastwave)
+                foreach (CastEvent c in casts)
                 {
-                    int castDuration = 2750;
-                    long expectedEndCast = c.Time + castDuration;
-                    (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-
-                    if (c.SkillId == Blastwave1)
+                    switch (c.SkillId)
                     {
-                        replay.Decorations.AddWithBorder(new CircleDecoration(530, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(expectedEndCast), 0, Colors.Red, 0.2, false);
-                    }
-                    else if (c.SkillId == Blastwave2)
-                    {
-                        replay.Decorations.AddWithBorder(new CircleDecoration(480, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(expectedEndCast), 0, Colors.Red, 0.2, false);
-                    }
-                }
+                        case Blastwave1: // Blastwave - AoE Knockback
+                            castDuration = 2750;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            replay.Decorations.AddWithBorder(new CircleDecoration(530, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(growing), 0, Colors.Red, 0.2, false);
+                            break;
+                        case Blastwave2:
+                            castDuration = 2750;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            replay.Decorations.AddWithBorder(new CircleDecoration(480, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(growing), 0, Colors.Red, 0.2, false);
+                            break;
+                        case Leap: // Leap with shockwaves
+                            castDuration = 2400;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
 
-                // Leap with shockwaves
-                var leap = casts.Where(x => x.SkillId == Leap);
-                foreach (CastEvent c in leap)
-                {
-                    int castDuration = 2400;
-                    long expectedEndCast = c.Time + castDuration;
-                    (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-
-                    // Find position at the end of the leap time
-                    if (target.TryGetCurrentPosition(log, expectedEndCast + 1000, out var targetPosition))
-                    {
-                        replay.Decorations.AddWithGrowing(new CircleDecoration(350, lifespan, Colors.Orange, 0.2, new PositionConnector(targetPosition)), expectedEndCast);
-
-                        // 3 rounds of decorations for the 3 waves
-                        if (lifespan.end == expectedEndCast)
-                        {
-                            uint shockwaveRadius = 1300;
-                            int duration = 2680;
-                            for (int i = 0; i < 3; i++)
+                            // Find position at the end of the leap time
+                            if (target.TryGetCurrentPosition(log, growing + 1000, out var targetPosition))
                             {
-                                long shockWaveStart = expectedEndCast + i * 120;
-                                (long, long) lifespanShockwave = (shockWaveStart, shockWaveStart + duration);
-                                GeographicalConnector connector = new PositionConnector(targetPosition);
-                                replay.Decorations.AddShockwave(connector, lifespanShockwave, Colors.Yellow, 0.3, shockwaveRadius);
+                                replay.Decorations.AddWithGrowing(new CircleDecoration(350, lifespan, Colors.Orange, 0.2, new PositionConnector(targetPosition)), growing);
+
+                                // 3 rounds of decorations for the 3 waves
+                                if (lifespan.end == growing)
+                                {
+                                    uint shockwaveRadius = 1300;
+                                    int duration = 2680;
+                                    for (int i = 0; i < 3; i++)
+                                    {
+                                        long shockWaveStart = growing + i * 120;
+                                        (long, long) lifespanShockwave = (shockWaveStart, shockWaveStart + duration);
+                                        GeographicalConnector connector = new PositionConnector(targetPosition);
+                                        replay.Decorations.AddShockwave(connector, lifespanShockwave, Colors.Yellow, 0.3, shockwaveRadius);
+                                    }
+                                }
                             }
-                        }
+                            break;
+                        default:
+                            break;
                     }
                 }
                 break;
             case (int)TargetID.BlueKnight:
             case (int)TargetID.RedKnight:
             case (int)TargetID.GreenKnight:
-                // Explosive Launch - Knight Jump in air
-                var explosiveLaunch = casts.Where(x => x.SkillId == ExplosiveLaunch);
-                foreach (CastEvent c in explosiveLaunch)
+                foreach (CastEvent c in casts)
                 {
-                    int castDuration = 1714;
-                    long expectedEndCast = c.Time + castDuration;
-                    (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                    replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), expectedEndCast, true);
-                }
-
-                // Explosive Impact - Knight fall and knockback AoE
-                var explosiveImpact = casts.Where(x => x.SkillId == ExplosiveImpact);
-                foreach (CastEvent c in explosiveImpact)
-                {
-                    int castDuration = 533;
-                    long expectedEndCast = c.Time + castDuration;
-                    (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                    replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), expectedEndCast);
-                }
-
-                // Pull AoE
-                var extraction = casts.Where(x => x.SkillId == Extraction);
-                foreach (CastEvent c in extraction)
-                {
-                    int castDuration = 3835;
-                    long expectedEndCast = c.Time + castDuration;
-                    (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                    replay.Decorations.AddWithGrowing(new DoughnutDecoration(300, 2000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), expectedEndCast);
+                    switch (c.SkillId)
+                    {
+                        case ExplosiveLaunch: // Explosive Launch - Knight Jump in air
+                            castDuration = 1714;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing, true);
+                            break;
+                        case ExplosiveImpact: // Explosive Impact - Knight fall and knockback AoE
+                            castDuration = 533;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing);
+                            break;
+                        case Extraction: // Extraction - Pull AoE
+                            castDuration = 3835;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            replay.Decorations.AddWithGrowing(new DoughnutDecoration(300, 2000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing);
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 break;
             default:

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -156,7 +156,7 @@ internal class MAMA : Nightmare
         switch (target.ID)
         {
             case (int)TargetID.MAMA:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {
@@ -207,7 +207,7 @@ internal class MAMA : Nightmare
             case (int)TargetID.BlueKnight:
             case (int)TargetID.RedKnight:
             case (int)TargetID.GreenKnight:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/MAMA.cs
@@ -156,28 +156,28 @@ internal class MAMA : Nightmare
         switch (target.ID)
         {
             case (int)TargetID.MAMA:
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId)
+                    switch (cast.SkillId)
                     {
                         // Blastwave - AoE Knockback
                         case Blastwave1:
                             castDuration = 2750;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             replay.Decorations.AddWithBorder(new CircleDecoration(530, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(growing), 0, Colors.Red, 0.2, false);
                             break;
                         case Blastwave2:
                             castDuration = 2750;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             replay.Decorations.AddWithBorder(new CircleDecoration(480, lifespan, Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(growing), 0, Colors.Red, 0.2, false);
                             break;
                         // Leap with shockwaves
                         case Leap:
                             castDuration = 2400;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
 
                             // Find position at the end of the leap time
                             if (target.TryGetCurrentPosition(log, growing + 1000, out var targetPosition))
@@ -207,29 +207,29 @@ internal class MAMA : Nightmare
             case (int)TargetID.BlueKnight:
             case (int)TargetID.RedKnight:
             case (int)TargetID.GreenKnight:
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId)
+                    switch (cast.SkillId)
                     {
                         // Explosive Launch - Knight Jump in air
                         case ExplosiveLaunch:
                             castDuration = 1714;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing, true);
                             break;
                         // Explosive Impact - Knight fall and knockback AoE
                         case ExplosiveImpact:
                             castDuration = 533;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             replay.Decorations.AddWithGrowing(new CircleDecoration(600, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing);
                             break;
                         // Extraction - Pull AoE
                         case Extraction:
                             castDuration = 3835;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             replay.Decorations.AddWithGrowing(new DoughnutDecoration(300, 2000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), growing);
                             break;
                         default:

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -140,16 +140,16 @@ internal class Siax : Nightmare
         switch (target.ID)
         {
             case (int)TargetID.Siax:
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId)
+                    switch (cast.SkillId)
                     {
                         // Caustic Explosion - Breakbar
                         case CausticExplosionSiaxBreakbar:
                             castDuration = 15000;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, cast.Time, castDuration));
                             var doughnut = new DoughnutDecoration(0, 1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
                             replay.Decorations.AddWithGrowing(doughnut, growing, true);
                             break;
@@ -157,16 +157,16 @@ internal class Siax : Nightmare
                         case CausticExplosionSiaxPhase66:
                         case CausticExplosionSiaxPhase33:
                             castDuration = 20000;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Determined762, cast.Time, castDuration));
                             var circle = new CircleDecoration(1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
                             replay.Decorations.AddWithGrowing(circle, growing);
                             break;
                         // Tail Swipe
                         case TailLashSiax:
                             castDuration = 1550;
-                            lifespan = (c.Time, c.Time + castDuration);
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + castDuration, out var facing))
+                            lifespan = (cast.Time, cast.Time + castDuration);
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + castDuration, out var facing))
                             {
                                 var rotation = new AngleConnector(facing);
                                 replay.Decorations.Add(new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation));
@@ -178,15 +178,15 @@ internal class Siax : Nightmare
                 }
                 break;
             case (int)TargetID.EchoOfTheUnclean:
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId)
+                    switch (cast.SkillId)
                     {
                         // Caustic Explosion
                         case CausticExplosionSiaxEcho:
                             // Duration is the same as Siax's explosion but starts 2 seconds later
                             // Display the explosion for a brief time
-                            lifespan = (c.Time + 18000, c.Time + 20000);
+                            lifespan = (cast.Time + 18000, cast.Time + 20000);
                             replay.Decorations.Add(new CircleDecoration(3000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)));
                             break;
                         default:

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -133,7 +133,6 @@ internal class Siax : Nightmare
 
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
-        var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
         long castDuration;
         long growing;
         (long start, long end) lifespan;
@@ -141,11 +140,12 @@ internal class Siax : Nightmare
         switch (target.ID)
         {
             case (int)TargetID.Siax:
-                foreach (CastEvent c in casts)
+                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (c.SkillId)
                     {
-                        case CausticExplosionSiaxBreakbar: // Siax's Breakbar
+                        // Caustic Explosion - Breakbar
+                        case CausticExplosionSiaxBreakbar:
                             castDuration = 15000;
                             growing = c.Time + castDuration;
                             lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
@@ -153,7 +153,17 @@ internal class Siax : Nightmare
                             var doughnut = new DoughnutDecoration(0, 1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
                             replay.Decorations.AddWithGrowing(doughnut, growing, true);
                             break;
-                        case TailLashSiax: // Tail Swipe
+                        // Caustic Explosion - 66% and 33% phases
+                        case CausticExplosionSiaxPhase66:
+                        case CausticExplosionSiaxPhase33:
+                            castDuration = 20000;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            var circle = new CircleDecoration(1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
+                            replay.Decorations.AddWithGrowing(circle, growing);
+                            break;
+                        // Tail Swipe
+                        case TailLashSiax:
                             castDuration = 1550;
                             lifespan = (c.Time, c.Time + castDuration);
                             if (target.TryGetCurrentFacingDirection(log, c.Time + castDuration, out var facing))
@@ -162,24 +172,17 @@ internal class Siax : Nightmare
                                 replay.Decorations.Add(new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation));
                             }
                             break;
-                        case CausticExplosionSiaxPhase66: // 66% and 33% phases
-                        case CausticExplosionSiaxPhase33:
-                            castDuration = 20000;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
-                            var circle = new CircleDecoration(1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
-                            replay.Decorations.AddWithGrowing(circle, growing);
-                            break;
                         default:
                             break;
                     }
                 }
                 break;
             case (int)TargetID.EchoOfTheUnclean:
-                foreach (CastEvent c in casts)
+                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (c.SkillId)
                     {
+                        // Caustic Explosion
                         case CausticExplosionSiaxEcho:
                             // Duration is the same as Siax's explosion but starts 2 seconds later
                             // Display the explosion for a brief time

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -134,53 +134,61 @@ internal class Siax : Nightmare
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
         var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
+        long castDuration;
+        long growing;
+        (long start, long end) lifespan;
 
         switch (target.ID)
         {
             case (int)TargetID.Siax:
-                // Siax's Breakbar
-                var causticExplosionBreakbar = casts.Where(x => x.SkillId == CausticExplosionSiaxBreakbar);
-                foreach (CastEvent c in causticExplosionBreakbar)
+                foreach (CastEvent c in casts)
                 {
-                    int castDuration = 15000;
-                    long expectedEndCast = c.Time + castDuration;
-                    (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                    lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
-                    var doughnut = new DoughnutDecoration(0, 1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
-                    replay.Decorations.AddWithGrowing(doughnut, expectedEndCast, true);
-                }
-                // Tail Swipe
-                var tailLash = casts.Where(x => x.SkillId == TailLashSiax);
-                foreach (CastEvent c in tailLash)
-                {
-                    int castDuration = 1550;
-                    (long start, long end) lifespan = (c.Time, c.Time + castDuration);
-                    if (target.TryGetCurrentFacingDirection(log, c.Time + castDuration, out var facing))
+                    switch (c.SkillId)
                     {
-                        var rotation = new AngleConnector(facing);
-                        replay.Decorations.Add(new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation));
+                        case CausticExplosionSiaxBreakbar: // Siax's Breakbar
+                            castDuration = 15000;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            var doughnut = new DoughnutDecoration(0, 1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
+                            replay.Decorations.AddWithGrowing(doughnut, growing, true);
+                            break;
+                        case TailLashSiax: // Tail Swipe
+                            castDuration = 1550;
+                            lifespan = (c.Time, c.Time + castDuration);
+                            if (target.TryGetCurrentFacingDirection(log, c.Time + castDuration, out var facing))
+                            {
+                                var rotation = new AngleConnector(facing);
+                                replay.Decorations.Add(new PieDecoration(600, 144, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target)).UsingRotationConnector(rotation));
+                            }
+                            break;
+                        case CausticExplosionSiaxPhase66: // 66% and 33% phases
+                        case CausticExplosionSiaxPhase33:
+                            castDuration = 20000;
+                            growing = c.Time + castDuration;
+                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            var circle = new CircleDecoration(1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
+                            replay.Decorations.AddWithGrowing(circle, growing);
+                            break;
+                        default:
+                            break;
                     }
                 }
-                // 66% and 33% phases
-                var causticExplosionPhases = casts.Where(x => x.SkillId == CausticExplosionSiaxPhase66 || x.SkillId == CausticExplosionSiaxPhase33);
-                foreach (CastEvent c in causticExplosionPhases)
-                {
-                    int castDuration = 20000;
-                    long expectedEndCast = c.Time + castDuration;
-                    (long start, long end) lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
-                    var circle = new CircleDecoration(1500, lifespan, Colors.Red, 0.2, new AgentConnector(target));
-                    replay.Decorations.AddWithGrowing(circle, expectedEndCast);
-                }
-
                 break;
             case (int)TargetID.EchoOfTheUnclean:
-                var causticExplosionEcho = casts.Where(x => x.SkillId == CausticExplosionSiaxEcho);
-                foreach (CastEvent c in causticExplosionEcho)
+                foreach (CastEvent c in casts)
                 {
-                    // Duration is the same as Siax's explosion but starts 2 seconds later
-                    // Display the explosion for a brief time
-                    (long start, long end) lifespan = (c.Time + 18000, c.Time + 20000);
-                    replay.Decorations.Add(new CircleDecoration(3000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)));
+                    switch (c.SkillId)
+                    {
+                        case CausticExplosionSiaxEcho:
+                            // Duration is the same as Siax's explosion but starts 2 seconds later
+                            // Display the explosion for a brief time
+                            lifespan = (c.Time + 18000, c.Time + 20000);
+                            replay.Decorations.Add(new CircleDecoration(3000, lifespan, Colors.Orange, 0.2, new AgentConnector(target)));
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 break;
             case (int)TargetID.VolatileHallucinationSiax:
@@ -189,7 +197,7 @@ internal class Siax : Nightmare
                 {
                     foreach (EffectEvent effect in expulsionEffects)
                     {
-                        (long start, long end) lifespan = effect.ComputeLifespan(log, 300);
+                        lifespan = effect.ComputeLifespan(log, 300);
                         var circle = new CircleDecoration(240, lifespan, Colors.LightOrange, 0.2, new AgentConnector(target));
                         replay.Decorations.AddWithGrowing(circle, lifespan.end);
                     }

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/Nightmare/Siax.cs
@@ -140,7 +140,7 @@ internal class Siax : Nightmare
         switch (target.ID)
         {
             case (int)TargetID.Siax:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {
@@ -178,7 +178,7 @@ internal class Siax : Nightmare
                 }
                 break;
             case (int)TargetID.EchoOfTheUnclean:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
@@ -287,11 +287,10 @@ internal class Arkk : ShatteredObservatory
     {
         base.ComputeNPCCombatReplayActors(target, log, replay);
 
-        IReadOnlyList<AnimatedCastEvent> casts = log.CombatData.GetAnimatedCastData(target.AgentItem);
         switch (target.ID)
         {
             case (int)TargetID.Arkk:
-                foreach (CastEvent cast in casts)
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Arkk.cs
@@ -290,7 +290,7 @@ internal class Arkk : ShatteredObservatory
         switch (target.ID)
         {
             case (int)TargetID.Arkk:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -203,7 +203,6 @@ internal class Artsariiv : ShatteredObservatory
     {
         base.ComputeNPCCombatReplayActors(target, log, replay);
         long castDuration;
-        long growing;
         (long start, long end) lifespan;
 
         switch (target.ID)

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Artsariiv.cs
@@ -208,7 +208,7 @@ internal class Artsariiv : ShatteredObservatory
         switch (target.ID)
         {
             case (int)TargetID.Artsariiv:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -270,9 +270,9 @@ internal class Skorvald : ShatteredObservatory
         switch (target.ID)
         {
             case (int)TargetID.Skorvald:
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId)
+                    switch (cast.SkillId)
                     {
                         // Horizon Strike
                         case HorizonStrikeSkorvald2:
@@ -280,15 +280,15 @@ internal class Skorvald : ShatteredObservatory
                             castDuration = 3900;
                             int shiftingAngle = 45;
                             int sliceSpawnInterval = 750;
-                            lifespan = (c.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            lifespan = (cast.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, cast.Time, castDuration));
 
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + 100, out var facingHorizonStrike, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + 100, out var facingHorizonStrike, castDuration))
                             {
                                 float degree = facingHorizonStrike.GetRoundedZRotationDeg();
 
                                 // Horizon Strike starting at Skorvald's facing point
-                                if (c.SkillId == HorizonStrikeSkorvald4)
+                                if (cast.SkillId == HorizonStrikeSkorvald4)
                                 {
                                     for (int i = 0; i < 4; i++)
                                     {
@@ -299,7 +299,7 @@ internal class Skorvald : ShatteredObservatory
                                     }
                                 }
                                 // Starting at Skorvald's 90° of facing point
-                                if (c.SkillId == HorizonStrikeSkorvald2)
+                                if (cast.SkillId == HorizonStrikeSkorvald2)
                                 {
                                     degree -= 90;
                                     for (int i = 0; i < 4; i++)
@@ -320,18 +320,18 @@ internal class Skorvald : ShatteredObservatory
                             castDuration = 3000;
                             uint radius = 1200;
                             int angleCrimsonDawn = 295;
-                            lifespan = (c.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            lifespan = (cast.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, cast.Time, castDuration));
 
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + 100, out var facingCrimsonDawn, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + 100, out var facingCrimsonDawn, castDuration))
                             {
                                 float degree = facingCrimsonDawn.GetRoundedZRotationDeg();
 
-                                if (c.SkillId == CrimsonDawnSkorvaldCM2)
+                                if (cast.SkillId == CrimsonDawnSkorvaldCM2)
                                 {
                                     degree += 90;
                                 }
-                                if (c.SkillId == CrimsonDawnSkorvaldCM1)
+                                if (cast.SkillId == CrimsonDawnSkorvaldCM1)
                                 {
                                     degree += 270;
                                 }
@@ -344,11 +344,11 @@ internal class Skorvald : ShatteredObservatory
                         // Punishing Kick
                         case PunishingKickSkorvald:
                             castDuration = 1850;
-                            lifespan = (c.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
-                            long expectedEndCast = c.Time + castDuration;
+                            lifespan = (cast.Time + 100, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, cast.Time, castDuration));
+                            long expectedEndCast = cast.Time + castDuration;
 
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + 100, out var frontalPoint, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + 100, out var frontalPoint, castDuration))
                             {
                                 float rotation = frontalPoint.GetRoundedZRotationDeg();
                                 // Frontal
@@ -358,9 +358,9 @@ internal class Skorvald : ShatteredObservatory
                         // Radiant Fury
                         case RadiantFurySkorvald:
                             castDuration = 2700;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, cast.Time, castDuration));
                             (long start, long end) lifespanWave = (lifespan.end, lifespan.end + 900);
 
                             if (growing <= lifespan.end)
@@ -372,19 +372,19 @@ internal class Skorvald : ShatteredObservatory
                         // Supernova - Phase Oneshot
                         case SupernovaSkorvaldCM:
                             castDuration = 75000;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
                             replay.Decorations.AddWithGrowing(new CircleDecoration(1200, lifespan, Colors.Red, 0.2, new AgentConnector(target)), growing);
                             break;
                         // Cranial Cascade
                         case CranialCascadeSkorvald:
                             castDuration = 1750;
-                            growing = c.Time + castDuration;
+                            growing = cast.Time + castDuration;
 
-                            lifespan = (c.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, c.Time, castDuration));
-                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, c.Time, castDuration));
+                            lifespan = (cast.Time, ComputeEndCastTimeByBuffApplication(log, target, Stun, cast.Time, castDuration));
+                            lifespan.end = Math.Min(lifespan.end, ComputeEndCastTimeByBuffApplication(log, target, Determined762, cast.Time, castDuration));
 
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + 100, out var facingCranialCascade, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + 100, out var facingCranialCascade, castDuration))
                             {
                                 float rotation = facingCranialCascade.GetRoundedZRotationDeg();
 
@@ -405,14 +405,14 @@ internal class Skorvald : ShatteredObservatory
             case (int)TargetID.FluxAnomalyCM2:
             case (int)TargetID.FluxAnomalyCM3:
             case (int)TargetID.FluxAnomalyCM4:
-                foreach (CastEvent c in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    switch (c.SkillId)
+                    switch (cast.SkillId)
                     {
                         // Solar Stomp
                         case SolarStomp:
                             castDuration = 2250;
-                            lifespan = (c.Time, c.Time + castDuration);
+                            lifespan = (cast.Time, cast.Time + castDuration);
                             uint radius = 280;
                             (long start, long end) lifespanShockwave = (lifespan.end, lifespan.end + castDuration);
 
@@ -424,10 +424,10 @@ internal class Skorvald : ShatteredObservatory
                         // Punishing Kick
                         case PunishingKickAnomaly:
                             castDuration = 1850;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, growing);
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, growing);
 
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + 100, out var frontalPoint, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + 100, out var frontalPoint, castDuration))
                             {
                                 float rotation = frontalPoint.GetRoundedZRotationDeg();
                                 // Frontal
@@ -437,11 +437,11 @@ internal class Skorvald : ShatteredObservatory
                         // Cranial Cascade
                         case CranialCascadeAnomaly:
                             castDuration = 1750;
-                            growing = c.Time + castDuration;
-                            lifespan = (c.Time, growing);
+                            growing = cast.Time + castDuration;
+                            lifespan = (cast.Time, growing);
                             int angleCranialCascade = 35;
 
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + 100, out var facingCranialCascade, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + 100, out var facingCranialCascade, castDuration))
                             {
                                 float rotation = facingCranialCascade.GetRoundedZRotationDeg();
 
@@ -454,7 +454,7 @@ internal class Skorvald : ShatteredObservatory
                         // Mist Smash
                         case MistSmash:
                             castDuration = 1933;
-                            lifespan = (c.Time, c.Time + castDuration);
+                            lifespan = (cast.Time, cast.Time + castDuration);
                             (long start, long end) lifespanShockwave2 = (lifespan.end, lifespan.end + 2250);
                             replay.Decorations.AddWithGrowing(new CircleDecoration(160, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), lifespan.end);
                             
@@ -465,10 +465,10 @@ internal class Skorvald : ShatteredObservatory
                         case WaveOfMutilation:
                             castDuration = 1850;
                             int angleWaveOfMutilation = 18;
-                            long expectedEndCast = c.Time + castDuration;
-                            lifespan = (c.Time, expectedEndCast);
+                            long expectedEndCast = cast.Time + castDuration;
+                            lifespan = (cast.Time, expectedEndCast);
 
-                            if (target.TryGetCurrentFacingDirection(log, c.Time + 100, out var facingWaveOfMutilation, castDuration))
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time + 100, out var facingWaveOfMutilation, castDuration))
                             {
                                 float rotation = facingWaveOfMutilation.GetRoundedZRotationDeg();
 

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/ShatteredObservatory/Skorvald.cs
@@ -270,7 +270,7 @@ internal class Skorvald : ShatteredObservatory
         switch (target.ID)
         {
             case (int)TargetID.Skorvald:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {
@@ -405,7 +405,7 @@ internal class Skorvald : ShatteredObservatory
             case (int)TargetID.FluxAnomalyCM2:
             case (int)TargetID.FluxAnomalyCM3:
             case (int)TargetID.FluxAnomalyCM4:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SilentSurf/Kanaxai.cs
@@ -338,11 +338,11 @@ internal class Kanaxai : SilentSurf
         switch (target.ID)
         {
             case (int)TargetID.KanaxaiScytheOfHouseAurkusCM:
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {
-                        // World Cleaver
+                        // World Cleaver - 66 & 33% Attack
                         case WorldCleaver:
                             castDuration = 26320;
                             lifespan = (cast.Time, cast.Time + castDuration);
@@ -358,7 +358,7 @@ internal class Kanaxai : SilentSurf
                                 AddWorldCleaverDecoration(target, replay, lifespan, lifespan.end);
                             }
                             break;
-                        // Dread Visage
+                        // Dread Visage - Eye
                         case DreadVisageKanaxaiSkill:
                         case DreadVisageKanaxaiSkillIsland:
                             castDuration = 5400;
@@ -386,7 +386,7 @@ internal class Kanaxai : SilentSurf
                 // Check if the log contains Sugar Rush
                 bool hasSugarRush = log.CombatData.GetBuffData(MistlockInstabilitySugarRush).Any(x => x.To.IsPlayer);
 
-                foreach (CastEvent cast in target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
                     switch (cast.SkillId)
                     {
@@ -395,7 +395,7 @@ internal class Kanaxai : SilentSurf
                             lifespan = (cast.Time, cast.ExpectedEndTime); // actual end is often much later, just use expected end for short highlight
                             replay.Decorations.Add(new CircleDecoration(180, 20, lifespan, Colors.LightBlue, 0.5, new AgentConnector(target)).UsingFilled(false));
                             break;
-                        // Dread Visage
+                        // Dread Visage - Eye
                         case DreadVisageAspectSkill:
                             castDuration = 5400;
                             growing = (int)cast.Time + castDuration;

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/SunquaPeak/AiKeeperOfThePeak.cs
@@ -489,12 +489,13 @@ internal class AiKeeperOfThePeak : SunquaPeak
                     const long sorrowFullCastDuration = 11840;
                     const long sorrowHitDelay = 400;
                     const uint sorrowIndicatorSize = 2000;
-                    var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).ToList();
+                    var casts = target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).ToList();
 
                     foreach (CastEvent cast in casts)
                     {
                         switch (cast.SkillId)
                         {
+                            // Overwhelming Sorrow - Explosion
                             case OverwhelmingSorrowWindup:
                                 growing = cast.Time + sorrowFullCastDuration;
                                 lifespan = (cast.Time, growing);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -158,67 +158,94 @@ internal class Sabetha : SpiritVale
 
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
-        var cls = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
+        long castDuration;
+        (long start, long end) lifespan;
+
         switch (target.ID)
         {
             case (int)TargetID.Sabetha:
-                var flameWall = cls.Where(x => x.SkillId == Firestorm);
-                foreach (CastEvent c in flameWall)
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    int start = (int)c.Time;
-                    int preCastTime = 2800;
-                    int duration = 10000;
-                    uint width = 1300; uint height = 60;
-                    if (target.TryGetCurrentFacingDirection(log, start, out var facing))
+                    switch (cast.SkillId)
                     {
-                        var positionConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(width / 2, 0, 0), true);
-                        replay.Decorations.Add(new RectangleDecoration(width, height, (start, start + preCastTime), Colors.Orange, 0.2, positionConnector).UsingRotationConnector(new AngleConnector(facing)));
-                        replay.Decorations.Add(new RectangleDecoration(width, height, (start + preCastTime, start + preCastTime + duration), Colors.Red, 0.5, positionConnector).UsingRotationConnector(new AngleConnector(facing, 360)));
+                        // Firestorm - Flame Wall
+                        case Firestorm:
+                            uint width = 1300;
+                            uint height = 60;
+                            long preCastTime = 2800;
+                            castDuration = 10000;
+                            lifespan = (cast.Time, cast.Time + preCastTime);
+                            (long start, long end) lifespanWall = (lifespan.end, lifespan.end + castDuration);
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time, out var facingFirestorm))
+                            {
+                                var positionConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(width / 2, 0, 0), true);
+                                replay.Decorations.Add(new RectangleDecoration(width, height, lifespan, Colors.Orange, 0.2, positionConnector).UsingRotationConnector(new AngleConnector(facingFirestorm)));
+                                replay.Decorations.Add(new RectangleDecoration(width, height, lifespanWall, Colors.Red, 0.5, positionConnector).UsingRotationConnector(new AngleConnector(facingFirestorm, 360)));
+                            }
+                            break;
+                        default:
+                            break;
                     }
                 }
                 break;
-
             case (int)TargetID.Kernan:
-                var bulletHail = cls.Where(x => x.SkillId == BulletHail);
-                foreach (CastEvent c in bulletHail)
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    int start = (int)c.Time;
-                    int firstConeStart = start;
-                    int secondConeStart = start + 800;
-                    int thirdConeStart = start + 1600;
-                    int firstConeEnd = firstConeStart + 400;
-                    int secondConeEnd = secondConeStart + 400;
-                    int thirdConeEnd = thirdConeStart + 400;
-                    uint radius = 1500;
-                    if (target.TryGetCurrentFacingDirection(log, start, out var facing))
+                    switch (cast.SkillId)
                     {
-                        var connector = new AgentConnector(target);
-                        var rotationConnector = new AngleConnector(facing);
-                        replay.Decorations.Add(new PieDecoration(radius, 28, (firstConeStart, firstConeEnd), Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
-                        replay.Decorations.Add(new PieDecoration(radius, 54, (secondConeStart, secondConeEnd), Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
-                        replay.Decorations.Add(new PieDecoration(radius, 81, (thirdConeStart, thirdConeEnd), Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
+                        // Bullet Hail - 3 Cones
+                        case BulletHail:
+                            uint radius = 1500;
+                            (long start, long end) firstCone = (cast.Time, cast.Time + 400);
+                            (long start, long end) secondCone = (cast.Time + 800, cast.Time + 800 + 400);
+                            (long start, long end) thirdCone = (cast.Time + 1600, cast.Time + 1600 + 400);
+                            if (target.TryGetCurrentFacingDirection(log, cast.Time, out var facingBulletHail))
+                            {
+                                var connector = new AgentConnector(target);
+                                var rotationConnector = new AngleConnector(facingBulletHail);
+                                replay.Decorations.Add(new PieDecoration(radius, 28, firstCone, Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
+                                replay.Decorations.Add(new PieDecoration(radius, 54, secondCone, Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
+                                replay.Decorations.Add(new PieDecoration(radius, 81, thirdCone, Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
+                            }
+                            break;
+                        default:
+                            break;
                     }
                 }
                 break;
 
             case (int)TargetID.Knuckles:
-                var breakbar = cls.Where(x => x.SkillId == PlatformQuake);
-                foreach (CastEvent c in breakbar)
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    replay.Decorations.Add(new CircleDecoration(180, ((int)c.Time, (int)c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    switch (cast.SkillId)
+                    {
+                        // Platform Quake
+                        case PlatformQuake:
+                            lifespan = (cast.Time, cast.EndTime);
+                            replay.Decorations.Add(new CircleDecoration(180, lifespan, Colors.LightBlue, 0.3, new AgentConnector(target)));
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 break;
 
             case (int)TargetID.Karde:
-                var flameBlast = cls.Where(x => x.SkillId == FlameBlast);
-                foreach (CastEvent c in flameBlast)
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    int start = (int)c.Time;
-                    int end = start + 4000;
-                    uint radius = 600;
-                    if (target.TryGetCurrentFacingDirection(log, start, out var facing))
+                    switch (cast.SkillId)
                     {
-                        replay.Decorations.Add(new PieDecoration(radius, 60, (start, end), Colors.Yellow, 0.5, new AgentConnector(target)).UsingRotationConnector(new AngleConnector(facing)));
+                        // Flame Blast
+                        case FlameBlast:
+                            castDuration = 4000;
+                            lifespan = (cast.Time, cast.Time + castDuration);
+                            if (target.TryGetCurrentFacingDirection(log, lifespan.start, out var facingFlameBlast))
+                            {
+                                replay.Decorations.Add(new PieDecoration(600, 60, lifespan, Colors.Yellow, 0.5, new AgentConnector(target)).UsingRotationConnector(new AngleConnector(facingFlameBlast)));
+                            }
+                            break;
+                        default:
+                            break;
                     }
                 }
                 break;
@@ -228,7 +255,7 @@ internal class Sabetha : SpiritVale
                     long hideStart = target.FirstAware;
                     foreach (var marker in swords)
                     {
-                        (long start, long end) lifespan = (marker.Time, marker.EndTime);
+                        lifespan = (marker.Time, marker.EndTime);
                         replay.Hidden.Add(new Segment(hideStart, lifespan.start));
                         hideStart = lifespan.end;
                         replay.Decorations.AddOverheadIcon(lifespan, target, ParserIcons.RedCrossSwordsMarker);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W1/Sabetha.cs
@@ -203,9 +203,9 @@ internal class Sabetha : SpiritVale
                             {
                                 var connector = new AgentConnector(target);
                                 var rotationConnector = new AngleConnector(facingBulletHail);
-                                replay.Decorations.Add(new PieDecoration(radius, 28, firstCone, Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
-                                replay.Decorations.Add(new PieDecoration(radius, 54, secondCone, Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
-                                replay.Decorations.Add(new PieDecoration(radius, 81, thirdCone, Colors.Yellow, 0.3, connector).UsingRotationConnector(rotationConnector));
+                                replay.Decorations.Add(new PieDecoration(radius, 28, firstCone, Colors.LightOrange, 0.2, connector).UsingRotationConnector(rotationConnector));
+                                replay.Decorations.Add(new PieDecoration(radius, 54, secondCone, Colors.LightOrange, 0.2, connector).UsingRotationConnector(rotationConnector));
+                                replay.Decorations.Add(new PieDecoration(radius, 81, thirdCone, Colors.LightOrange, 0.2, connector).UsingRotationConnector(rotationConnector));
                             }
                             break;
                         default:

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
@@ -296,103 +296,108 @@ internal class KeepConstruct : StrongholdOfTheFaithful
 
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
-        var cls = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
-        int start = (int)replay.TimeOffsets.start;
-        int end = (int)replay.TimeOffsets.end;
+        long start = replay.TimeOffsets.start;
+        long end = replay.TimeOffsets.end;
         switch (target.ID)
         {
             case (int)TargetID.KeepConstruct:
+                // Phantasmal Blades
+                int bladeDelay = 150;
+                int duration = 1000;
+                float bladeOpeningAngle = 360 * 3 / 32;
+                uint bladeRadius = 1600;
+
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                {
+                    switch (cast.SkillId)
+                    {
+                        case TowerDrop:
+                            {
+                                start = cast.Time;
+                                end = cast.EndTime;
+                                long skillCast = end - 1000;
+                                if (target.TryGetCurrentInterpolatedPosition(log, end, out var position))
+                                {
+                                    replay.Decorations.AddWithFilledWithGrowing(new CircleDecoration(400, (start, skillCast), Colors.LightOrange, 0.5, new PositionConnector(position)).UsingFilled(false), true, skillCast);
+                                }
+                            }
+                            break;
+                        case PhantasmalBlades1:
+                            {
+                                int ticks = (int)Math.Max(0, Math.Min(Math.Ceiling((cast.ActualDuration - 1150) / 1000.0), 9));
+                                start = cast.Time + bladeDelay;
+                                if (target.TryGetCurrentFacingDirection(log, start + 1000, out var facing))
+                                {
+                                    var connector = new AgentConnector(target);
+                                    replay.Decorations.Add(new CircleDecoration(200, (start, start + (ticks + 1) * 1000), Colors.Red, 0.4, connector));
+                                    float initialAngle = facing.GetRoundedZRotationDeg();
+                                    replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle))); // First blade lasts twice as long
+                                    for (int i = 1; i < ticks; i++)
+                                    {
+                                        float angle = initialAngle + i * 360 / 8;
+                                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle))); // First blade lasts longer
+                                    }
+                                }
+                            }
+                            break;
+                        case PhantasmalBlades2:
+                            {
+                                int ticks = (int)Math.Max(0, Math.Min(Math.Ceiling((cast.ActualDuration - 1150) / 1000.0), 9));
+                                start = cast.Time + bladeDelay;
+                                if (target.TryGetCurrentFacingDirection(log, start + 1000, out var facing))
+                                {
+                                    var connector = new AgentConnector(target);
+                                    replay.Decorations.Add(new CircleDecoration(200, (start, start + (ticks + 1) * 1000), Colors.Red, 0.4, connector));
+                                    float initialAngle1 = facing.GetRoundedZRotationDeg();
+                                    replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle1))); // First blade lasts twice as long
+                                    float initialAngle2 = RadianToDegreeF(Math.Atan2(-facing.Y, -facing.X));
+                                    replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle2))); // First blade lasts twice as long
+                                    for (int i = 1; i < ticks; i++)
+                                    {
+                                        float angle1 = initialAngle1 + i * 360 / 8;
+                                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle1))); // First blade lasts longer
+                                        float angle2 = initialAngle2 + i * 360 / 8;
+                                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle2))); // First blade lasts longer
+                                    }
+                                }
+                            }
+                            break;
+                        case PhantasmalBlades3:
+                            {
+                                int ticks = (int)Math.Max(0, Math.Min(Math.Ceiling((cast.ActualDuration - 1150) / 1000.0), 9));
+                                start = cast.Time + bladeDelay;
+                                if (target.TryGetCurrentFacingDirection(log, start + 1000, out var facing))
+                                {
+                                    var connector = new AgentConnector(target);
+                                    replay.Decorations.Add(new CircleDecoration(200, (start, start + (ticks + 1) * 1000), Colors.Red, 0.4, connector));
+                                    float initialAngle1 = RadianToDegreeF(Math.Atan2(-facing.Y, -facing.X));
+                                    replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle1))); // First blade lasts twice as long
+                                    float initialAngle2 = initialAngle1 + 120;
+                                    replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle2))); // First blade lasts twice as long
+                                    float initialAngle3 = initialAngle1 - 120;
+                                    replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle3))); // First blade lasts twice as long
+                                    for (int i = 1; i < ticks; i++)
+                                    {
+                                        float angle1 = initialAngle1 + i * 360 / 8;
+                                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle1))); // First blade lasts longer
+                                        float angle2 = initialAngle2 + i * 360 / 8;
+                                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle2))); // First blade lasts longer
+                                        float angle3 = initialAngle3 + i * 360 / 8;
+                                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle3))); // First blade lasts longer
+                                    }
+                                }
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
 
                 var kcOrbCollect = target.GetBuffStatus(log, XerasBoon, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
                 foreach (Segment seg in kcOrbCollect)
                 {
                     replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (seg.Start, seg.End), Colors.Red, 0.6, Colors.Black, 0.2, [(seg.Start, 0), (seg.End, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
-                }
-                
-                var towerDrop = cls.Where(x => x.SkillId == TowerDrop);
-                foreach (CastEvent c in towerDrop)
-                {
-                    start = (int)c.Time;
-                    end = (int)c.EndTime;
-                    int skillCast = end - 1000;
-                    if (target.TryGetCurrentInterpolatedPosition(log, end, out var position))
-                    {
-                        replay.Decorations.AddWithFilledWithGrowing(new CircleDecoration(400, (start, skillCast), Colors.LightOrange, 0.5, new PositionConnector(position)).UsingFilled(false), true, skillCast);
-                    }
-                }
-               
-                var blades1 = cls.Where(x => x.SkillId == PhantasmalBlades1);
-                var blades2 = cls.Where(x => x.SkillId == PhantasmalBlades2);
-                var blades3 = cls.Where(x => x.SkillId == PhantasmalBlades3);
-                int bladeDelay = 150;
-                int duration = 1000;
-                float bladeOpeningAngle = 360 * 3 / 32;
-                uint bladeRadius = 1600;
-                foreach (CastEvent c in blades1)
-                {
-                    int ticks = (int)Math.Max(0, Math.Min(Math.Ceiling((c.ActualDuration - 1150) / 1000.0), 9));
-                    start = (int)c.Time + bladeDelay;
-                    if (target.TryGetCurrentFacingDirection(log, start + 1000, out var facing))
-                    {
-                        var connector = new AgentConnector(target);
-                        replay.Decorations.Add(new CircleDecoration(200, (start, start + (ticks + 1) * 1000), Colors.Red, 0.4, connector));
-                        float initialAngle = facing.GetRoundedZRotationDeg();
-                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle))); // First blade lasts twice as long
-                        for (int i = 1; i < ticks; i++)
-                        {
-                            float angle = initialAngle + i * 360 / 8;
-                            replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle))); // First blade lasts longer
-                        }
-                    }
-                }
-
-                foreach (CastEvent c in blades2)
-                {
-                    int ticks = (int)Math.Max(0, Math.Min(Math.Ceiling((c.ActualDuration - 1150) / 1000.0), 9));
-                    start = (int)c.Time + bladeDelay;
-                    if (target.TryGetCurrentFacingDirection(log, start + 1000, out var facing))
-                    {
-                        var connector = new AgentConnector(target);
-                        replay.Decorations.Add(new CircleDecoration(200, (start, start + (ticks + 1) * 1000), Colors.Red, 0.4, connector));
-                        float initialAngle1 = facing.GetRoundedZRotationDeg();
-                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle1))); // First blade lasts twice as long
-                        float initialAngle2 = RadianToDegreeF(Math.Atan2(-facing.Y, -facing.X));
-                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle2))); // First blade lasts twice as long
-                        for (int i = 1; i < ticks; i++)
-                        {
-                            float angle1 = initialAngle1 + i * 360 / 8;
-                            replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle1))); // First blade lasts longer
-                            float angle2 = initialAngle2 + i * 360 / 8;
-                            replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle2))); // First blade lasts longer
-                        }
-                    }
-                }
-
-                foreach (CastEvent c in blades3)
-                {
-                    int ticks = (int)Math.Max(0, Math.Min(Math.Ceiling((c.ActualDuration - 1150) / 1000.0), 9));
-                    start = (int)c.Time + bladeDelay;
-                    if (target.TryGetCurrentFacingDirection(log, start + 1000, out var facing))
-                    {
-                        var connector = new AgentConnector(target);
-                        replay.Decorations.Add(new CircleDecoration(200, (start, start + (ticks + 1) * 1000), Colors.Red, 0.4, connector));
-                        float initialAngle1 = RadianToDegreeF(Math.Atan2(-facing.Y, -facing.X));
-                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle1))); // First blade lasts twice as long
-                        float initialAngle2 = initialAngle1 + 120;
-                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle2))); // First blade lasts twice as long
-                        float initialAngle3 = initialAngle1 - 120;
-                        replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start, start + 2 * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(initialAngle3))); // First blade lasts twice as long
-                        for (int i = 1; i < ticks; i++)
-                        {
-                            float angle1 = initialAngle1 + i * 360 / 8;
-                            replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle1))); // First blade lasts longer
-                            float angle2 = initialAngle2 + i * 360 / 8;
-                            replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle2))); // First blade lasts longer
-                            float angle3 = initialAngle3 + i * 360 / 8;
-                            replay.Decorations.Add(new PieDecoration(bladeRadius, bladeOpeningAngle, (start + 1000 + i * duration, start + 1000 + (i + 1) * duration), Colors.Magenta, 0.5, connector).UsingRotationConnector(new AngleConnector(angle3))); // First blade lasts longer
-                        }
-                    }
                 }
                 break;
             case (int)TargetID.KeepConstructCore:
@@ -430,7 +435,7 @@ internal class KeepConstruct : StrongholdOfTheFaithful
 
     internal override FightData.EncounterMode GetEncounterMode(CombatData combatData, AgentData agentData, FightData fightData)
     {
-        return combatData.GetSkills().Contains(34958) ? FightData.EncounterMode.CM : FightData.EncounterMode.Normal;
+        return combatData.GetSkills().Contains(AchievementEligibilityDownDownDowned) ? FightData.EncounterMode.CM : FightData.EncounterMode.Normal;
     }
 
     internal override void ComputePlayerCombatReplayActors(PlayerActor p, ParsedEvtcLog log, CombatReplay replay)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Xera.cs
@@ -210,7 +210,7 @@ internal class Xera : StrongholdOfTheFaithful
         }
         _xeraFirstPhaseEndTime = firstXera.LastAware;
         //
-        var maxHPUpdates = combatData.Where(x => x.IsStateChange == StateChange.MaxHealthUpdate).Select(x => new MaxHealthUpdateEvent(x, agentData));
+        var maxHPUpdates = combatData.Where(x => x.IsStateChange == StateChange.MaxHealthUpdate).Select(x => new MaxHealthUpdateEvent(x, agentData)).ToList();
         //
         var bloodstoneFragments = maxHPUpdates.Where(x => x.MaxHealth == 104580).Select(x => x.Src).Where(x => x.Type == AgentItem.AgentType.Gadget);
         foreach (AgentItem gadget in bloodstoneFragments)
@@ -327,11 +327,16 @@ internal class Xera : StrongholdOfTheFaithful
         switch (target.ID)
         {
             case (int)TargetID.Xera:
-                var cls = target.GetCastEvents(log, 0, log.FightData.FightEnd);
-                var summon = cls.Where(x => x.SkillId == SummonFragments);
-                foreach (CastEvent c in summon)
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    replay.Decorations.Add(new CircleDecoration(180, (c.Time, c.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                    switch (cast.SkillId)
+                    {
+                        case SummonFragments:
+                            replay.Decorations.Add(new CircleDecoration(180, (cast.Time, cast.EndTime), Colors.LightBlue, 0.3, new AgentConnector(target)));
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 if (_xeraFirstPhaseEndTime != 0)
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/MursaatOverseer.cs
@@ -96,22 +96,28 @@ internal class MursaatOverseer : BastionOfThePenitent
         switch (target.ID)
         {
             case (int)TargetID.Jade:
-                var cls = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
+                {
+                    switch (cast.SkillId)
+                    {
+                        case JadeSoldierExplosion:
+                            long start = cast.Time;
+                            long precast = 1350;
+                            long duration = 100;
+                            uint radius = 1200;
+                            replay.Decorations.Add(new CircleDecoration(radius, (start, start + precast + duration), Colors.Red, 0.05, new AgentConnector(target)));
+                            replay.Decorations.Add(new CircleDecoration(radius, (start + precast, start + precast + duration), Colors.Red, 0.25, new AgentConnector(target)));
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                // Jade Scout Shield
                 var shields = target.GetBuffStatus(log, MursaatOverseersShield, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-                uint shieldRadius = 100;
                 foreach (var seg in shields)
                 {
-                    replay.Decorations.Add(new CircleDecoration(shieldRadius, seg, Colors.Yellow, 0.3, new AgentConnector(target)));
-                }
-                var explosion = cls.Where(x => x.SkillId == JadeSoldierExplosion);
-                foreach (CastEvent c in explosion)
-                {
-                    int start = (int)c.Time;
-                    int precast = 1350;
-                    int duration = 100;
-                    uint radius = 1200;
-                    replay.Decorations.Add(new CircleDecoration(radius, (start, start + precast + duration), Colors.Red, 0.05, new AgentConnector(target)));
-                    replay.Decorations.Add(new CircleDecoration(radius, (start + precast, start + precast + duration), Colors.Red, 0.25, new AgentConnector(target)));
+                    replay.Decorations.Add(new CircleDecoration(100, seg, Colors.Yellow, 0.3, new AgentConnector(target)));
                 }
                 break;
             default:

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W4/Samarog.cs
@@ -148,15 +148,13 @@ internal class Samarog : BastionOfThePenitent
         if (evtcVersion.Build >= ArcDPSBuilds.LingeringAgents)
         {
             var spearAgents = combatData.Where(x => MaxHealthUpdateEvent.GetMaxHealth(x) == 104580 && x.IsStateChange == StateChange.MaxHealthUpdate).Select(x => agentData.GetAgent(x.SrcAgent, x.Time)).Where(x => x.Type == AgentItem.AgentType.Gadget && x.HitboxWidth == 100 && x.HitboxHeight == 300);
-            if (spearAgents.Any())
+            foreach (AgentItem spear in spearAgents)
             {
-                foreach (AgentItem spear in spearAgents)
-                {
-                    spear.OverrideType(AgentItem.AgentType.NPC, agentData);
-                    spear.OverrideID(TargetID.SpearAggressionRevulsion, agentData);
-                }
+                spear.OverrideType(AgentItem.AgentType.NPC, agentData);
+                spear.OverrideID(TargetID.SpearAggressionRevulsion, agentData);
             }
         }
+
         base.EIEvtcParse(gw2Build, evtcVersion, fightData, agentData, combatData, extensions);
         int curGuldhem = 1;
         int curRigom = 1;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/ConjuredAmalgamate.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/ConjuredAmalgamate.cs
@@ -364,12 +364,12 @@ internal class ConjuredAmalgamate : MythwrightGambit
         var shieldCast = casts.Where(x => x.SkillId == ConjuredProtectionSAK);
         foreach (CastEvent c in shieldCast)
         {
-            int start = (int)c.Time;
             int duration = 10000;
             uint radius = 300;
-            if (p.TryGetCurrentInterpolatedPosition(log, start, out var position))
+            (long start, long end) lifespan = (c.Time, c.Time + duration);
+            if (p.TryGetCurrentInterpolatedPosition(log, lifespan.start, out var position))
             {
-                var circle = new CircleDecoration(radius, (start, start + duration), "rgba(255, 0, 255, 0.2)", new PositionConnector(position));
+                var circle = new CircleDecoration(radius, lifespan, Colors.Magenta, 0.2, new PositionConnector(position));
                 replay.Decorations.AddWithBorder(circle);
             }
         }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W6/TwinLargos.cs
@@ -289,68 +289,75 @@ internal class TwinLargos : MythwrightGambit
 
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
+        (long start, long end) lifespan;
+
         var cls = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
         switch (target.ID)
         {
             case (int)TargetID.Nikare:
-                //CC
-                var barrageN = cls.Where(x => x.SkillId == AquaticBarrage);
-                foreach (CastEvent c in barrageN)
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
-                        .UsingRotationConnector(new AngleConnector(180)));
-                }
-                //Platform wipe (CM only)
-                var aquaticDomainN = cls.Where(x => x.SkillId == AquaticDomain);
-                foreach (CastEvent c in aquaticDomainN)
-                {
-                    int start = (int)c.Time;
-                    int end = (int)c.EndTime;
-                    uint radius = 800;
-                    replay.Decorations.Add(new CircleDecoration(radius, (start, end), Colors.Yellow, 0.3, new AgentConnector(target)).UsingGrowingEnd(end));
+                    switch (cast.SkillId)
+                    {
+                        // Aquatic Barrage - Breakbar CC
+                        case AquaticBarrage:
+                            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (cast.Time, cast.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(cast.Time, 0), (cast.ExpectedEndTime, 100)], new AgentConnector(target))
+                            .UsingRotationConnector(new AngleConnector(180)));
+                            break;
+                        // Aquatic Domain - Platform wipe (CM only)
+                        case AquaticDomain:
+                            lifespan = (cast.Time, cast.EndTime);
+                            replay.Decorations.Add(new CircleDecoration(800, lifespan, Colors.Yellow, 0.3, new AgentConnector(target)).UsingGrowingEnd(lifespan.end));
+                            break;
+                        default:
+                            break;
+                    }
                 }
                 break;
             case (int)TargetID.Kenut:
-                //CC
-                var barrageK = cls.Where(x => x.SkillId == AquaticBarrage);
-                foreach (CastEvent c in barrageK)
+                foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                 {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.ExpectedEndTime, 100)], new AgentConnector(target))
-                        .UsingRotationConnector(new AngleConnector(180)));
-                }
-                //Platform wipe (CM only)
-                var aquaticDomainK = cls.Where(x => x.SkillId == AquaticDomain);
-                foreach (CastEvent c in aquaticDomainK)
-                {
-                    int start = (int)c.Time;
-                    int end = (int)c.EndTime;
-                    uint radius = 800;
-                    replay.Decorations.Add(new CircleDecoration(radius, (start, end), Colors.Yellow, 0.3, new AgentConnector(target)).UsingGrowingEnd(end));
-                }
-                var shockwave = cls.Where(x => x.SkillId == SeaSwell);
-                foreach (CastEvent c in shockwave)
-                {
-                    int start = (int)c.Time;
-                    int delay = 960;
-                    int duration = 3000;
-                    uint radius = 1200;
-                    (long, long) lifespan = (start + delay, start + delay + duration);
-                    GeographicalConnector connector = new AgentConnector(target);
-                    replay.Decorations.AddShockwave(connector, lifespan, Colors.SkyBlue, 0.5, radius);
-                }
-                var boonSteal = cls.Where(x => x.SkillId == VaporJet);
-                foreach (CastEvent c in boonSteal)
-                {
-                    int start = (int)c.Time;
-                    int delay = 1000;
-                    int duration = 500;
-                    uint width = 500;
-                    uint height = 250;
-                    if (target.TryGetCurrentFacingDirection(log, start, out var facing))
+                    switch (cast.SkillId)
                     {
-                        var positionConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(width / 2, 0, 0), true);
-                        var rotationConnextor = new AngleConnector(facing);
-                        replay.Decorations.AddWithBorder((RectangleDecoration)new RectangleDecoration(width, height, (start + delay, start + delay + duration), Colors.LightOrange, 0.4, positionConnector).UsingRotationConnector(rotationConnextor));
+                        // Aquatic Barrage - Breakbar CC
+                        case AquaticBarrage:
+                            replay.Decorations.Add(new OverheadProgressBarDecoration(ParserHelper.CombatReplayOverheadProgressBarMajorSizeInPixel, (cast.Time, cast.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(cast.Time, 0), (cast.ExpectedEndTime, 100)], new AgentConnector(target))
+                            .UsingRotationConnector(new AngleConnector(180)));
+                            break;
+                        // Aquatic Domain - Platform wipe (CM only)
+                        case AquaticDomain:
+                            lifespan = (cast.Time, cast.EndTime);
+                            replay.Decorations.Add(new CircleDecoration(800, lifespan, Colors.Yellow, 0.3, new AgentConnector(target)).UsingGrowingEnd(lifespan.end));
+                            break;
+                        // Sea Swell - Shockwave
+                        case SeaSwell:
+                            {
+                                int delay = 960;
+                                int duration = 3000;
+                                uint radius = 1200;
+                                lifespan = (cast.Time + delay, cast.Time + delay + duration);
+                                GeographicalConnector connector = new AgentConnector(target);
+                                replay.Decorations.AddShockwave(connector, lifespan, Colors.SkyBlue, 0.5, radius);
+                            }
+                            break;
+                        // Vapor Jet - Boon steal
+                        case VaporJet:
+                            {
+                                int delay = 1000;
+                                int duration = 500;
+                                uint width = 500;
+                                uint height = 250;
+                                lifespan = (cast.Time + delay, cast.Time + delay + duration);
+                                if (target.TryGetCurrentFacingDirection(log, cast.Time + 250, out var facing))
+                                {
+                                    var positionConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(width / 2, 0, 0), true);
+                                    var rotationConnextor = new AngleConnector(facing);
+                                    replay.Decorations.AddWithBorder((RectangleDecoration)new RectangleDecoration(width, height, lifespan, Colors.LightOrange, 0.4, positionConnector).UsingRotationConnector(rotationConnextor));
+                                }
+                            }
+                            break;
+                        default:
+                            break;
                     }
                 }
                 break;

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/GreerTheBlightbringer.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/GreerTheBlightbringer.cs
@@ -495,7 +495,7 @@ internal class GreerTheBlightbringer : MountBalrior
         // Swepp the Mold / Rake the Rot - Indicator
         if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.GreerSweepTheMoldRakeTheRotIndicator, out var indicators))
         {
-            var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).Where(x =>
+            var casts = target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).Where(x =>
             x.SkillId == SweepTheMold || x.SkillId == SweepTheMold2 || x.SkillId == SweepTheMold3 ||
             x.SkillId == RakeTheRot || x.SkillId == RakeTheRot2 || x.SkillId == RakeTheRot3);
 
@@ -660,7 +660,7 @@ internal class GreerTheBlightbringer : MountBalrior
         // Stomp the Growth - Circle indicator
         if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.GreerStompTheGrowth, out var stompTheGrowth))
         {
-            var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.SkillId == StompTheGrowth || x.SkillId == StompTheGrowth2 || x.SkillId == StompTheGrowth3);
+            var casts = target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.SkillId == StompTheGrowth || x.SkillId == StompTheGrowth2 || x.SkillId == StompTheGrowth3);
             
             foreach (var cast in casts)
             {

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/EndOfDragons/XunlaiJadeJunkyard.cs
@@ -273,19 +273,21 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
 
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
+        long castDuration;
+        (long start, long end) lifespan;
 
         switch (target.ID)
         {
             case (int)TargetID.Ankka:
                 {
-                    var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
-                    var deathsEmbraces = casts.Where(x => x.SkillId == DeathsEmbraceSkill);
-                    int deathsEmbraceCastDuration = 10143;
-                    foreach (CastEvent deathEmbrace in deathsEmbraces)
-                    {
-                        int endTime = (int)deathEmbrace.Time + deathsEmbraceCastDuration;
+                    var casts = target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.SkillId == DeathsEmbraceSkill).ToList();
+                    castDuration = 10143;
 
-                        if (target.TryGetCurrentPosition(log, deathEmbrace.Time, out var ankkaPosition))
+                    foreach (CastEvent cast in casts)
+                    {
+                        long endTime = cast.Time + castDuration;
+
+                        if (target.TryGetCurrentPosition(log, cast.Time, out var ankkaPosition))
                         {
                             if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.DeathsEmbrace, out var deathsEmbraceEffects))
                             {
@@ -302,10 +304,10 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
                                     radius = 380;
                                 }
 
-                                var effects = deathsEmbraceEffects.Where(x => x.Time >= deathEmbrace.Time && x.Time <= deathEmbrace.EndTime);
+                                var effects = deathsEmbraceEffects.Where(x => x.Time >= cast.Time && x.Time <= cast.EndTime);
                                 foreach (EffectEvent effectEvt in effects)
                                 {
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, radius, (int)(effectEvt.Time - deathEmbrace.Time), effectEvt.Position);
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, radius, effectEvt.Time - cast.Time, effectEvt.Position);
                                 }
                             }
                             else
@@ -315,25 +317,25 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
                                 // Zone 1
                                 if (ankkaPosition.X > -6000 && ankkaPosition.X < -2500 && ankkaPosition.Y < 1000 && ankkaPosition.Y > -1000)
                                 {
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 500, delay, new(-3941.78f, 66.76819f, -3611.2f)); // CENTER
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 500, delay, new(-3941.78f, 66.76819f, -3611.2f)); // CENTER
                                 }
 
                                 // Zone 2
                                 if (ankkaPosition.X > 0 && ankkaPosition.X < 4000)
                                 {
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 340, delay, new(1663.69f, 1739.87f, -4639.695f)); // NW
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 340, delay, new(2563.689f, 1739.87f, -4664.611f)); // NE
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 340, delay, new(1663.69f, 839.8699f, -4640.633f)); // SW
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 340, delay, new(2563.689f, 839.8699f, -4636.368f)); // SE
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 340, delay, new(1663.69f, 1739.87f, -4639.695f)); // NW
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 340, delay, new(2563.689f, 1739.87f, -4664.611f)); // NE
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 340, delay, new(1663.69f, 839.8699f, -4640.633f)); // SW
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 340, delay, new(2563.689f, 839.8699f, -4636.368f)); // SE
                                 }
 
                                 // Zone 3
                                 if (ankkaPosition.Y > 4000 && ankkaPosition.Y < 6000)
                                 {
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 380, delay, new(-2547.61f, 5466.439f, -6257.504f)); // NW
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 380, delay, new(-1647.61f, 5466.439f, -6256.795f)); // NE
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 380, delay, new(-2547.61f, 4566.439f, -6256.799f)); // SW
-                                    AddDeathEmbraceDecoration(replay, (int)deathEmbrace.Time, deathsEmbraceCastDuration, 380, delay, new(-1647.61f, 4566.439f, -6257.402f)); // SE
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 380, delay, new(-2547.61f, 5466.439f, -6257.504f)); // NW
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 380, delay, new(-1647.61f, 5466.439f, -6256.795f)); // NE
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 380, delay, new(-2547.61f, 4566.439f, -6256.799f)); // SW
+                                    AddDeathEmbraceDecoration(replay, cast.Time, castDuration, 380, delay, new(-1647.61f, 4566.439f, -6257.402f)); // SE
                                 }
                             }
                         }
@@ -345,7 +347,7 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
                         {
                             if (log.CombatData.GetBuffRemoveAllData(DeathsHandSpreadBuff).Any(x => Math.Abs(x.Time - deathsHandEffect.Time) < ServerDelayConstant))
                             {
-                                AddDeathsHandDecoration(replay, deathsHandEffect.Position, (int)deathsHandEffect.Time, 3000, 300, 13000);
+                                AddDeathsHandDecoration(replay, deathsHandEffect.Position, deathsHandEffect.Time, 3000, 300, 13000);
                             }
                         }
                     }
@@ -357,14 +359,14 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
                             if (!log.CombatData.GetBuffRemoveAllData(DeathsHandSpreadBuff).Any(x => Math.Abs(x.Time - deathsHandEffect.Time) < ServerDelayConstant))
                             {
                                 // One also happens during death's embrace so we filter that one out
-                                if (!deathsEmbraces.Any(x => x.Time <= deathsHandEffect.Time && x.Time + deathsEmbraceCastDuration >= deathsHandEffect.Time))
+                                if (!casts.Any(x => x.Time <= deathsHandEffect.Time && x.Time + castDuration >= deathsHandEffect.Time))
                                 {
-                                    AddDeathsHandDecoration(replay, deathsHandEffect.Position, (int)deathsHandEffect.Time, 3000, 380, 1000);
+                                    AddDeathsHandDecoration(replay, deathsHandEffect.Position, deathsHandEffect.Time, 3000, 380, 1000);
                                 }
                             }
                             else if (log.FightData.IsCM)
                             {
-                                AddDeathsHandDecoration(replay, deathsHandEffect.Position, (int)deathsHandEffect.Time, 3000, 380, 33000);
+                                AddDeathsHandDecoration(replay, deathsHandEffect.Position, deathsHandEffect.Time, 3000, 380, 33000);
                             }
                         }
                     }
@@ -376,73 +378,89 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
                 break;
 
             case (int)TargetID.KraitsHallucination:
-                // Wall of Fear
-                long firstMovementTime = target.FirstAware + 2550;
-                uint kraitsRadius = 420;
-
-                replay.Decorations.Add(new CircleDecoration(kraitsRadius, (target.FirstAware, firstMovementTime), Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(firstMovementTime));
-                replay.Decorations.Add(new CircleDecoration(kraitsRadius, (firstMovementTime, target.LastAware), Colors.Red, 0.2, new AgentConnector(target)));
+                {
+                    // Wall of Fear
+                    long firstMovementTime = target.FirstAware + 2550;
+                    uint kraitsRadius = 420;
+                    var agentConnector = new AgentConnector(target);
+                    replay.Decorations.Add(new CircleDecoration(kraitsRadius, (target.FirstAware, firstMovementTime), Colors.Orange, 0.2, agentConnector).UsingGrowingEnd(firstMovementTime));
+                    replay.Decorations.Add(new CircleDecoration(kraitsRadius, (firstMovementTime, target.LastAware), Colors.Red, 0.2, agentConnector));
+                }
                 break;
 
             case (int)TargetID.LichHallucination:
-                // Terrifying Apparition
-                long awareTime = target.FirstAware + 1000;
-                uint lichRadius = 280;
-
-                replay.Decorations.Add(new CircleDecoration(lichRadius, (target.FirstAware, awareTime), Colors.Orange, 0.2, new AgentConnector(target)).UsingGrowingEnd(awareTime));
-                replay.Decorations.Add(new CircleDecoration(lichRadius, (awareTime, target.LastAware), Colors.Red, 0.2, new AgentConnector(target)));
+                {
+                    // Terrifying Apparition
+                    long awareTime = target.FirstAware + 1000;
+                    uint lichRadius = 280;
+                    var agentConnector = new AgentConnector(target);
+                    replay.Decorations.Add(new CircleDecoration(lichRadius, (target.FirstAware, awareTime), Colors.Orange, 0.2, agentConnector).UsingGrowingEnd(awareTime));
+                    replay.Decorations.Add(new CircleDecoration(lichRadius, (awareTime, target.LastAware), Colors.Red, 0.2, agentConnector));
+                }
                 break;
 
             case (int)TargetID.QuaggansHallucinationNM:
                 {
-                    var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
-                    var waveOfTormentNM = casts.Where(x => x.SkillId == WaveOfTormentNM);
-                    foreach (CastEvent c in waveOfTormentNM)
+                    foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                     {
-                        int castTime = 2800;
-                        uint radius = 300;
-                        int endTime = (int)c.Time + castTime;
-                        replay.Decorations.AddWithGrowing(new CircleDecoration(radius, (c.Time, endTime), Colors.Orange, 0.2, new AgentConnector(target)), endTime);
+                        switch (cast.SkillId)
+                        {
+                            // Wave of Torment - Circle explosion around Quaggan
+                            case WaveOfTormentNM:
+                                castDuration = 2800;
+                                lifespan = (cast.Time, cast.Time + castDuration);
+                                replay.Decorations.AddWithGrowing(new CircleDecoration(300, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), lifespan.end);
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
                 break;
 
             case (int)TargetID.QuaggansHallucinationCM:
                 {
-                    var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
-                    var waveOfTormentCM = casts.Where(x => x.SkillId == WaveOfTormentCM);
-                    foreach (CastEvent c in waveOfTormentCM)
+                    foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                     {
-                        int castTime = 5600;
-                        uint radius = 450;
-                        int endTime = (int)c.Time + castTime;
-                        replay.Decorations.AddWithGrowing(new CircleDecoration(radius, (c.Time, endTime), Colors.Orange, 0.2, new AgentConnector(target)), endTime);
+                        switch (cast.SkillId)
+                        {
+                            // Wave of Torment - Circle explosion around Quaggan
+                            case WaveOfTormentCM:
+                                castDuration = 5600;
+                                lifespan = (cast.Time, cast.Time + castDuration);
+                                replay.Decorations.AddWithGrowing(new CircleDecoration(450, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), lifespan.end);
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
                 break;
 
             case (int)TargetID.ZhaitansReach:
                 {
-                    var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
-                    // Thrash - Circle that pulls in
-                    var thrash = casts.Where(x => x.SkillId == ZhaitansReachThrashXJJ1 || x.SkillId == ZhaitansReachThrashXJJ2);
-                    foreach (CastEvent c in thrash)
+                    foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
                     {
-                        int castTime = 1900;
-                        int endTime = (int)c.Time + castTime;
-                        replay.Decorations.AddWithGrowing(new DoughnutDecoration(300, 500, (c.Time, endTime), Colors.Orange, 0.2, new AgentConnector(target)), endTime);
-                    }
-                    // Ground Slam - AoE that knocks out
-                    var groundSlam = casts.Where(x => x.SkillId == ZhaitansReachGroundSlam || x.SkillId == ZhaitansReachGroundSlamXJJ);
-                    foreach (CastEvent c in groundSlam)
-                    {
-                        int castTime = 0;
-                        uint radius = 400;
-                        int endTime = 0;
-                        // 66534 -> Fast AoE -- 66397 -> Slow AoE
-                        if (c.SkillId == ZhaitansReachGroundSlam) { castTime = 800; } else if (c.SkillId == ZhaitansReachGroundSlamXJJ) { castTime = 2500; }
-                        endTime = (int)c.Time + castTime;
-                        replay.Decorations.AddWithGrowing(new CircleDecoration(radius, (c.Time, endTime), Colors.Orange, 0.2, new AgentConnector(target)), endTime);
+                        switch (cast.SkillId)
+                        {
+                            // Thrash - Circle that pulls in
+                            case ZhaitansReachThrashXJJ1:
+                            case ZhaitansReachThrashXJJ2:
+                                castDuration = 1900;
+                                lifespan = (cast.Time, cast.Time + castDuration);
+                                replay.Decorations.AddWithGrowing(new DoughnutDecoration(300, 500, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), lifespan.end);
+                                break;
+                            // Ground Slam - AoE that knocks out
+                            case ZhaitansReachGroundSlam:
+                            case ZhaitansReachGroundSlamXJJ:
+                                // 66534 -> Fast AoE -- 66397 -> Slow AoE
+                                castDuration = cast.SkillId == ZhaitansReachGroundSlam ? 800 : 2500;
+                                lifespan = (cast.Time, cast.Time + castDuration);
+                                replay.Decorations.AddWithGrowing(new CircleDecoration(400, lifespan, Colors.Orange, 0.2, new AgentConnector(target)), lifespan.end);
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
                 break;
@@ -481,7 +499,7 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
                     {
                         if (p.TryGetCurrentPosition(log, segment.End, out var playerPosition))
                         {
-                            AddDeathsHandDecoration(replay, playerPosition, (int)segment.End, 3000, deathsHandRadius, deathsHandDuration);
+                            AddDeathsHandDecoration(replay, playerPosition, segment.End, 3000, deathsHandRadius, deathsHandDuration);
                         }
                     }
                 }
@@ -498,23 +516,23 @@ internal class XunlaiJadeJunkyard : EndOfDragonsStrike
         replay.Decorations.AddTetherByThirdPartySrcBuff(log, p, FixatedAnkkaKainengOverlook, (int)TargetID.Ankka, (int)TargetID.ReanimatedHatred, Colors.Magenta, 0.5);
     }
 
-    private static void AddDeathsHandDecoration(CombatReplay replay, Vector3 position, int start, int delay, uint radius, int duration)
+    private static void AddDeathsHandDecoration(CombatReplay replay, Vector3 position, long start, int delay, uint radius, int duration)
     {
-        int deathHandGrowStart = start;
-        int deathHandGrowEnd = deathHandGrowStart + delay;
+        (long start, long end) lifespan = (start, start + delay);
+        (long start, long end) lifespanAoE = (lifespan.end, lifespan.start + duration);
+        var positionConnector = new PositionConnector(position);
         // Growing AoE
-        replay.Decorations.AddWithGrowing(new CircleDecoration(radius, (deathHandGrowStart, deathHandGrowEnd), Colors.Orange, 0.2, new PositionConnector(position)), deathHandGrowEnd);
+        replay.Decorations.AddWithGrowing(new CircleDecoration(radius, lifespan, Colors.Orange, 0.2, positionConnector), lifespan.end);
         // Damaging AoE
-        int AoEStart = deathHandGrowEnd;
-        int AoEEnd = AoEStart + duration;
-        replay.Decorations.AddWithBorder(new CircleDecoration(radius, (AoEStart, AoEEnd), "rgba(0, 100, 0, 0.3)", new PositionConnector(position)), Colors.Red, 0.4);
+        replay.Decorations.AddWithBorder(new CircleDecoration(radius, lifespanAoE, Colors.DarkGreen, 0.3, positionConnector), Colors.Red, 0.4);
     }
 
-    private static void AddDeathEmbraceDecoration(CombatReplay replay, int startCast, int durationCast, uint radius, int delay, Vector3 position)
+    private static void AddDeathEmbraceDecoration(CombatReplay replay, long start, long duration, uint radius, long delay, Vector3 position)
     {
-        int endTime = startCast + durationCast;
-        var connector = new PositionConnector(position);
-        replay.Decorations.Add(new CircleDecoration(radius, (startCast, startCast + delay), Colors.Orange, 0.2, connector).UsingGrowingEnd(startCast + delay));
-        replay.Decorations.Add(new CircleDecoration(radius, (startCast + delay, endTime), Colors.Red, 0.2, connector));
+        (long start, long end) lifespan = (start, start + delay);
+        (long start, long end) lifespanAoE = (lifespan.end, lifespan.start + duration);
+        var positionConnector = new PositionConnector(position);
+        replay.Decorations.Add(new CircleDecoration(radius, lifespan, Colors.Orange, 0.2, positionConnector).UsingGrowingEnd(lifespan.end));
+        replay.Decorations.Add(new CircleDecoration(radius, lifespanAoE, Colors.Red, 0.2, positionConnector));
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
@@ -88,6 +88,8 @@ internal class CosmicObservatory : SecretOfTheObscureStrike
         switch (target.ID)
         {
             case (int)TargetID.Dagda:
+                var demonicBlasts = casts.Where(x => x.SkillId == DemonicBlast);
+
                 foreach (CastEvent cast in casts)
                 {
                     switch (cast.SkillId)
@@ -131,7 +133,7 @@ internal class CosmicObservatory : SecretOfTheObscureStrike
                             // Before then, the mechanic would continue during the phase and shoot.
                             if (log.LogData.GW2Build >= GW2Builds.DagdaNMHPChangedAndCMRelease)
                             {
-                                foreach (CastEvent demonicBlastCast in casts.Where(x => x.SkillId == DemonicBlast))
+                                foreach (CastEvent demonicBlastCast in demonicBlasts)
                                 {
                                     if (lifespan.start < demonicBlastCast.Time && lifespan.end > demonicBlastCast.Time)
                                     {

--- a/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Strikes/SotO/CosmicObservatory.cs
@@ -82,78 +82,76 @@ internal class CosmicObservatory : SecretOfTheObscureStrike
 
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
-        var casts = target.GetCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd);
+        (long start, long end) lifespan;
+        var casts = target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd).ToList();
 
         switch (target.ID)
         {
             case (int)TargetID.Dagda:
-                var phaseBuffs = target.GetBuffStatus(log, DagdaDuringPhase75_50_25, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
-
-                // Red AoE during 75-50-25 % phases
-                var demonicBlasts = casts.Where(x => x.SkillId == DemonicBlast);
-                foreach (CastEvent cast in demonicBlasts)
+                foreach (CastEvent cast in casts)
                 {
-                    // Dagda uses Demonic Blast at 90% but she will not spawn the red pushback AoE
-                    // We check if she has gained the buff to be sure that the phase has started.
-                    var phaseBuff = phaseBuffs.Where(x => x.Start >= cast.Time).FirstOrNull();
-                    if (phaseBuff is null || Math.Abs(cast.Time - phaseBuff.Value.Start) > 4000)
+                    switch (cast.SkillId)
                     {
-                        continue;
-                    }
-                    // Hardcoded positional value, Dagda isn't in the center but the AoE is
-                    var connector = new PositionConnector(new(305.26892f, 920.6105f, -5961.992f));
-                    var circle = new CircleDecoration(800, (cast.Time, phaseBuff.Value.End), Colors.Red, 0.4, connector);
-                    replay.Decorations.Add(circle);
-                }
-
-                //
-                var planetCrashes = casts.Where(x => x.SkillId == PlanetCrashSkill);
-                foreach (CastEvent c in planetCrashes)
-                {
-                    replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (c.Time, c.EndTime), Colors.Red, 0.6, Colors.Black, 0.2, [(c.Time, 0), (c.Time + 10000, 100)], new AgentConnector(target))
-                        .UsingRotationConnector(new AngleConnector(180)));
-                }
-
-                // Spinning nebula
-                var spinningNebulas = casts.Where(x => x.SkillId == SpinningNebulaCentral || x.SkillId == SpinningNebulaWithTeleport);
-                foreach (CastEvent cast in spinningNebulas)
-                {
-                    (long, long) lifespan = (cast.Time, cast.Time + cast.ActualDuration);
-                    var connector = new AgentConnector(target);
-                    var circle = new CircleDecoration(300, lifespan, "rgba(0, 191, 255, 0.2)", connector);
-                    replay.Decorations.AddWithGrowing(circle, lifespan.Item2);
-                }
-
-                // Shooting Stars - Green Arrow
-                var shootingStars = casts.Where(x => x.SkillId == ShootingStars);
-                foreach (CastEvent cast in shootingStars)
-                {
-                    uint length = 1500;
-                    uint width = 100;
-                    int castDuration = 6700;
-                    (long, long) lifespan = (cast.Time, cast.Time + castDuration);
-
-                    // The mechanic gets cancelled during the intermission phases since the CM release.
-                    // Before then, the mechanic would continue during the phase and shoot.
-                    if (log.LogData.GW2Build >= GW2Builds.DagdaNMHPChangedAndCMRelease)
-                    {
-                        foreach (CastEvent demonicBlastCast in demonicBlasts)
-                        {
-                            if (lifespan.Item1 < demonicBlastCast.Time && lifespan.Item2 > demonicBlastCast.Time)
+                        // Demonic Blast - Red AoE during 75-50-25 % phases
+                        case DemonicBlast:
+                            var phaseBuffs = target.GetBuffStatus(log, DagdaDuringPhase75_50_25, log.FightData.FightStart, log.FightData.FightEnd).Where(x => x.Value > 0);
+                            // Dagda uses Demonic Blast at 90% but she will not spawn the red pushback AoE
+                            // We check if she has gained the buff to be sure that the phase has started.
+                            var phaseBuff = phaseBuffs.Where(x => x.Start >= cast.Time).FirstOrNull();
+                            if (phaseBuff is null || Math.Abs(cast.Time - phaseBuff.Value.Start) > 4000)
                             {
-                                lifespan.Item2 = demonicBlastCast.Time;
-                                break;
+                                continue;
                             }
-                        }
-                    }
+                            // Hardcoded positional value, Dagda isn't in the center but the AoE is
+                            lifespan = (cast.Time, phaseBuff.Value.End);
+                            var connector = new PositionConnector(new(305.26892f, 920.6105f, -5961.992f));
+                            var circle = new CircleDecoration(800, lifespan, Colors.Red, 0.4, connector);
+                            replay.Decorations.Add(circle);
+                            break;
+                        // Planet Crash - Breakbar
+                        case PlanetCrashSkill:
+                            lifespan = (cast.Time, cast.EndTime);
+                            replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, lifespan, Colors.Red, 0.6, Colors.Black, 0.2, [(cast.Time, 0), (cast.Time + 10000, 100)], new AgentConnector(target))
+                                .UsingRotationConnector(new AngleConnector(180)));
+                            break;
+                        // Spinning Nebula
+                        case SpinningNebulaCentral:
+                        case SpinningNebulaWithTeleport:
+                            lifespan = (cast.Time, cast.Time + cast.ActualDuration);
+                            replay.Decorations.AddWithGrowing(new CircleDecoration(300, lifespan, "rgba(0, 191, 255, 0.2)", new AgentConnector(target)), lifespan.end);
+                            break;
+                        // Shooting Stars - Green Arrow
+                        case ShootingStars:
+                            uint length = 1500;
+                            uint width = 100;
+                            int castDuration = 6700;
+                            lifespan = (cast.Time, cast.Time + castDuration);
 
-                    // Find the targeted player
-                    Player? player = log.PlayerList.FirstOrDefault(x => x.HasBuff(log, ShootingStarsTargetBuff, cast.Time, ServerDelayConstant));
-                    if (player != null)
-                    {
-                        var rotation = new AgentFacingAgentConnector(target, player);
-                        var connector = (AgentConnector)new AgentConnector(target).WithOffset(new(length / 2, 0, 0), true);
-                        replay.Decorations.Add(new RectangleDecoration(length, width, lifespan, Colors.DarkGreen, 0.4, connector).UsingRotationConnector(rotation));
+                            // The mechanic gets cancelled during the intermission phases since the CM release.
+                            // Before then, the mechanic would continue during the phase and shoot.
+                            if (log.LogData.GW2Build >= GW2Builds.DagdaNMHPChangedAndCMRelease)
+                            {
+                                foreach (CastEvent demonicBlastCast in casts.Where(x => x.SkillId == DemonicBlast))
+                                {
+                                    if (lifespan.start < demonicBlastCast.Time && lifespan.end > demonicBlastCast.Time)
+                                    {
+                                        lifespan.end = demonicBlastCast.Time;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            // Find the targeted player
+                            Player? player = log.PlayerList.FirstOrDefault(x => x.HasBuff(log, ShootingStarsTargetBuff, cast.Time, ServerDelayConstant));
+                            if (player != null)
+                            {
+                                var rotation = new AgentFacingAgentConnector(target, player);
+                                var agentConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(length / 2, 0, 0), true);
+                                replay.Decorations.Add(new RectangleDecoration(length, width, lifespan, Colors.DarkGreen, 0.4, agentConnector).UsingRotationConnector(rotation));
+                            }
+                            break;
+                        default:
+                            break;
                     }
                 }
                 break;
@@ -183,7 +181,7 @@ internal class CosmicObservatory : SecretOfTheObscureStrike
 
         // Tethering the player to the Soul Feast.
         // The buff is applied by Dagda to the player and the Soul Feast follows that player until death.
-        var buffAppliesAll = log.CombatData.GetBuffData(Revealed).OfType<BuffApplyEvent>().Where(x => x.CreditedBy.IsSpecies(TargetID.Dagda));
+        var buffAppliesAll = log.CombatData.GetBuffData(Revealed).OfType<BuffApplyEvent>().Where(x => x.CreditedBy.IsSpecies(TargetID.Dagda)).ToList();
         var buffAppliesPlayer = buffAppliesAll.Where(x => x.To == p.AgentItem);
         var agentsToTether = log.AgentData.GetNPCsByID(TargetID.SoulFeast);
 


### PR DESCRIPTION
# Scope:

- Remove multiple iterations of the IEnumerable returned by GetCastEvents
- - If multiple iterations are necessary due to how the Combat Replay works, cast to ToList(), eg Dhuum, Dagda, Cerus
- Remove unnecessary iterations of Instant Casts by using the new API GetAnimatedCastEvents
- - This mostly affects raid encounters with aura damage. For a random Vale Guardian log, out of 92 casts, 50 were aura damage, now only 42 will be iterated.

The main part of the rework is the introduction of a switch to iterate GetAnimatedCastEvents only once.

```C#
foreach (CastEvent cast in target.GetAnimatedCastEvents(log, log.FightData.FightStart, log.FightData.FightEnd))
{
    switch (cast.SkillId)
    {
        case SkillId1:
            // Decoration Creation
            break;
        case SkillId2:
            // Decoration Creation
            break;
        default:
            break;
    }
}
```

## Other:

- Cleaned up Combat Replays overall, compacted code and cleaned up a lot of unnecessary (int)cast.Time that were leftover from when decorations accepted int instead of long.
- Transitioned some colors from string to the Colors class