### PR TITLE
Encounter infobox redesign & EvtcRecordingDuration addition

### DIFF
--- a/GW2EIBuilders/HtmlModels/LogDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/LogDataDto.cs
@@ -148,7 +148,7 @@ internal class LogDataDto
                 FightMode = "Story Mode";
                 break;
             case FightData.EncounterMode.Normal:
-                FightMode = log.FightData.Logic.GetInstanceBuffs(log).Where(x => x.buff.ID == Emboldened) != null ? "Emboldened Normal Mode" : "Normal Mode";
+                FightMode = log.FightData.Logic.GetInstanceBuffs(log).Any(x => x.buff.ID == Emboldened) ? "Emboldened Normal Mode" : "Normal Mode";
                 break;
             case FightData.EncounterMode.CM:
             case FightData.EncounterMode.CMNoName:

--- a/GW2EIBuilders/HtmlModels/LogDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/LogDataDto.cs
@@ -12,6 +12,7 @@ using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using Tracing;
 using static GW2EIEvtcParser.ParserHelper;
+using static GW2EIEvtcParser.SkillIDs;
 
 [assembly: InternalsVisibleTo("GW2EIParser.tst")]
 namespace GW2EIBuilders.HtmlModels;
@@ -146,14 +147,8 @@ internal class LogDataDto
             case FightData.EncounterMode.Story:
                 FightMode = "Story Mode";
                 break;
-            case FightData.EncounterMode.StoryCM:
-                FightMode = "Story Challenge Mode";
-                break;
-            case FightData.EncounterMode.NormalEmboldened:
-                FightMode = "Emboldened Normal Mode";
-                break;
             case FightData.EncounterMode.Normal:
-                FightMode = "Normal Mode";
+                FightMode = log.FightData.Logic.GetInstanceBuffs(log).Where(x => x.buff.ID == Emboldened) != null ? "Emboldened Normal Mode" : "Normal Mode";
                 break;
             case FightData.EncounterMode.CM:
             case FightData.EncounterMode.CMNoName:

--- a/GW2EIBuilders/HtmlModels/LogDataDto.cs
+++ b/GW2EIBuilders/HtmlModels/LogDataDto.cs
@@ -60,12 +60,16 @@ internal class LogDataDto
     public BarrierStatsExtension? BarrierStatsExtension;
     // meta data
     public string EncounterDuration;
+    public string EvtcRecordingDuration;
     public bool Success;
     public bool Wvw;
     public bool HasCommander;
     public bool Targetless;
+    public string FightNameNoMode;
     public string FightName;
     public string FightIcon;
+    public string FightMode;
+    public string FightStartStatus;
     public bool LightTheme;
     public bool NoMechanics;
     public bool SingleGroup;
@@ -130,11 +134,52 @@ internal class LogDataDto
         }
 
         EncounterDuration = log.FightData.DurationString;
+        EvtcRecordingDuration = log.FightData.EvtcRecordingDuration;
         Success = log.FightData.Success;
         Wvw = log.FightData.Logic.ParseMode == FightLogic.ParseModeEnum.WvW;
         Targetless = log.FightData.Logic.Targetless;
+        FightNameNoMode = log.FightData.FightNameNoMode;
         FightName = log.FightData.FightName;
         FightIcon = log.FightData.Logic.Icon;
+        switch (log.FightData.FightMode)
+        {
+            case FightData.EncounterMode.Story:
+                FightMode = "Story Mode";
+                break;
+            case FightData.EncounterMode.StoryCM:
+                FightMode = "Story Challenge Mode";
+                break;
+            case FightData.EncounterMode.NormalEmboldened:
+                FightMode = "Emboldened Normal Mode";
+                break;
+            case FightData.EncounterMode.Normal:
+                FightMode = "Normal Mode";
+                break;
+            case FightData.EncounterMode.CM:
+            case FightData.EncounterMode.CMNoName:
+                FightMode = "Challenge Mode";
+                break;
+            case FightData.EncounterMode.LegendaryCM:
+                FightMode = "Legendary Challenge Mode";
+                break;
+            default:
+                break;
+        }
+        switch (log.FightData.FightStartStatus)
+        {
+            case FightData.EncounterStartStatus.Normal:
+                break;
+            case FightData.EncounterStartStatus.NotSet:
+                break;
+            case FightData.EncounterStartStatus.Late:
+                FightStartStatus = "Late Start";
+                break;
+            case FightData.EncounterStartStatus.NoPreEvent:
+                FightStartStatus = "No Pre-Event";
+                break;
+            default:
+                break;
+        }
         LightTheme = light;
         SingleGroup = log.PlayerList.Select(x => x.Group).Distinct().Count() == 1;
         HasBreakbarDamage = log.CombatData.HasBreakbarDamageData;

