### PR TITLE
Updated mechanics for ura and decima, renamed unstrippable boons

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -423,9 +423,9 @@ internal static class EncounterBuffs
             new Buff("Achievement Eligibility: This Bug Can Dance", AchievementEligibilityThisBugCanDance, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             // Greer
             new Buff("Empowered (Greer)", EmpoweredGreer, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.EmpoweredMursaarOverseer),
-            new Buff("Might (Greer)", MightUnstrippable, Source.FightSpecific, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.Might),
-            new Buff("Protection (Greer)", ProtectionUnstrippable, Source.FightSpecific, BuffStackType.Queue, 9, BuffClassification.Other, BuffImages.Protection),
-            new Buff("Resolution (Greer)", ResolutionGreer, Source.FightSpecific, BuffStackType.Queue, 99, BuffClassification.Other, BuffImages.Resolution),
+            new Buff("Might (Unstrippable)", MightUnstrippable, Source.FightSpecific, BuffStackType.Stacking, 25, BuffClassification.Other, BuffImages.Might),
+            new Buff("Protection (Unstrippable)", ProtectionUnstrippable, Source.FightSpecific, BuffStackType.Queue, 9, BuffClassification.Other, BuffImages.Protection),
+            new Buff("Resolution (Unstrippable)", ResolutionUnstrippable, Source.FightSpecific, BuffStackType.Queue, 99, BuffClassification.Other, BuffImages.Resolution),
             new Buff("Damage Immunity 1", DamageImmunity1, Source.FightSpecific, BuffClassification.Other, BuffImages.DefensiveInspiration),
             new Buff("Damage Immunity 2", DamageImmunity2, Source.FightSpecific, BuffClassification.Other, BuffImages.DefensiveInspiration),
             new Buff("Damage Immunity 3", DamageImmunity3, Source.FightSpecific, BuffClassification.Other, BuffImages.DefensiveInspiration),

--- a/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/EncounterDamageModifiers.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/EncounterDamageModifiers.cs
@@ -140,7 +140,7 @@ internal static class EncounterDamageModifiers
                 return !VulnerabilityAdditiveChecker(ahde, log, RisingPressure, 5);
             }),
         new BuffOnFoeDamageModifier(Mod_UnstrippableProtection, ProtectionUnstrippable, "Protection (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Strike, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Protection, DamageModifierMode.PvE),
-        new BuffOnFoeDamageModifier(Mod_UnstrippableResolution, ResolutionGreer, "Resolution (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Condition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Resolution, DamageModifierMode.PvE),
+        new BuffOnFoeDamageModifier(Mod_UnstrippableResolution, ResolutionUnstrippable, "Resolution (Unstrippable)", "-33%", DamageSource.All, -33.0, DamageType.Condition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Resolution, DamageModifierMode.PvE),
         // Enrages
         new BuffOnFoeDamageModifier(Mod_Enraged_inc25, Enraged_100_strike_25_reduc, "Enraged (-25%)", "-25%, stacks additively with Vulnerability", DamageSource.All, -25, DamageType.StrikeAndCondition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Enraged, DamageModifierMode.PvE).UsingGainAdjuster(VulnerabilityAdjuster),
         new BuffOnFoeDamageModifier(Mod_Enraged_inc50, Enraged_200_strike_50_reduc, "Enraged (-50%)", "-50%, stacks additively with Vulnerability", DamageSource.All, -50, DamageType.StrikeAndCondition, DamageType.All, Source.FightSpecific, ByPresence, BuffImages.Enraged, DamageModifierMode.PvE).UsingGainAdjuster(VulnerabilityAdjuster),

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/DecimaTheStormsinger.cs
@@ -27,6 +27,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 new PlayerDstEffectMechanic(EffectGUIDs.DecimaChorusOfThunderAoE, new MechanicPlotlySetting(Symbols.Circle, Colors.LightGrey), "ChorThun.T", "Targeted by Chorus of Thunder (Spreads)", "Chorus of Thunder Target", 0),
             ]),
             new PlayerDstHitMechanic([DiscordantThunderCM], new MechanicPlotlySetting(Symbols.Circle, Colors.Orange), "DiscThun.H", "Hit by Discordant Thunder", "Discordant Thunder Hit", 0),
