### PR TITLE
Added various missing decorations

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -453,6 +453,7 @@ internal static class EncounterBuffs
             new Buff("Achievement Eligibility: No Geysers, No Problems", AchievementEligibilityNoGeysersNoProblems, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             new Buff("Achievement Eligibility: Hopscotch Master", AchievementEligibilityHopscotchMaster, Source.FightSpecific, BuffClassification.Other, BuffImages.AchievementEffect),
             new Buff("Toxic Buildup", ToxicBuildup, Source.FightSpecific, BuffStackType.Stacking, 20, BuffClassification.Other, BuffImages.Unknown),
+            new Buff("Acid Rain", AcidRain, Source.FightSpecific, BuffClassification.Other, BuffImages.ScaldingWater),
             //////////////////////////////////////////////
             // Fractals 
             new Buff("Rigorous Certainty", RigorousCertainty, Source.Common, BuffClassification.Defensive, BuffImages.DesertCarapace),

--- a/GW2EIEvtcParser/EIData/Colors.cs
+++ b/GW2EIEvtcParser/EIData/Colors.cs
@@ -56,6 +56,7 @@ internal static class Colors
     public static Color LightBrown = new(196, 164, 132);
     public static Color Brown = new(120, 100, 0);
     public static Color Chocolate = new(123, 63, 0);
+    public static Color DarkerLime = new(150, 255, 80);
     public static Color Lime = new(200, 255, 100);
     public static Color Green = new(0, 255, 0);
     public static Color GreenishYellow = new(220, 255, 0);

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W2/Slothasor.cs
@@ -187,10 +187,12 @@ internal class Slothasor : SalvationPass
                         // Tantrum - 3 sets ground AoEs
                         case TantrumSkill:
                             // Generic indicator of casting
-                            // TODO(Linka) @decorations: Add tantrum AoEs to Environment Decorations and lock this behind !log.CombatData.HasEffectData
-                            lifespan = (cast.Time, cast.EndTime);
-                            var tantrum = new CircleDecoration(300, lifespan, Colors.LightOrange, 0.4, new AgentConnector(target));
-                            replay.Decorations.AddWithFilledWithGrowing(tantrum.UsingFilled(false), true, lifespan.end);
+                            if (!log.CombatData.HasEffectData)
+                            {
+                                lifespan = (cast.Time, cast.EndTime);
+                                var tantrum = new CircleDecoration(300, lifespan, Colors.LightOrange, 0.4, new AgentConnector(target));
+                                replay.Decorations.AddWithFilledWithGrowing(tantrum.UsingFilled(false), true, lifespan.end);
+                            }
                             break;
                         // Spore Release - Shake
                         case SporeRelease:
@@ -210,6 +212,17 @@ internal class Slothasor : SalvationPass
                 {
                     replay.Decorations.Add(new OverheadProgressBarDecoration(CombatReplayOverheadProgressBarMajorSizeInPixel, (narcolepsy.Start, narcolepsy.End), Colors.LightBlue, 0.6, Colors.Black, 0.2, [(narcolepsy.Start, 0), (narcolepsy.Start + 120000, 100)], new AgentConnector(target))
                         .UsingRotationConnector(new AngleConnector(180)));
+                }
+
+                // Tantrum - Knockdown AoEs
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.SlothasorTantrum, out var tantrums))
+                {
+                    foreach (EffectEvent effect in tantrums)
+                    {
+                        lifespan = effect.ComputeLifespan(log, 2000);
+                        var circle = new CircleDecoration(100, lifespan, Colors.LightOrange, 0.1, new PositionConnector(effect.Position));
+                        replay.Decorations.Add(circle);
+                    }
                 }
                 break;
             case (int)TargetID.PoisonMushroom:

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/Escort.cs
@@ -321,6 +321,7 @@ internal class Escort : StrongholdOfTheFaithful
         return
         [
             new EffectCastFinder(OverHere, EffectGUIDs.EscortOverHere),
+            new DamageCastFinder(TeleportDisplacementField, TeleportDisplacementField).UsingICD(50),
         ];
     }
 }

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -557,6 +557,11 @@ public static class EffectGUIDs
     public static readonly GUID SabethaPlatformCrush = new("1EAC8EDCB57CDC4DB19DA7F2D37D25E8"); // 1000 duration - No Src - Platform debris falling
     public static readonly GUID SabethaFlakShot = new("1D17794F2428F344A5D9755AB8899633"); // 25000 duration - Src Sabetha
     public static readonly GUID SabethaSapperBombGroundAoE = new("09D5D14BE3AFEA48958B1A8D7634B08A"); // 1000 duration - No Src
+    // Slothasor
+    public static readonly GUID SlothasorTantrum = new("CAF62AE316C2D445A08D8E84C89027D2"); // 2000 duration - Src Slothasor
+    // Matthias
+    public static readonly GUID MatthiasShardsOfRageAoEs = new("0D2192849D53B4469F56B1C74542DBE9"); // 3000 duration - No Src
+    public static readonly GUID MatthiasWellOfTheProfane = new("9BEF037F1B8C2346B5F71A88128DF1A4"); // 90000 duration - Matthias Src
     // Escort Glenna
     public static readonly GUID EscortOverHere = new("64CD79C1A121EC42B1278DEF9280ED35");
     // Xera