--- a/GW2EIBuilders/Resources/ei.css
+++ b/GW2EIBuilders/Resources/ei.css
@@ -802,3 +802,64 @@ td.approximate::before {
     overflow: auto;
     overscroll-behavior: contain;
 }
+
+.card-header {
+    padding: 0.25rem 1.25rem !important;
+}
+
+.card-header-fightMode {
+    padding: 0.10rem 1.25rem;
+    margin-bottom: 0px;
+}
+
+.card-body-encounter {
+    padding: 1rem !important;
+}
+
+/* Fight Mode Header - Light Theme */
+.fightModeStory-light {
+    background-color: #EEEEEE;
+}
+
+.fightModeEmboldened-light {
+    background-color: #39925A;
+}
+
+.fightModeNormal-light {
+    background-color: #00779E;
+}
+
+.fightModeChallenge-light {
+    background-color: #E99002;
+}
+
+.fightModeLegendary-light {
+    background-color: #C9A0FF;
+}
+
+/* Fight Mode Header - Dark Theme */
+.fightModeStory-dark {
+    background-color: #515960;
+}
+
+.fightModeEmboldened-dark {
+    background-color: #036E09;
+}
+
+.fightModeNormal-dark {
+    background-color: #0C5E94;
+}
+
+.fightModeChallenge-dark {
+    background-color: #736625;
+}
+
+.fightModeLegendary-dark {
+    background-color: #6C4DA3;
+}
+
+.healthBar {
+    height: 7px;
+    width: 100%;
+    border-radius: 5px;
+}

--- a/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplEncounter.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplEncounter.html
@@ -26,7 +26,8 @@
                                 {{ targetHealthValues(target) }}
                             </div>
                         </div>
-                    <div class="mb-2">Duration: {{ encounter.duration }}</div>
+                    </div>
+                    <div class="mb-2 mt-2">Duration: {{ encounter.duration }}</div>
                     <div class="mb-2" v-if="fractalScale > 0">Fractal Scale: {{ fractalScale }}</div>
                     <div class="mb-2 text-warning" v-if="encounter.start"> {{ encounter.start }}</div>
                     <div v-if="!wvw" class="text" :class="resultStatus.class">

--- a/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplEncounter.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplEncounter.html
@@ -1,7 +1,8 @@
 <template>
     <div class="card fight-summary" style="min-width: 350px;">
         <h3 class="card-header text-center">{{ encounter.name }}</h3>
-        <div class="card-body container">
+        <h7 class="card-header-fightMode text-center" :class="fightModeColorClass">{{ encounter.mode }}</h7>
+        <div class="card-body card-body-encounter container">
             <div class="d-flex flex-row justify-content-center align-items-center">
                 <div class="d-flex flex-column mr-3 justify-content-center">
                     <div v-if="instanceBuffs" class="d-flex flex-row justify-content-around mb-1">
@@ -13,30 +14,24 @@
                     </div>
                     <img class="encounter-icon" :src="encounter.icon" :alt="encounter.name">
                 </div>
-                <div class="ml-3 d-flex flex-column justify-content-center">
-                    <div v-if="!wvw" class="mb-2" v-for="target in encounter.targets">
+                <div class="ml-1 d-flex flex-column justify-content-center">
+                    <div v-if="!wvw" class="mb-1" v-for="target in encounter.targets">
                         <div class="small" style="text-align:center;">
                             {{target.name}}
                         </div>
-                        <div v-if="target.health > 0" class="super-small" style="text-align:center;">
-                            {{ target.health }} Health
-                        </div>
                         <div :data-original-title="healthRemaining(target)">
-                            <div :style="{'background': getGradient(target), 'height': '10px', 'width': '100%', 'border-radius': '5px'}">
+                            <div class="healthBar" :style="{'background': getGradient(target)}">
                             </div>
-                            <div v-if="target.hpLeftPercent > 0" class="small" style="text-align:center;">
-                                {{ target.hpLeftPercent }}% health remaining
-                            </div>
-                            <div v-if="target.barrierLeftPercent > 0" class="small" style="text-align:center;">
-                                {{ target.barrierLeftPercent }}% barrier remaining
+                            <div v-if="target.health > 0" class="super-small" style="text-align: center;">
+                                {{ targetHealthValues(target) }}
                             </div>
                         </div>