+            new PlayerDstHitMechanic(HarmoniousThunder, new MechanicPlotlySetting(Symbols.Circle, Colors.Yellow), "HarmThun.H", "Hit by Harmonious Thunder", "Harmonious Thunder Hit", 0),
             new MechanicGroup([
                 new PlayerDstHitMechanic([SeismicCrashDamage, SeismicCrashDamageCM, SeismicCrashDamageCM2], new MechanicPlotlySetting(Symbols.Hourglass, Colors.White), "SeisCrash.H", "Hit by Seismic Crash (Concentric Rings)", "Seismic Crash Hit", 0),
                 new PlayerDstHitMechanic([SeismicCrashDamage, SeismicCrashDamageCM, SeismicCrashDamageCM2], new MechanicPlotlySetting(Symbols.Hourglass, Colors.DarkWhite), "SeisCrash.CC", "CC by Seismic Crash (Concentric Rings)", "Seismic Crash CC", 0)
@@ -79,7 +80,7 @@ internal class DecimaTheStormsinger : MountBalrior
                 new PlayerDstHitMechanic(Sparkwave, new MechanicPlotlySetting(Symbols.TriangleDown, Colors.LightOrange), "Sparkwave.H", "Hit by Sparkwave (Transcendent Boulders Cone)", "Sparkwave Hit", 0),
                 new PlayerDstHitMechanic(ChargedGround, new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.CobaltBlue), "CharGrnd.H", "Hit by Charged Ground (Transcendent Boulders AoEs)", "Charged Ground Hit", 0),
             ]),