@@ -585,6 +590,12 @@ public static class EffectGUIDs
     public static readonly GUID DeimosSoulFeast = new("1BBF189B7174604F822656C5A85FC0D6"); // Src Hands - 2000 duration - hand - reapplied each animation
     public static readonly GUID DeimosAnnihilateSliceIndicator = new("F5B44356708C9243BE2D67986FDD0CF4"); // Src Deimos - 1500 duration - Pizza slice indicator
     public static readonly GUID DeimosAnnihilateHit = new("D94547E5FC797B458BF25D06C8E32C68"); // Src Deimos - 1000 duration - Pizza slice hit
+    // Soulless Horror
+    public static readonly GUID SoullessHorrorSoulRift = new("AB9A517AE2F63B419522D57B7AD3B82F"); // 57000 duration - Src Volatile Soul - Tormented Dead death AoE
+    // River of Souls
+    public static readonly GUID RiverSoullessTorrentInnerPlayerAoE = new("301D9FC427E7BE4BAD4DBFA87D085B51"); // 3000 duration - Src River of Souls
+    public static readonly GUID RiverSoullessTorrentOuterPlayerAoE = new("B4C41DD0D494464B948532D9EA00D132"); // 4000 duration - Src River of Souls
+    public static readonly GUID RiverSoullessTorrentLightningStrikeDamage = new("E52B6BD6BE3A0243B5BD26A486C21CAD"); // 1000 duration - No Src No Dst
     // Broken King
     public static readonly GUID BrokenKingNumbingBreachIndicator = new("5341E83B29B534408E90DBE7BE6F452D");
     public static readonly GUID BrokenKingNumbingBreachDamage = new("1BF014091BFD1E40A11ED36B92601342");

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -2667,7 +2667,7 @@ public static class SkillIDs
     public const long FractalGod = 47222;
     public const long FractalSavant = 47248;
     public const long ExposedStatueOfDarkness = 47251;
-    public const long TimedBomb = 47258;
+    public const long SoullessTorrent = 47258;
     public const long LastGraspFate = 47278;
     public const long MistlockInstabilityToxicSickness = 47288;
     public const long HungeringMiasma = 47303;
@@ -2744,6 +2744,7 @@ public static class SkillIDs
     public const long DhuumShacklesBuff2 = 48591;
     public const long HowlingDeath = 48662;
     public const long DhuumPlayerToSoulTrackBuff = 48670; // Buff applied from the player to the soul gadget
+    public const long EnervatorDamageSkillToDesmina = 48730;
     public const long CullDamage = 48752;
     public const long CullSkill = 48758;
     public const long PutridBomb = 48760;
@@ -4578,6 +4579,7 @@ public static class SkillIDs
     public const long CageOfDecay = 74773;
     public const long FluxlanceTargetBuff1 = 74774;
     public const long Ejects = 74775;
+    public const long AcidRain = 74783;
     public const long TargetOrder3JW = 74789;
     public const long FluxNova = 74790;
     public const long NovaShield = 74791;

--- a/GW2EIEvtcParser/ParserHelpers/Images/BuffImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/BuffImages.cs
@@ -338,6 +338,7 @@ public static class BuffImages
     public const string FireEffect = "https://wiki.guildwars2.com/images/e/eb/Fire_%28effect%29.png";
     public const string SinisterThread = "https://wiki.guildwars2.com/images/d/d7/Sinister_Thread.png";
     public const string SonicOverload = "https://wiki.guildwars2.com/images/2/29/Sonic_Overload.png";
+    public const string ScaldingWater = "https://wiki.guildwars2.com/images/b/bc/Scalding_Water.png";
     // Fractal
     public const string GambitExhausted = "https://wiki.guildwars2.com/images/4/41/Gambit_Exhausted.png";
     public const string ReflectiveShielding = "https://wiki.guildwars2.com/images/c/c6/Reflective_Shielding.png";


### PR DESCRIPTION
## Slothasor
- Updated Tantrum progression bar to be only for logs without effect data
- Added Tantrum AoEs using effect data when available

## Matthias
- Updated Spirit and Tornado colors
- Added Shard of Rage AoEs
- Fixed progress bar for the wells being mispositioned if the player with Corruption took a portal
- Updated Well of the Profane to be using effect data when available

## Escort
- Added Teleport Displacement Field instant cast for McLeod

## Soulless Horror
- Updated Soul Rift (Tormented Dead AoE) to be using effect data when available
- Cleaned up GetEncounterMode

## River of Souls
- Updated TimeBomb description and SkillID name
- Added Bomb Shell and Tether damage hits to Desmina as mechanics
- Added Soulless Torrent player AoE & ground AoE
- Added damage tether between Enervator and Desmina

## Ura
- Added Acid Rain