-                    </div>
-                    <div v-if="!wvw" class="mb-2 text" :class="resultStatus.class">
-                        Result: {{resultStatus.text}}
-                    </div>
                     <div class="mb-2">Duration: {{ encounter.duration }}</div>
                     <div class="mb-2" v-if="fractalScale > 0">Fractal Scale: {{ fractalScale }}</div>
+                    <div class="mb-2 text-warning" v-if="encounter.start"> {{ encounter.start }}</div>
+                    <div v-if="!wvw" class="text" :class="resultStatus.class">
+                        Result: {{resultStatus.text}}
+                    </div>
                 </div>
             </div>
         </div>
@@ -45,7 +40,7 @@
 
 <script>
     Vue.component("encounter-component", {
-        props: [],
+        props: ["light"],
         template: `${template}`,
         data: function () {
             return {
@@ -71,15 +66,27 @@
                 var hpLeft = target.hpLeft;
                 var barrierLeft = target.barrierLeft;
                 if (hpLeft > 0 && barrierLeft > 0) {
-                    return 'Health: ' + hpLeft + '<br>Barrier: ' + barrierLeft;
+                    return 'Remaining:<br>Health: ' + hpLeft + '<br>Barrier: ' + barrierLeft;
                 }
                 else if (hpLeft > 0 && barrierLeft == 0) {
-                    return 'Health: ' + hpLeft;
+                    return 'Remaining:<br>Health: ' + hpLeft;
                 }
                 else if (barrierLeft > 0) {
-                    return 'Barrier: ' + barrierLeft;
+                    return 'Remaining:<br>Barrier: ' + barrierLeft;
                 }
                 return false;
+            },
+            targetHealthValues: function (target) {
+                var health = target.health;
+                var hpLeft = target.hpLeftPercent;
+                var barrierLeft = target.barrierLeftPercent;
+                if ((hpLeft > 0 && barrierLeft > 0) || (hpLeft == 0 && barrierLeft > 0)) { // If only barrier is left, show 0 + x.y barrier
+                    return health + " HP (" + hpLeft + "% + " + barrierLeft + "%)";
+                }
+                else if (hpLeft > 0 && barrierLeft == 0) {
+                    return health + " HP (" + hpLeft + "%)";
+                }
+                return health + " HP";
             },
         },
         computed: {
@@ -101,10 +108,12 @@
                 }
 
                 var encounter = {
-                    name: logData.fightName,
+                    name: logData.fightNameNoMode,
                     icon: logData.fightIcon,
                     duration: logData.encounterDuration,
-                    targets: targets
+                    targets: targets,
+                    mode: logData.fightMode,
+                    start: logData.fightStartStatus,
                 };
                 return encounter;
             },
@@ -112,7 +121,7 @@
                 return logData.fractalScale;
             },
             resultStatus: function () {
-                return logData.success ? { text: 'Success', class: ["text-success"] } : { text: 'Failure', class: ["text-warning"] };
+                return logData.success ? { text: 'Success', class: ["text-success"] } : { text: 'Failure', class: ["text-danger"] };
             },
             instanceBuffs: function () {
                 if (logData.instanceBuffs.length == 0) {
@@ -123,6 +132,29 @@
                     res.push({buff: findSkill(true, logData.instanceBuffs[i][0]), stack: logData.instanceBuffs[i][1]});
                 }
                 return res;
+            },
+            fightModeColorClass: function () {
+                switch (logData.fightMode) {
+                    case "Story Mode":
+                        return { 'fightModeStory-light': this.light, 'fightModeStory-dark': !this.light };
+                        break;
+                    case "Emboldened Normal Mode":
+                        return { 'fightModeEmboldened-light': this.light, 'fightModeEmboldened-dark': !this.light };
+                        break;
+                    case "Normal Mode":
+                        return { 'fightModeNormal-light': this.light, 'fightModeNormal-dark': !this.light };
+                        break;
+                    case "Story Challenge Mode":
+                    case "Challenge Mode":
+                        return { 'fightModeChallenge-light': this.light, 'fightModeChallenge-dark': !this.light };
+                        break;
+                    case "Legendary Challenge Mode":
+                        return { 'fightModeLegendary-light': this.light, 'fightModeLegendary-dark': !this.light };
+                        break;
+                    default:
+                        break;
+                }
+                return;
             },
         }
     });