-            new PlayerDstHitMechanic([FulgentFenceCM, FluxlanceFusilladeCM, FluxlanceSalvoCM1, FluxlanceSalvoCM2, FluxlanceSalvoCM3, FluxlanceSalvoCM4, FluxlanceSalvoCM5, ChorusOfThunderCM, DiscordantThunderCM], new MechanicPlotlySetting(Symbols.Pentagon, Colors.Lime), "BugDance.Achiv", "Achievement Elibigility: This Bug Can Dance", "Achiv: This Bug Can Dance", 0).UsingChecker((adhe, log) =>
+            new PlayerDstHitMechanic([FulgentFenceCM, FluxlanceFusilladeCM, FluxlanceSalvoCM1, FluxlanceSalvoCM2, FluxlanceSalvoCM3, FluxlanceSalvoCM4, FluxlanceSalvoCM5, ChorusOfThunderCM, DiscordantThunderCM, HarmoniousThunder], new MechanicPlotlySetting(Symbols.Pentagon, Colors.Lime), "BugDance.Achiv", "Achievement Elibigility: This Bug Can Dance", "Achiv: This Bug Can Dance", 0).UsingChecker((adhe, log) =>
             {
                 // If you are dead, lose the achievement
                 if (adhe.To.IsDead(log, log.FightData.FightStart, log.FightData.FightEnd))
@@ -111,7 +112,7 @@ internal class DecimaTheStormsinger : MountBalrior
 
                 // If you get hit by your own thunder, keep the achievement
                 // If you get hit by a thunder on another player or on a conduit, lose the achievement
-                long[] thunderIds = [ChorusOfThunderCM, DiscordantThunderCM];
+                long[] thunderIds = [ChorusOfThunderCM, DiscordantThunderCM, HarmoniousThunder];
                 var thunderTimes = damageTaken.Where(x => (thunderIds.Contains(x.SkillId)) && x.HasHit).Select(x => x.Time).OrderBy(x => x);
                 foreach (long thunderTime in thunderTimes)
                 {

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/UraTheSteamshrieker.cs
@@ -19,50 +19,61 @@ internal class UraTheSteamshrieker : MountBalrior
 {
     public UraTheSteamshrieker(int triggerID) : base(triggerID)
     {
-        MechanicList.Add(new MechanicGroup([      
+        MechanicList.Add(new MechanicGroup([
+            // Sulfuric Geysers
             new MechanicGroup([
+                new PlayerDstHitMechanic(SulfuricEruption, new MechanicPlotlySetting(Symbols.StarOpen, Colors.LightBlue), "SulfErup.H", "Hit by Sulfuric Eruption (Geyser Spawn)", "Sulfuric Eruption Hit", 0),
                 new PlayerDstHitMechanic(EruptionVent, new MechanicPlotlySetting(Symbols.TriangleSW, Colors.DarkPink), "ErupVent.H", "Hit by Eruption Vent (Geyser Shockwave)", "Eruption Vent Hit", 0),
-                new PlayerDstHitMechanic(EruptionVent, new MechanicPlotlySetting(Symbols.TriangleSW, Colors.Pink), "Achiv.Hop", "Achievement Eligibility: Hopscotch Master", "Achiv: Hopscotch Master", 0)
+                new PlayerDstEffectMechanic([EffectGUIDs.UraSulfuricGeyserTarget, EffectGUIDs.UraSulfuricGeyserTargetCM], new MechanicPlotlySetting(Symbols.Hexagon, Colors.Blue), "SulfGey.T", "Targeted by Sulfuric Geyser (Spawn)", "Sulfuric Geyser Spawn Target", 0),
+                new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, new MechanicPlotlySetting(Symbols.CircleCrossOpen, Colors.White), "Dispel.Sulf", "Dispelled Sulfuric Geyser (Removed Hardened Crust)", "Dispelled Sulfuric Geyser", 0)
+                    .UsingChecker((brae, log) => brae.To.IsSpecies(TargetID.SulfuricGeyser)),
+                new PlayerDstHitMechanic([EruptionVent, SulfuricEruption], new MechanicPlotlySetting(Symbols.TriangleSW, Colors.Pink), "Achiv.Hop", "Achievement Eligibility: Hopscotch Master", "Achiv: Hopscotch Master", 0)
                     .UsingEnable(log => log.FightData.IsCM || log.FightData.IsLegendaryCM).UsingAchievementEligibility(true),
             ]),
+            // Titanspawn Geysers
             new MechanicGroup([
                 new PlayerDstHitMechanic(CreateTitanspawnGeyser, new MechanicPlotlySetting(Symbols.CircleXOpen, Colors.Orange), "UraJump.H", "Hit by Create Titanspawn Geyser AoE (Ura jump in place)", "Create Titanspawn Geyser Hit", 0),
                 new PlayerDstHitMechanic(CreateTitanspawnGeyser, new MechanicPlotlySetting(Symbols.CircleXOpen, Colors.LightOrange), "UraJump.CC", "CC by Create Titanspawn Geyser AoE (Ura jump in place)", "Create Titanspawn Geyser CC", 0)
                     .UsingChecker((hde, log) => hde.To.HasBuff(log, Stability, hde.Time, ServerDelayConstant)),
-            ]),
-            new MechanicGroup([
                 new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, new MechanicPlotlySetting(Symbols.CircleX, Colors.White), "Dispel.Titn", "Dispelled Titanspawn Geyser (Removed Hardened Crust)", "Dispelled Titanspawn Geyser", 0)
                     .UsingChecker((brae, log) => brae.To.IsSpecies(TargetID.TitanspawnGeyser)),
             ]),
+            // Toxic Geysers
             new MechanicGroup([
                 new PlayerDstHitMechanic([ToxicGeyser1, ToxicGeyser2, ToxicGeyserCM], new MechanicPlotlySetting(Symbols.StarSquare, Colors.GreenishYellow), "ToxGeyser.H", "Hit by Toxic Geyser", "Toxic Geyser Hit", 0),
                 new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, new MechanicPlotlySetting(Symbols.CircleCross, Colors.White), "Dispel.Toxc", "Dispelled Toxic Geyser (Removed Hardened Crust)", "Dispelled Toxic Geyser", 0)
                     .UsingChecker((brae, log) => brae.To.IsSpecies(TargetID.ToxicGeyser)),
             ]),
+            // Ura
             new MechanicGroup([
-                new PlayerDstEffectMechanic([EffectGUIDs.UraSulfuricGeyserTarget, EffectGUIDs.UraSulfuricGeyserTargetCM], new MechanicPlotlySetting(Symbols.Hexagon, Colors.Blue), "SulfGey.T", "Targeted by Sulfuric Geyser (Spawn)", "Sulfuric Geyser Spawn Target", 0),
-                new PlayerDstHitMechanic(SulfuricEruption, new MechanicPlotlySetting(Symbols.StarOpen, Colors.LightBlue), "SulfErup.H", "Hit by Sulfuric Eruption (Geyser Spawn)", "Sulfuric Eruption Hit", 0),
-                new PlayerSrcBuffRemoveFromMechanic(HardenedCrust, new MechanicPlotlySetting(Symbols.CircleCrossOpen, Colors.White), "Dispel.Sulf", "Dispelled Sulfuric Geyser (Removed Hardened Crust)", "Dispelled Sulfuric Geyser", 0)
-                    .UsingChecker((brae, log) => brae.To.IsSpecies(TargetID.SulfuricGeyser)),
+                new PlayerDstHitMechanic(ScaldingAura, new MechanicPlotlySetting(Symbols.Pentagon, Colors.LightPink), "ScalAura.H", "Hit by Scalding Aura (Ura's Hitbox)", "Scalding Aura Hit", 0),
+                new PlayerDstBuffApplyMechanic(SulfuricAcid, new MechanicPlotlySetting(Symbols.TriangleNEOpen, Colors.Purple), "SulfAcid.A", "Received Sulfuric Acid", "Sulfuric Acid Application", 0),
+                new PlayerDstHitMechanic(SulfuricFroth, new MechanicPlotlySetting(Symbols.TriangleLeft, Colors.LightGrey), "SulfFroth.H", "Hit by Sulfuric Froth (Acid Projectile from Ura)", "Sulfuric Froth Hit", 0),
             ]),
+            // Steam Prison
             new MechanicGroup([
                 new PlayerDstHitMechanic(SteamPrison, new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.Orange), "Ste.Prison.H", "Hit by Steam Prison", "Steam Prison Hit", 0),
                 new PlayerDstEffectMechanic(EffectGUIDs.UraSteamPrisonIndicator, new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.LightOrange), "Ste.Prison.T", "Targeted by Steam Prison (Ring)", "Steam Prison Target", 0),
             ]),
-            new PlayerDstHitMechanic(ScaldingAura, new MechanicPlotlySetting(Symbols.Pentagon, Colors.LightPink), "ScalAura.H", "Hit by Scalding Aura (Ura's Hitbox)", "Scalding Aura Hit", 0),
-            new PlayerDstBuffApplyMechanic(SulfuricAcid, new MechanicPlotlySetting(Symbols.TriangleNEOpen, Colors.Purple), "SulfAcid.A", "Received Sulfuric Acid", "Sulfuric Acid Application", 0),
-            new PlayerDstHitMechanic(SulfuricFroth, new MechanicPlotlySetting(Symbols.TriangleLeft, Colors.LightGrey), "SulfFroth.H", "Hit by Sulfuric Froth (Acid Projectile from Ura)", "Sulfuric Froth Hit", 0),
-            new PlayerDstHitMechanic(BreakingGround, new MechanicPlotlySetting(Symbols.Star, Colors.Red), "BreGround.H", "Hit by Breaking Ground (8 pointed star)", "Breaking Ground Hit", 0),
+            // Pressure Blast
             new MechanicGroup([
                 new PlayerDstBuffApplyMechanic(PressureBlastTargetBuff, new MechanicPlotlySetting(Symbols.CircleOpen, Colors.LightBlue), "Pres.Blast.T", "Targeted by Pressure Blast (Bubbles)", "Pressure Blast Target", 0),
                 new PlayerDstBuffApplyMechanic(PressureBlastBubbleBuff, new MechanicPlotlySetting(Symbols.CircleOpen, Colors.Blue), "Pres.Blast.Up", "Lifted in a bubble by Pressure Blast", "Pressure Blast Bubble", 0),
                 new PlayerSrcBuffRemoveFromMechanic(PressureBlastBubbleBuff, new MechanicPlotlySetting(Symbols.CircleOpen, Colors.White), "Dispel.P", "Dispelled Player (Removed Pressure Blast)", "Dispelled Player", 0)
                     .UsingChecker((brae, log) => brae.To.IsPlayer),
             ]),
+            // Dispel
             new MechanicGroup([
                 new PlayerDstBuffApplyMechanic(Deterrence, new MechanicPlotlySetting(Symbols.Diamond, Colors.LightRed), "Pick-up Shard", "Picked up the Bloodstone Shard", "Bloodstone Shard Pick-up", 0),
                 new PlayerDstBuffApplyMechanic(BloodstoneSaturation, new MechanicPlotlySetting(Symbols.Diamond, Colors.DarkPurple), "Dispel", "Used Dispel (SAK)", "Used Dispel", 0),
             ]),
+            // Fumaroller
+            new MechanicGroup([
+                new PlayerDstHitMechanic(BreakingGround, new MechanicPlotlySetting(Symbols.Star, Colors.Red), "BreGround.H", "Hit by Breaking Ground (Fumaroller 8 pointed star)", "Breaking Ground Hit", 0),
+                new PlayerDstHitMechanic(MantleGrinder, new MechanicPlotlySetting(Symbols.HourglassOpen, Colors.DarkPurple), "MantGrind.H", "Hit by Mantle Grinder (Fumaroller Roll)", "Mantle Grinder Hit", 0),
+                new PlayerDstHitMechanic(FullSteam, new MechanicPlotlySetting(Symbols.Octagon, Colors.GreyishGreen), "FullSteam.H", "Hit by Full Steam (Fumaroller Dash)", "Full Steam Hit", 0),
+            ]),
+            // Ventshot
             new MechanicGroup([
                 new PlayerDstHitMechanic(PressureRelease, new MechanicPlotlySetting(Symbols.CircleOpenDot, Colors.CobaltBlue), "PresRel.H", "Hit by Pressure Release (Ventshot Jump AoE)", "Pressure Release Hit", 0),
                 new PlayerDstHitMechanic(ForcedEruption, new MechanicPlotlySetting(Symbols.PentagonOpen, Colors.Blue), "ForcErup.H", "Hit by Forced Eruption (Ventshot Homing Orb)", "Forced Eruption Hit", 0),

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -4719,6 +4719,7 @@ public static class SkillIDs
     public const long DecimaConduitWallBuffCM = 75479;
     public const long Sparkwave = 75484;
     public const long FulgentAuraTier2CM = 75486;
+    public const long HarmoniousThunder = 75518;
     public const long RipplesOfRotCM2 = 75519;
     public const long ChargedLeapW8 = 75520;
     public const long ChorusOfThunderCM = 75523;
@@ -4759,7 +4760,7 @@ public static class SkillIDs
     public const long RelicOfTheHolosmith = 75748;
     public const long EnfeeblingMiasma3 = 75749;
     public const long DamageImmunity3 = 75754;
-    public const long ResolutionGreer = 75755;
+    public const long ResolutionUnstrippable = 75755;
     public const long DecimaConduitWallWarningBuffCM = 75763;
     public const long SeismicReposition2 = 75764;
     public const long SeismicCrashDamageCM2 = 75793;


### PR DESCRIPTION
- Renamed unstrippable Might, Protection and Resolution
- Added Harmonious Thunder mechanic to Decima
- Updated This Bug Can Dance eligibility to include Harmonious Thunder
- Fixed Hopscotch eligibility to include Sulfuric Eruption
- Added Full Steam and Mantle Grinder to mechanics for Ura
- Reordered and labeled Ura mechanics