--- a/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplEncounter.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplEncounter.html
@@ -145,7 +145,6 @@
                     case "Normal Mode":
                         return { 'fightModeNormal-light': this.light, 'fightModeNormal-dark': !this.light };
                         break;
-                    case "Story Challenge Mode":
                     case "Challenge Mode":
                         return { 'fightModeChallenge-light': this.light, 'fightModeChallenge-dark': !this.light };
                         break;

--- a/GW2EIBuilders/Resources/template.html
+++ b/GW2EIBuilders/Resources/template.html
@@ -65,7 +65,7 @@
             <div v-if="!!errorMessages" class="d-flex flex-column justify-content-center align-items-center">
                 <img v-for="message in errorMessages" class="mb-1 icon" :src="UIIcons.ExclamationMark" :data-original-title="message" />
             </div>
-            <encounter-component></encounter-component>
+            <encounter-component :light="light"></encounter-component>
             <div class="d-flex flex-column justify-content-center align-items-center ml-5">
                 <div class="d-flex flex-row justify-content-center align-items-center mt-2 mb-2">
                     <ul class="nav nav-pills" style="pointer-events:auto;">
@@ -107,7 +107,7 @@
             </div>
         </div>
         <div class="footer">
-            <div>Time Start: {{getLogData().encounterStart}} | Time End: {{getLogData().encounterEnd}}</div>      
+            <div>Time Start: {{getLogData().encounterStart}} | Time End: {{getLogData().encounterEnd}} | EVTC Duration: {{ getLogData().evtcRecordingDuration}}</div>      
             <div v-if="getLogData().instanceStart">Instance Start: {{getLogData().instanceStart}} {{ getLogData().instanceIP ? ' | Instance IP: ' + getLogData().instanceIP : '' }}</div>
             <div>ARC: {{getLogData().arcVersion}} | GW2 Build: {{getLogData().gw2Build}} | Trigger ID: {{getLogData().triggerID}} | Encounter ID: {{getLogData().encounterID}} | {{getLogData().parser}}</div>
             <div v-if="uploadLinks">

--- a/GW2EIEvtcParser/EncounterLogic/Story/Mordremoth.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Story/Mordremoth.cs
@@ -36,7 +36,7 @@ internal class Mordremoth : StoryInstance
     internal override List<PhaseData> GetPhases(ParsedEvtcLog log, bool requirePhases)
     {
         List<PhaseData> phases = GetInitialPhase(log);
-        SingleActor mainTarget = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Mordremoth)) ?? throw new MissingKeyActorsException("Vale Guardian not found");
+        SingleActor mainTarget = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Mordremoth)) ?? throw new MissingKeyActorsException("Mordremoth not found");
         phases[0].AddTarget(mainTarget);
         if (!requirePhases)
         {
@@ -86,7 +86,7 @@ internal class Mordremoth : StoryInstance
     internal override FightData.EncounterMode GetEncounterMode(CombatData combatData, AgentData agentData, FightData fightData)
     {
         SingleActor mordremoth = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Mordremoth)) ?? throw new MissingKeyActorsException("Mordremoth not found");
-        return (mordremoth.GetHealth(combatData) > 9e6) ? FightData.EncounterMode.CM : FightData.EncounterMode.Story;
+        return (mordremoth.GetHealth(combatData) > 9e6) ? FightData.EncounterMode.StoryCM : FightData.EncounterMode.Story;
     }
 
     protected override ReadOnlySpan<TargetID> GetFriendlyNPCIDs()

--- a/GW2EIEvtcParser/EncounterLogic/Story/Mordremoth.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Story/Mordremoth.cs
@@ -86,7 +86,7 @@ internal class Mordremoth : StoryInstance
     internal override FightData.EncounterMode GetEncounterMode(CombatData combatData, AgentData agentData, FightData fightData)
     {
         SingleActor mordremoth = Targets.FirstOrDefault(x => x.IsSpecies(TargetID.Mordremoth)) ?? throw new MissingKeyActorsException("Mordremoth not found");
-        return (mordremoth.GetHealth(combatData) > 9e6) ? FightData.EncounterMode.StoryCM : FightData.EncounterMode.Story;
+        return (mordremoth.GetHealth(combatData) > 9e6) ? FightData.EncounterMode.CM : FightData.EncounterMode.Story;
     }
 
     protected override ReadOnlySpan<TargetID> GetFriendlyNPCIDs()

--- a/GW2EIEvtcParser/ParsedData/FightData.cs
+++ b/GW2EIEvtcParser/ParsedData/FightData.cs
@@ -38,18 +38,15 @@ public class FightData
     {
         NotSet,
         Story,
-        StoryCM,
         Normal,
-        NormalEmboldened,
         LegendaryCM,
         CM,
         CMNoName
     }
 
-    public EncounterMode FightMode = EncounterMode.NotSet;
-    public bool IsCM => FightMode == EncounterMode.CMNoName || FightMode == EncounterMode.CM || FightMode == EncounterMode.StoryCM;
+    public EncounterMode FightMode { get; private set; } = EncounterMode.NotSet;
+    public bool IsCM => FightMode == EncounterMode.CMNoName || FightMode == EncounterMode.CM;
     public bool IsLegendaryCM => FightMode == EncounterMode.LegendaryCM;
-    public bool IsEmboldened => FightMode == EncounterMode.NormalEmboldened;
 
     public enum EncounterStartStatus
     {
@@ -58,7 +55,7 @@ public class FightData
         Late,
         NoPreEvent
     }
-    public EncounterStartStatus FightStartStatus = EncounterStartStatus.NotSet;
+    public EncounterStartStatus FightStartStatus { get; private set; } = EncounterStartStatus.NotSet;
     public bool IsLateStart => FightStartStatus == EncounterStartStatus.Late || MissingPreEvent;
     public bool MissingPreEvent => FightStartStatus == EncounterStartStatus.NoPreEvent;
 
@@ -303,8 +300,8 @@ public class FightData
     internal void CompleteFightName(CombatData combatData, AgentData agentData)
     {
         FightNameNoMode = Logic.GetLogicName(combatData, agentData);
-        FightName = Logic.GetLogicName(combatData, agentData)
-            + (FightMode == EncounterMode.CM || FightMode == EncounterMode.StoryCM ? " CM" : "")
+        FightName = FightNameNoMode
+            + (FightMode == EncounterMode.CM ? " CM" : "")
             + (FightMode == EncounterMode.LegendaryCM ? " LCM" : "")
             + (FightMode == EncounterMode.Story ? " Story" : "")
             + (IsLateStart && !MissingPreEvent ? " (Late Start)" : "")
@@ -355,10 +352,6 @@ public class FightData
             if (FightMode == EncounterMode.Story)
             {
                 Logic.InvalidateEncounterID();
-            }
-            if (combatData.GetBuffData(Emboldened).Any())
-            {
-                FightMode = EncounterMode.NormalEmboldened;
             }
             FightStartStatus = Logic.GetEncounterStartStatus(combatData, agentData, this);
         }

--- a/GW2EIEvtcParser/ParsedData/FightData.cs
+++ b/GW2EIEvtcParser/ParsedData/FightData.cs
@@ -3,6 +3,7 @@ using GW2EIEvtcParser.EncounterLogic;
 using GW2EIEvtcParser.EncounterLogic.OpenWorld;
 using static GW2EIEvtcParser.ArcDPSEnums;
 using static GW2EIEvtcParser.ParsedData.AgentItem;
+using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.SpeciesIDs;
 
 namespace GW2EIEvtcParser.ParsedData;
@@ -18,10 +19,11 @@ public class FightData
     public long FightDuration => FightEnd;
 
     public string FightName { get; private set; }
+    public string FightNameNoMode { get; private set; }
     public long LogStart { get; private set; }
     public long LogEnd { get; private set; }
     public long LogOffset { get; private set; }
-
+    public string EvtcRecordingDuration {  get; private set; }
     public long FightStartOffset => -LogStart;
     public string DurationString
     {
@@ -32,29 +34,33 @@ public class FightData
     }
     public bool Success { get; private set; }
 
-    internal enum EncounterMode
+    public enum EncounterMode
     {
         NotSet,
         Story,
+        StoryCM,
         Normal,
+        NormalEmboldened,
         LegendaryCM,
         CM,
         CMNoName
     }
-    private EncounterMode _encounterMode = EncounterMode.NotSet;
-    public bool IsCM => _encounterMode == EncounterMode.CMNoName || _encounterMode == EncounterMode.CM;
-    public bool IsLegendaryCM => _encounterMode == EncounterMode.LegendaryCM;
 
-    internal enum EncounterStartStatus
+    public EncounterMode FightMode = EncounterMode.NotSet;
+    public bool IsCM => FightMode == EncounterMode.CMNoName || FightMode == EncounterMode.CM || FightMode == EncounterMode.StoryCM;
+    public bool IsLegendaryCM => FightMode == EncounterMode.LegendaryCM;
+    public bool IsEmboldened => FightMode == EncounterMode.NormalEmboldened;
+
+    public enum EncounterStartStatus
     {
         NotSet,
         Normal,
         Late,
         NoPreEvent
     }
-    private EncounterStartStatus _encounterStartStatus = EncounterStartStatus.NotSet;
-    public bool IsLateStart => _encounterStartStatus == EncounterStartStatus.Late || MissingPreEvent;
-    public bool MissingPreEvent => _encounterStartStatus == EncounterStartStatus.NoPreEvent;
+    public EncounterStartStatus FightStartStatus = EncounterStartStatus.NotSet;
+    public bool IsLateStart => FightStartStatus == EncounterStartStatus.Late || MissingPreEvent;
+    public bool MissingPreEvent => FightStartStatus == EncounterStartStatus.NoPreEvent;
 
     // Constructors
     internal FightData(int id, AgentData agentData, List<CombatItem> combatData, EvtcParserSettings parserSettings, long start, long end, EvtcVersionEvent evtcVersion)
@@ -62,6 +68,7 @@ public class FightData
         LogStart = start;
         LogEnd = end;
         FightEnd = end - start;
+        EvtcRecordingDuration = ParserHelper.ToDurationString(FightEnd);
 
         Logic = DetectFight(id, agentData, parserSettings, evtcVersion);
         Logic = Logic.AdjustLogic(agentData, combatData, parserSettings);
@@ -295,10 +302,11 @@ public class FightData
 
     internal void CompleteFightName(CombatData combatData, AgentData agentData)
     {
+        FightNameNoMode = Logic.GetLogicName(combatData, agentData);
         FightName = Logic.GetLogicName(combatData, agentData)
-            + (_encounterMode == EncounterMode.CM ? " CM" : "")
-            + (_encounterMode == EncounterMode.LegendaryCM ? " LCM" : "")
-            + (_encounterMode == EncounterMode.Story ? " Story" : "")
+            + (FightMode == EncounterMode.CM || FightMode == EncounterMode.StoryCM ? " CM" : "")
+            + (FightMode == EncounterMode.LegendaryCM ? " LCM" : "")
+            + (FightMode == EncounterMode.Story ? " Story" : "")
             + (IsLateStart && !MissingPreEvent ? " (Late Start)" : "")
             + (MissingPreEvent ? " (No Pre-Event)" : "");
     }
@@ -341,14 +349,18 @@ public class FightData
     // Setters
     internal void ProcessEncounterStatus(CombatData combatData, AgentData agentData)
     {
-        if (_encounterMode == EncounterMode.NotSet)
+        if (FightMode == EncounterMode.NotSet)
         {
-            _encounterMode = Logic.GetEncounterMode(combatData, agentData, this);
-            if (_encounterMode == EncounterMode.Story)
+            FightMode = Logic.GetEncounterMode(combatData, agentData, this);
+            if (FightMode == EncounterMode.Story)
             {
                 Logic.InvalidateEncounterID();
             }
-            _encounterStartStatus = Logic.GetEncounterStartStatus(combatData, agentData, this);
+            if (combatData.GetBuffData(Emboldened).Any())
+            {
+                FightMode = EncounterMode.NormalEmboldened;
+            }
+            FightStartStatus = Logic.GetEncounterStartStatus(combatData, agentData, this);
         }
     }
 


### PR DESCRIPTION
Redesigned the encounter infobox

Added to LogData:
- EvtcRecordingDuration: shown in the log info at the bottom of the page
- FightNameNoMode: the encounter name without CM/LCM/Late Start/No Pre-Event
- FightMode: the type of encounter mode, with new additions
- FightStartStatus: the starting state, late / no pre-event

Reasonings:
- EvtcRecordingDuration was requested for fights where the timer ends the fight but the starting time is trimmed, example Cerus fight duration is  "Duration: 09m 57s 469ms" but the evtc duration is "EVTC Duration: 10m 01s 72ms"
- Just like Legendary mode being a more difficult version of the Challenge mode, Emboldened is a easier version of Normal. Even though there aren't mechanical changes for Emboldened in game other than the buff, this is also future proof.