### PR TITLE
Professions cleanup

### DIFF
--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -128,7 +128,6 @@ internal static class ElementalistHelper
         new DamageLogDamageModifier(Mod_FlowLikeWater5, "Flow like Water (< 50%)", "5% if hp <50%", DamageSource.NoPets, 5, DamageType.Strike, DamageType.All, Source.Elementalist, TraitImages.FlowLikeWater, (x, log) => x.From.GetCurrentHealthPercent(log, x.Time) < 50, DamageModifierMode.All)
             .WithBuilds(GW2Builds.June2024Balance)
             .UsingApproximate(true),
-        //new DamageLogDamageModifier("Flow like Water", "10% over 75% HP", DamageSource.NoPets, 10.0, DamageType.Power, DamageType.All, ParseHelper.Source.Elementalist, BuffImages.FlowLikeWater, x => x.IsOverNinety, GW2Builds.July2019Balance),
         // Arcane
         new BuffOnActorDamageModifier(Mod_BountifulPower, NumberOfBoons, "Bountiful Power", "2% per boon", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByStack, TraitImages.BountifulPower, DamageModifierMode.All),
         new BuffOnFoeDamageModifier(Mod_StormSoul, [Stun, Daze, Knockdown, Fear, Taunt], "Stormsoul", "10% to disabled foes", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.Strike, Source.Elementalist, ByPresence, TraitImages.Stormsoul, DamageModifierMode.All)
@@ -152,7 +151,9 @@ internal static class ElementalistHelper
                 x.From.TryGetCurrentPosition(log, x.Time, out var currentPosition)
                 && x.To.TryGetCurrentPosition(log, x.Time, out var currentTargetPosition)
                 && (currentPosition - currentTargetPosition).Length() <= 360.0
-            , DamageModifierMode.All).UsingApproximate(true).WithBuilds(GW2Builds.July2019Balance)
+            , DamageModifierMode.All)
+            .UsingApproximate(true)
+            .WithBuilds(GW2Builds.July2019Balance)
     ];
 
 
@@ -165,13 +166,9 @@ internal static class ElementalistHelper
         new Buff("Signet of Fire", SignetOfFire, Source.Elementalist, BuffClassification.Other, SkillImages.SignetOfFire),
         new Buff("Signet of Water", SignetOfWater, Source.Elementalist, BuffClassification.Other, SkillImages.SignetOfWater),
         // Attunements
-        // Fire
         new Buff("Fire Attunement", FireAttunementBuff, Source.Elementalist, BuffClassification.Other, SkillImages.FireAttunement),
-        // Water
         new Buff("Water Attunement", WaterAttunementBuff, Source.Elementalist, BuffClassification.Other, SkillImages.WaterAttunement),
-        // Air
         new Buff("Air Attunement", AirAttunementBuff, Source.Elementalist, BuffClassification.Other, SkillImages.AirAttunement),
-        // Earth
         new Buff("Earth Attunement", EarthAttunementBuff, Source.Elementalist, BuffClassification.Other, SkillImages.EarthAttunement),
         // Forms
         new Buff("Mist Form", MistForm, Source.Elementalist, BuffClassification.Other, SkillImages.MistForm),
@@ -204,7 +201,7 @@ internal static class ElementalistHelper
         new Buff("Arcane Power (Ferocity)", ArcanePowerFerocityBuff, Source.Elementalist, BuffClassification.Other, SkillImages.ArcanePower),
         new Buff("Arcane Shield", ArcaneShieldBuff, Source.Elementalist, BuffStackType.Stacking, 25, BuffClassification.Other, SkillImages.ArcaneShield),
         new Buff("Renewal of Fire", RenewalOfFire, Source.Elementalist, BuffClassification.Other, SkillImages.RenewalOfFire),
-        new Buff("Rock Barrier", RockBarrier, Source.Elementalist, BuffClassification.Other, SkillImages.RockBarrier),//750?
+        new Buff("Rock Barrier", RockBarrier, Source.Elementalist, BuffClassification.Other, SkillImages.RockBarrier),
         new Buff("Magnetic Wave", MagneticWave, Source.Elementalist, BuffClassification.Other, SkillImages.MagneticWave),
         new Buff("Obsidian Flesh", ObsidianFlesh, Source.Elementalist, BuffClassification.Other, SkillImages.ObsidianFlesh),
         new Buff("Persisting Flames", PersistingFlames, Source.Elementalist, BuffStackType.Stacking, 10, BuffClassification.Other, TraitImages.PersistingFlames)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -252,14 +252,14 @@ internal static class ElementalistHelper
     ];
 
 
-    private static readonly HashSet<long> _elementalSwaps =
+    private static readonly HashSet<long> _attunements =
     [
-        FireAttunementSkill,WaterAttunementSkill,AirAttunementSkill, EarthAttunementSkill, DualFireAttunement, FireWaterAttunement, FireAirAttunement, FireEarthAttunement, WaterFireAttunement, DualWaterAttunement, WaterAirAttunement, WaterEarthAttunement, AirFireAttunement, AirWaterAttunement, DualAirAttunement, AirEarthAttunement, EarthFireAttunement, EarthWaterAttunement, EarthAirAttunement, DualEarthAttunement
+        FireAttunementSkill, WaterAttunementSkill, AirAttunementSkill, EarthAttunementSkill
     ];
 
-    public static bool IsElementalSwap(long id)
+    public static bool IsAttunementSwap(long id)
     {
-        return _elementalSwaps.Contains(id);
+        return _attunements.Contains(id);
     }
 
     public static void RemoveDualBuffs(IReadOnlyList<BuffEvent> buffsPerDst, Dictionary<long, List<BuffEvent>> buffsByID, SkillData skillData)
@@ -283,7 +283,7 @@ internal static class ElementalistHelper
         }
     }
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.LesserAirElemental,
         (int)MinionID.LesserEarthElemental,

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/TempestHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/TempestHelper.cs
@@ -14,7 +14,6 @@ internal static class TempestHelper
 {
     internal static readonly List<InstantCastFinder> InstantCastFinder =
     [
-        //new DamageCastFinder(30662, 30662, 10000), // "Feel the Burn!" - shockwave, fire aura indiscernable from the focus skill
         new EffectCastFinder(FeelTheBurn, EffectGUIDs.TempestFeelTheBurn)
             .UsingSrcSpecChecker(Spec.Tempest),
         new EffectCastFinder(EyeOfTheStormShout, EffectGUIDs.TempestEyeOfTheStorm1)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/WeaverHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/WeaverHelper.cs
@@ -12,16 +12,21 @@ namespace GW2EIEvtcParser.EIData;
 internal static class WeaverHelper
 {
     private const long extraOrbHammerDelay = 520;
-    private static readonly IReadOnlyList<long> _weaverAtunements = new List<long>
+    private static readonly IReadOnlyList<long> _weaverAttunements = new List<long>
     {
         DualFireAttunement, FireWaterAttunement, FireAirAttunement, FireEarthAttunement, WaterFireAttunement, DualWaterAttunement, WaterAirAttunement, WaterEarthAttunement, AirFireAttunement, AirWaterAttunement, DualAirAttunement, AirEarthAttunement, EarthFireAttunement, EarthWaterAttunement, EarthAirAttunement, DualEarthAttunement
     };
+
+    public static bool IsAttunementSwap(long id)
+    {
+        return _weaverAttunements.Contains(id);
+    }
 
     private static long GetLastAttunement(AgentItem agent, long time, CombatData combatData)
     {
         time = Math.Max(time, ServerDelayConstant);
         var list = new List<BuffEvent>();
-        foreach (long attunement in _weaverAtunements)
+        foreach (long attunement in _weaverAttunements)
         {
             list.AddRange(combatData.GetBuffDataByIDByDst(attunement, agent).Where(x => x is BuffApplyEvent && x.Time <= time + ServerDelayConstant));
         }
@@ -213,9 +218,12 @@ internal static class WeaverHelper
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
-        new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "10% cDam (8s) after switching element",  DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.All).WithBuilds(GW2Builds.StartOfLife, GW2Builds.September2023Balance),
-        new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "5% cDam (8s) after switching element",  DamageSource.NoPets, 5.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.PvE).WithBuilds(GW2Builds.September2023Balance),
-        new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "10% cDam (8s) after switching element",  DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.sPvPWvW).WithBuilds(GW2Builds.September2023Balance),
+        new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "10% cDam (8s) after switching element",  DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.September2023Balance),
+        new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "5% cDam (8s) after switching element",  DamageSource.NoPets, 5.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.September2023Balance),
+        new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "10% cDam (8s) after switching element",  DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.September2023Balance),
         new BuffOnActorDamageModifier(Mod_ElementsOfRage, ElementsOfRage, "Elements of Rage", "10% (8s) after double attuning", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.All)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.May2021Balance),
         new BuffOnActorDamageModifier(Mod_ElementsOfRage, ElementsOfRage, "Elements of Rage", "5% (8s) after double attuning", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.All)
@@ -227,7 +235,8 @@ internal static class WeaverHelper
         new BuffOnActorDamageModifier(Mod_ElementsOfRage, ElementsOfRage, "Elements of Rage", "5% (8s) after double attuning", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.November2022Balance),
         new BuffOnActorDamageModifier(Mod_WovenFire, WovenFire, "Woven Fire", "20%", DamageSource.NoPets, 20.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, SkillImages.WovenFire, DamageModifierMode.All),
-        new BuffOnActorDamageModifier(Mod_WovenAir, WovenAir, "Wover Air", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, SkillImages.WovenAir, DamageModifierMode.All).WithBuilds(GW2Builds.February2023Balance),
+        new BuffOnActorDamageModifier(Mod_WovenAir, WovenAir, "Wover Air", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, SkillImages.WovenAir, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.February2023Balance),
         new BuffOnActorDamageModifier(Mod_PerfectWeaveCondition, PerfectWeave, "Perfect Weave (Condition)", "20%", DamageSource.NoPets, 20.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, SkillImages.WeaveSelf, DamageModifierMode.All),
         new BuffOnActorDamageModifier(Mod_PerfectWeaveStrike, PerfectWeave, "Perfect Weave (Strike)", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, SkillImages.WeaveSelf, DamageModifierMode.All)
             .WithBuilds(GW2Builds.February2023Balance),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
@@ -114,17 +114,6 @@ internal static class EngineerHelper
             .UsingICD(1100), // Automatically procs on the target that has the Focused buff and is hit by Spear #5 Devastator, hits 6 times in 1 second.
     ];
 
-    private static bool SelfHigherHPChecker(DamageEvent x, ParsedEvtcLog log)
-    {
-        double selfHP = x.From.GetCurrentHealthPercent(log, x.Time);
-        double dstHP = x.To.GetCurrentHealthPercent(log, x.Time);
-        if (selfHP < 0.0 || dstHP < 0.0)
-        {
-            return false;
-        }
-        return selfHP > dstHP;
-    }
-
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
         // Explosives
@@ -141,7 +130,8 @@ internal static class EngineerHelper
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2019Balance),
         new BuffOnFoeDamageModifier(Mod_ShapedCharge, Vulnerability, "Shaped Charge", "0.5% per stack vuln", DamageSource.NoPets, 0.5, DamageType.Strike, DamageType.All, Source.Engineer, ByStack, TraitImages.ExplosivePowder, DamageModifierMode.All)
             .WithBuilds(GW2Builds.October2019Balance),
-        new DamageLogDamageModifier(Mod_BigBoomer, "Big Boomer", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Engineer, TraitImages.BigBoomer, SelfHigherHPChecker, DamageModifierMode.All ).UsingApproximate(true)
+        new DamageLogDamageModifier(Mod_BigBoomer, "Big Boomer", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Engineer, TraitImages.BigBoomer, SelfHigherHPChecker, DamageModifierMode.All )
+            .UsingApproximate(true)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2022Balance),
         new DamageLogDamageModifier(Mod_BigBoomer, "Big Boomer", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Engineer, TraitImages.BigBoomer, SelfHigherHPChecker, DamageModifierMode.sPvPWvW )
             .UsingApproximate(true)
@@ -257,7 +247,7 @@ internal static class EngineerHelper
         }
     }
 
-    private static HashSet<int> Minions = [];
+    private static readonly HashSet<int> Minions = [];
     internal static bool IsKnownMinionID(int id)
     {
         return Minions.Contains(id);

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/HolosmithHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/HolosmithHelper.cs
@@ -40,14 +40,18 @@ internal static class HolosmithHelper
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
-        new BuffOnActorDamageModifier(Mod_LasersEdge, LasersEdge, "Laser's Edge", "15%", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Holosmith, ByPresence, TraitImages.LasersEdge, DamageModifierMode.PvE).WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
+        new BuffOnActorDamageModifier(Mod_LasersEdge, LasersEdge, "Laser's Edge", "15%", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Holosmith, ByPresence, TraitImages.LasersEdge, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =
     [
-        new BuffOnActorDamageModifier(Mod_SpectrumShield, SpectrumShieldBuff, "Spectrum Shield", "-50%", DamageSource.Incoming, -50, DamageType.StrikeAndCondition, DamageType.All, Source.Holosmith, ByPresence, SkillImages.SpectrumShield, DamageModifierMode.All).WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2020Balance),
-        new BuffOnActorDamageModifier(Mod_SpectrumShield, SpectrumShieldBuff, "Spectrum Shield", "-50%", DamageSource.Incoming, -50, DamageType.StrikeAndCondition, DamageType.All, Source.Holosmith, ByPresence, SkillImages.SpectrumShield, DamageModifierMode.PvEWvW).WithBuilds(GW2Builds.February2020Balance),
-        new BuffOnActorDamageModifier(Mod_SpectrumShield, SpectrumShieldBuff, "Spectrum Shield", "-33%", DamageSource.Incoming, -33, DamageType.StrikeAndCondition, DamageType.All, Source.Holosmith, ByPresence, SkillImages.SpectrumShield, DamageModifierMode.sPvP).WithBuilds(GW2Builds.February2020Balance),
+        new BuffOnActorDamageModifier(Mod_SpectrumShield, SpectrumShieldBuff, "Spectrum Shield", "-50%", DamageSource.Incoming, -50, DamageType.StrikeAndCondition, DamageType.All, Source.Holosmith, ByPresence, SkillImages.SpectrumShield, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2020Balance),
+        new BuffOnActorDamageModifier(Mod_SpectrumShield, SpectrumShieldBuff, "Spectrum Shield", "-50%", DamageSource.Incoming, -50, DamageType.StrikeAndCondition, DamageType.All, Source.Holosmith, ByPresence, SkillImages.SpectrumShield, DamageModifierMode.PvEWvW)
+            .WithBuilds(GW2Builds.February2020Balance),
+        new BuffOnActorDamageModifier(Mod_SpectrumShield, SpectrumShieldBuff, "Spectrum Shield", "-33%", DamageSource.Incoming, -33, DamageType.StrikeAndCondition, DamageType.All, Source.Holosmith, ByPresence, SkillImages.SpectrumShield, DamageModifierMode.sPvP)
+            .WithBuilds(GW2Builds.February2020Balance),
         new BuffOnActorDamageModifier(Mod_LightDensityAmplifier, PhotonForge, "Light Density Amplifier", "-15%", DamageSource.Incoming, -15, DamageType.Strike, DamageType.All, Source.Holosmith, ByPresence, TraitImages.LightDensityAmplifier, DamageModifierMode.All),
     ];
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/MechanistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/MechanistHelper.cs
@@ -40,7 +40,8 @@ internal static class MechanistHelper
         new MinionCastCastFinder(RoilingSmash, RoilingSmash),
         new MinionCastCastFinder(ExplosiveKnuckle, ExplosiveKnuckle),
         new MinionCastCastFinder(SparkRevolver, SparkRevolver),
-        new BuffGainCastFinder(DischargeArray, DischargeArrayBuff).WithMinions(true),
+        new BuffGainCastFinder(DischargeArray, DischargeArrayBuff)
+            .WithMinions(true),
         new EffectCastFinderByDst(CrisisZone, EffectGUIDs.MechanistCrisisZone)
             .WithMinions(true)
             .UsingSecondaryEffectChecker(EffectGUIDs.MechanistMechEyeGlow)
@@ -98,7 +99,7 @@ internal static class MechanistHelper
         new Buff("Overclock Signet (J-Drive)", OverclockSignetJDrive, Source.Mechanist, BuffClassification.Other, SkillImages.OverclockSignet),
     ];
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.JadeMech,
     ];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/ScrapperHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/ScrapperHelper.cs
@@ -37,7 +37,8 @@ internal static class ScrapperHelper
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =
     [
-        new DamageLogDamageModifier(Mod_AdaptiveArmor, "Adaptive Armor", "-20%", DamageSource.Incoming, -20.0, DamageType.Condition, DamageType.All, Source.Scrapper, TraitImages.AdaptiveArmor, (x, log) => x.ShieldDamage > 0 , DamageModifierMode.All).WithBuilds(GW2Builds.July2019Balance, GW2Builds.January2024Balance),
+        new DamageLogDamageModifier(Mod_AdaptiveArmor, "Adaptive Armor", "-20%", DamageSource.Incoming, -20.0, DamageType.Condition, DamageType.All, Source.Scrapper, TraitImages.AdaptiveArmor, (x, log) => x.ShieldDamage > 0 , DamageModifierMode.All)
+            .WithBuilds(GW2Builds.July2019Balance, GW2Builds.January2024Balance),
     ];
 
     internal static readonly IReadOnlyList<Buff> Buffs =
@@ -46,7 +47,7 @@ internal static class ScrapperHelper
         new Buff("Watchful Eye PvP", WatchfulEyePvP, Source.Scrapper, BuffClassification.Defensive, SkillImages.BulwarkGyro),
     ];
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.BlastGyro,
         (int)MinionID.BulwarkGyro,

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
@@ -165,7 +165,8 @@ internal static class GuardianHelper
         new Buff("Signet of Wrath (PI)", SignetOfWrathPI, Source.Guardian, BuffClassification.Other, SkillImages.SignetOfWrath)
             .WithBuilds(GW2Builds.June2022Balance),
         new Buff("Signet of Courage", SignetOfCourage, Source.Guardian, BuffClassification.Other, SkillImages.SignetOfCourage),
-        new Buff("Signet of Courage (Shared)", SignetOfCourageShared , Source.Guardian, BuffStackType.Stacking, 25, BuffClassification.Defensive, SkillImages.SignetOfCourage).WithBuilds(GW2Builds.StartOfLife, GW2Builds.June2022Balance),
+        new Buff("Signet of Courage (Shared)", SignetOfCourageShared , Source.Guardian, BuffStackType.Stacking, 25, BuffClassification.Defensive, SkillImages.SignetOfCourage)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.June2022Balance),
         new Buff("Signet of Courage (PI)", SignetOfCouragePI , Source.Guardian, BuffClassification.Other, SkillImages.SignetOfCourage)
             .WithBuilds(GW2Builds.June2022Balance),
         // Virtues
@@ -183,14 +184,15 @@ internal static class GuardianHelper
             .WithBuilds(GW2Builds.July2019Balance),
         new Buff("Inspiring Virtue", InspiringVirtue, Source.Guardian, BuffStackType.Queue, 99, BuffClassification.Other, TraitImages.VirtuousSolace)
             .WithBuilds(GW2Builds.February2020Balance, GW2Builds.February2020Balance2),
-        new Buff("Inspiring Virtue", InspiringVirtue, Source.Guardian, BuffClassification.Other, TraitImages.VirtuousSolace).WithBuilds(GW2Builds.February2020Balance2),
+        new Buff("Inspiring Virtue", InspiringVirtue, Source.Guardian, BuffClassification.Other, TraitImages.VirtuousSolace)
+            .WithBuilds(GW2Builds.February2020Balance2),
         new Buff("Force of Will", ForceOfWill, Source.Guardian, BuffClassification.Other, TraitImages.ForceOfWill),
         // Spear
         new Buff("Symbol of Luminance", SymbolOfLuminanceBuff, Source.Guardian, BuffClassification.Other, SkillImages.SymbolOfLuminance),
         new Buff("Illuminated", Illuminated, Source.Guardian, BuffClassification.Other, SkillImages.Illuminated),
     ];
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.BowOfTruth,
         (int)MinionID.HammerOfWisdom,

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
@@ -15,21 +15,30 @@ internal static class ChronomancerHelper
 {
     internal static readonly List<InstantCastFinder> InstantCastFinder =
     [
-        new BuffGainCastFinder(ContinuumSplit, TimeAnchored), // Continuum Split
-        new BuffLossCastFinder(ContinuumShift, TimeAnchored), // Continuum Shift
-        new EffectCastFinder(SplitSecond, EffectGUIDs.ChronomancerSplitSecond).UsingSrcSpecChecker(Spec.Chronomancer)
-            .UsingSecondaryEffectChecker(EffectGUIDs.ChronomancerSeizeTheMomentShatter),
-        new EffectCastFinder(Rewinder, EffectGUIDs.ChronomancerRewinder).UsingSrcSpecChecker(Spec.Chronomancer)
-            .UsingSecondaryEffectChecker(EffectGUIDs.ChronomancerSeizeTheMomentShatter),
-        new EffectCastFinder(TimeSink, EffectGUIDs.ChronomancerTimeSink).UsingSrcSpecChecker(Spec.Chronomancer)
-            .UsingSecondaryEffectChecker(EffectGUIDs.ChronomancerSeizeTheMomentShatter),
+        new BuffGainCastFinder(ContinuumSplit, TimeAnchored),
+        new BuffLossCastFinder(ContinuumShift, TimeAnchored),
+        new EffectCastFinder(SplitSecond, EffectGUIDs.ChronomancerSplitSecond)
+            .UsingSecondaryEffectChecker(EffectGUIDs.ChronomancerSeizeTheMomentShatter)
+            .UsingSrcSpecChecker(Spec.Chronomancer),
+        new EffectCastFinder(Rewinder, EffectGUIDs.ChronomancerRewinder)
+            .UsingSecondaryEffectChecker(EffectGUIDs.ChronomancerSeizeTheMomentShatter)
+            .UsingSrcSpecChecker(Spec.Chronomancer),
+        new EffectCastFinder(TimeSink, EffectGUIDs.ChronomancerTimeSink)
+            .UsingSecondaryEffectChecker(EffectGUIDs.ChronomancerSeizeTheMomentShatter)
+            .UsingSrcSpecChecker(Spec.Chronomancer),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
-        new BuffOnFoeDamageModifier(Mod_DangerTime, Slow, "Danger Time", "10% crit damage on slowed target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.DangerTime, DamageModifierMode.All).UsingChecker((x, log) => x.HasCrit).WithBuilds(GW2Builds.February2018Balance, GW2Builds.December2018Balance),
-        new BuffOnFoeDamageModifier(Mod_DangerTime, Slow, "Danger Time", "10% crit damage on slowed target", DamageSource.All, 10.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.DangerTime, DamageModifierMode.All).UsingChecker((x, log) => x.HasCrit).WithBuilds(GW2Builds.December2018Balance, GW2Builds.May2021Balance),
-        new BuffOnActorDamageModifier(Mod_ImprovedAlacrity, Alacrity, "Improved Alacrity", "10% crit under alacrity", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.ImprovedAlacrity, DamageModifierMode.All).UsingChecker((x, log) => x.HasCrit).WithBuilds(GW2Builds.August2022BalanceHotFix),
+        new BuffOnFoeDamageModifier(Mod_DangerTime, Slow, "Danger Time", "10% crit damage on slowed target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.DangerTime, DamageModifierMode.All)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.February2018Balance, GW2Builds.December2018Balance),
+        new BuffOnFoeDamageModifier(Mod_DangerTime, Slow, "Danger Time", "10% crit damage on slowed target", DamageSource.All, 10.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.DangerTime, DamageModifierMode.All)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.December2018Balance, GW2Builds.May2021Balance),
+        new BuffOnActorDamageModifier(Mod_ImprovedAlacrity, Alacrity, "Improved Alacrity", "10% crit under alacrity", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.ImprovedAlacrity, DamageModifierMode.All)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.August2022BalanceHotFix),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers = [];
@@ -37,7 +46,8 @@ internal static class ChronomancerHelper
 
     internal static readonly IReadOnlyList<Buff> Buffs =
     [
-        new Buff("Time Echo", TimeEcho, Source.Chronomancer, BuffClassification.Other, SkillImages.DejaVu).WithBuilds(GW2Builds.StartOfLife, GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
+        new Buff("Time Echo", TimeEcho, Source.Chronomancer, BuffClassification.Other, SkillImages.DejaVu)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
         new Buff("Time Anchored", TimeAnchored, Source.Chronomancer, BuffStackType.Queue, 25, BuffClassification.Other, SkillImages.ContinuumSplit),
         new Buff("Temporal Stasis", TemporalStasis, Source.Chronomancer, BuffClassification.Other, BuffImages.Stun),
     ];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -154,15 +154,15 @@ internal static class MesmerHelper
             .UsingApproximate(true),
         new BuffOnFoeDamageModifier(Mod_Fragility, Vulnerability, "Fragility", "0.5% per stack vuln on target", DamageSource.NoPets, 0.5, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.Fragility, DamageModifierMode.All),
         // Dueling
-        new DamageLogDamageModifier(Mod_SuperiorityComplex, "Superiority Complex", "15% always", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, (x, log) => x.HasCrit && !SuperiorityComplexBonusChecker(x, log), DamageModifierMode.All)
+        new DamageLogDamageModifier(Mod_SuperiorityComplex, "Superiority Complex", "15% always", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, (x, log) => x.HasCrit && !SuperiorityComplexBonusChecker(x, log), DamageModifierMode.PvEInstanceOnly)
             .WithEvtcBuilds(ArcDPSBuilds.StartOfLife, ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents)
             .UsingApproximate(true),
-        new DamageLogDamageModifier(Mod_SuperiorityComplex, "Superiority Complex", "15% always", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, (x, log) => x.HasCrit && !SuperiorityComplexBonusChecker(x, log), DamageModifierMode.All)
+        new DamageLogDamageModifier(Mod_SuperiorityComplex, "Superiority Complex", "15% always", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, (x, log) => x.HasCrit && !SuperiorityComplexBonusChecker(x, log), DamageModifierMode.PvEInstanceOnly)
             .WithEvtcBuilds(ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents),
-        new DamageLogDamageModifier(Mod_SuperiorityComplexBonus, "Superiority Complex", "25% against disabled foes or below 50% hp", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, SuperiorityComplexBonusChecker, DamageModifierMode.All)
+        new DamageLogDamageModifier(Mod_SuperiorityComplexBonus, "Superiority Complex", "25% against disabled foes or below 50% hp", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, SuperiorityComplexBonusChecker, DamageModifierMode.PvEInstanceOnly)
             .WithEvtcBuilds(ArcDPSBuilds.StartOfLife, ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents)
             .UsingApproximate(true),
-        new DamageLogDamageModifier(Mod_SuperiorityComplexBonus, "Superiority Complex", "25% against disabled foes or below 50% hp", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, SuperiorityComplexBonusChecker, DamageModifierMode.All)
+        new DamageLogDamageModifier(Mod_SuperiorityComplexBonus, "Superiority Complex", "25% against disabled foes or below 50% hp", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, SuperiorityComplexBonusChecker, DamageModifierMode.PvEInstanceOnly)
             .WithEvtcBuilds(ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents),
         // Illusions
         new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -354,6 +354,7 @@ internal static class MesmerHelper
         (int)MinionID.IllusionaryWhaler,
         (int)MinionID.IllusionaryAvenger,
         (int)MinionID.IllusionarySharpShooter,
+        (int)MinionID.IllusionaryLancer,
     ];
 
     private static IEnumerable<int> Illusions()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -23,11 +23,14 @@ internal static class MesmerHelper
             })
             .UsingNotAccurate(true) // HideInShadows may not be applied if the Mesmer has a full stack of HideInShadows already
             .UsingDisableWithEffectData(),
-        new EffectCastFinderByDst(SignetOfMidnightSkill, EffectGUIDs.MesmerSignetOfMidnight).UsingDstBaseSpecChecker(Spec.Mesmer),
+        new EffectCastFinderByDst(SignetOfMidnightSkill, EffectGUIDs.MesmerSignetOfMidnight)
+            .UsingDstBaseSpecChecker(Spec.Mesmer),
         new BuffGainCastFinder(PortalEntre, PortalWeaving),
         new BuffGainCastFinder(PortalExeunt, PortalUses),
-        new DamageCastFinder(LesserPhantasmalDefender, LesserPhantasmalDefender).UsingOrigin(EIData.InstantCastFinder.InstantCastOrigin.Trait),
-        new EffectCastFinder(Feedback, EffectGUIDs.MesmerFeedback).UsingSrcBaseSpecChecker(Spec.Mesmer),
+        new DamageCastFinder(LesserPhantasmalDefender, LesserPhantasmalDefender)
+            .UsingOrigin(EIData.InstantCastFinder.InstantCastOrigin.Trait),
+        new EffectCastFinder(Feedback, EffectGUIDs.MesmerFeedback)
+            .UsingSrcBaseSpecChecker(Spec.Mesmer),
         // identify swap by buff remove
         // identify phase retreat by spawned staff clone
         // fallback to blink or phase retreat
@@ -62,61 +65,121 @@ internal static class MesmerHelper
             .UsingChecker((evt, combatData, agentData, skillData) => combatData.HasGainedBuff(DistortionBuff, evt.Src, evt.Time))
             .WithBuilds(GW2Builds.October2022Balance),
         // Mantras        
-        new DamageCastFinder(PowerSpike, PowerSpike).WithBuilds(GW2Builds.StartOfLife, GW2Builds.May2021Balance),
-        new DamageCastFinder(MantraOfPain, MantraOfPain).WithBuilds(GW2Builds.May2021Balance, GW2Builds.February2023Balance),
-        new DamageCastFinder(PowerSpike, PowerSpike).WithBuilds(GW2Builds.February2023Balance),
-        new EXTHealingCastFinder(MantraOfRecovery, MantraOfRecovery).WithBuilds(GW2Builds.May2021Balance, GW2Builds.February2023Balance),
-        new EffectCastFinderByDst(PowerReturn, EffectGUIDs.MesmerPowerReturn).UsingDstBaseSpecChecker(Spec.Mesmer).WithBuilds(GW2Builds.February2023Balance),
-        new EffectCastFinder(MantraOfResolve, EffectGUIDs.MesmerMantraOfResolveAndPowerCleanse).UsingSrcBaseSpecChecker(Spec.Mesmer).WithBuilds(GW2Builds.StartOfLife ,GW2Builds.February2023Balance),
-        new EffectCastFinder(PowerCleanse, EffectGUIDs.MesmerMantraOfResolveAndPowerCleanse).UsingSrcBaseSpecChecker(Spec.Mesmer).WithBuilds(GW2Builds.February2023Balance, GW2Builds.February2024NewWeapons),
+        new DamageCastFinder(PowerSpike, PowerSpike)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.May2021Balance),
+        new DamageCastFinder(MantraOfPain, MantraOfPain)
+            .WithBuilds(GW2Builds.May2021Balance, GW2Builds.February2023Balance),
+        new DamageCastFinder(PowerSpike, PowerSpike)
+            .WithBuilds(GW2Builds.February2023Balance),
+        new EXTHealingCastFinder(MantraOfRecovery, MantraOfRecovery)
+            .WithBuilds(GW2Builds.May2021Balance, GW2Builds.February2023Balance),
+        new EffectCastFinderByDst(PowerReturn, EffectGUIDs.MesmerPowerReturn)
+            .UsingDstBaseSpecChecker(Spec.Mesmer)
+            .WithBuilds(GW2Builds.February2023Balance),
+        new EffectCastFinder(MantraOfResolve, EffectGUIDs.MesmerMantraOfResolveAndPowerCleanse)
+            .UsingSrcBaseSpecChecker(Spec.Mesmer)
+            .WithBuilds(GW2Builds.StartOfLife ,GW2Builds.February2023Balance),
+        new EffectCastFinder(PowerCleanse, EffectGUIDs.MesmerMantraOfResolveAndPowerCleanse)
+            .UsingSrcBaseSpecChecker(Spec.Mesmer)
+            .WithBuilds(GW2Builds.February2023Balance, GW2Builds.February2024NewWeapons),
         new EffectCastFinderByDst(PowerCleanse, EffectGUIDs.MesmerMantraOfResolveAndPowerCleanse2)
             .UsingSrcNotBaseSpecChecker(Spec.Mesmer)
             .UsingDstBaseSpecChecker(Spec.Mesmer)
             .UsingSecondaryEffectCheckerInvertedSrc(EffectGUIDs.MesmerMantraOfResolveAndPowerCleanse)
             .WithBuilds(GW2Builds.February2024NewWeapons),
-        new EffectCastFinderByDst(MantraOfConcentration, EffectGUIDs.MesmerMantraOfConcentrationAndPowerBreak).UsingDstBaseSpecChecker(Spec.Mesmer).WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2023Balance),
-        new EffectCastFinderByDst(PowerBreak, EffectGUIDs.MesmerMantraOfConcentrationAndPowerBreak).UsingDstBaseSpecChecker(Spec.Mesmer).WithBuilds(GW2Builds.February2023Balance),
+        new EffectCastFinderByDst(MantraOfConcentration, EffectGUIDs.MesmerMantraOfConcentrationAndPowerBreak)
+            .UsingDstBaseSpecChecker(Spec.Mesmer)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2023Balance),
+        new EffectCastFinderByDst(PowerBreak, EffectGUIDs.MesmerMantraOfConcentrationAndPowerBreak)
+            .UsingDstBaseSpecChecker(Spec.Mesmer)
+            .WithBuilds(GW2Builds.February2023Balance),
         // Rifle
         new BuffGiveCastFinder(DimensionalApertureSkill, DimensionalAperturePortalBuff),
         new EffectCastFinder(Abstraction, EffectGUIDs.MesmerRifleAbstraction)
             .UsingSecondaryEffectChecker(EffectGUIDs.MesmerRifleAbstraction2)
             .UsingSrcBaseSpecChecker(Spec.Mesmer),
     ];
-    private static bool SelfHigherHPChecker(DamageEvent x, ParsedEvtcLog log)
+
+    private static bool WithIllusionsChecker(DamageEvent x, ParsedEvtcLog log)
     {
-        double selfHP = x.From.GetCurrentHealthPercent(log, x.Time);
-        double dstHP = x.To.GetCurrentHealthPercent(log, x.Time);
-        if (selfHP < 0.0 || dstHP < 0.0)
+        return x.From == x.CreditedFrom || x.From.IsAnySpecies(Illusions());
+    }
+
+    private static bool SuperiorityComplexBonusChecker(HealthDamageEvent x, ParsedEvtcLog log)
+    {
+        // Damage event must be a critical hit
+        if (!x.HasCrit)
         {
             return false;
         }
-        return selfHP > dstHP;
+
+        bool isCC = false;
+        bool hasCCBuffs = false;
+
+        // If the target doesn't have a defiance bar, it can be CC'd
+        if (x.To.GetCurrentBreakbarState(log, x.Time) == BreakbarState.None)
+        {
+            var ccEvents = log.CombatData.GetIncomingCrowdControlData(x.To);
+            isCC = ccEvents.Any(cc => x.Time >= cc.Time && x.Time <= cc.Time + cc.Duration);
+        }
+        // Otherwise check for these buffs being applied
+        else
+        {
+            long[] buffs = [Stun, Daze, Fear, Taunt];
+            hasCCBuffs = x.To.HasAnyBuff(log, buffs, x.Time);
+        }
+
+        // Conditions are: Must be a crowd control event or below 50% HP.
+        return isCC || hasCCBuffs || x.To.GetCurrentHealthPercent(log, x.Time) < 50.0;
     }
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
         // Domination
-        // Empowered illusions require knowing all illusion species ID
-        // We need illusion species ID to enable Vicious Expression on All
-        new BuffOnFoeDamageModifier(Mod_ViciousExpression, NumberOfBoons, "Vicious Expression", "25% on boonless target",  DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByAbsence, TraitImages.ConfoundingSuggestions, DamageModifierMode.PvE).WithBuilds(GW2Builds.February2020Balance, GW2Builds.February2020Balance2),
-        new BuffOnFoeDamageModifier(Mod_ViciousExpression, NumberOfBoons, "Vicious Expression", "15% on boonless target",  DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByAbsence, TraitImages.ConfoundingSuggestions, DamageModifierMode.All).WithBuilds(GW2Builds.February2020Balance2),
-        //
-        new DamageLogDamageModifier(Mod_Egotism, "Egotism", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.TemporalEnchanter, SelfHigherHPChecker, DamageModifierMode.PvE).WithBuilds(GW2Builds.October2018Balance, GW2Builds.February2023Balance).UsingApproximate(true),
-        new DamageLogDamageModifier(Mod_Egotism, "Egotism", "5% if target hp% lower than self hp%", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.TemporalEnchanter, SelfHigherHPChecker, DamageModifierMode.sPvPWvW).WithBuilds(GW2Builds.October2018Balance, GW2Builds.February2023Balance).UsingApproximate(true),
-        new DamageLogDamageModifier(Mod_Egotism, "Egotism", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.TemporalEnchanter, SelfHigherHPChecker, DamageModifierMode.All).WithBuilds(GW2Builds.February2023Balance).UsingApproximate(true),
-        //
+        new DamageLogDamageModifier(Mod_EmpoweredIllusions, "Empowered Illusions", "Illusions deal 15% increased strike damage", DamageSource.PetsOnly, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.EmpoweredIllusions, WithIllusionsChecker, DamageModifierMode.All),
+        new BuffOnFoeDamageModifier(Mod_ViciousExpressionWithIllusions, NumberOfBoons, "Vicious Expression", "25% on boonless target", DamageSource.All, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByAbsence, TraitImages.ConfoundingSuggestions, DamageModifierMode.PvE)
+            .UsingChecker(WithIllusionsChecker)
+            .WithBuilds(GW2Builds.February2020Balance, GW2Builds.February2020Balance2),
+        new BuffOnFoeDamageModifier(Mod_ViciousExpressionWithIllusions, NumberOfBoons, "Vicious Expression", "15% on boonless target", DamageSource.All, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByAbsence, TraitImages.ConfoundingSuggestions, DamageModifierMode.All)
+            .UsingChecker(WithIllusionsChecker)
+            .WithBuilds(GW2Builds.February2020Balance2),
+        new DamageLogDamageModifier(Mod_Egotism, "Egotism", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.TemporalEnchanter, SelfHigherHPChecker, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.October2018Balance, GW2Builds.February2023Balance)
+            .UsingApproximate(true),
+        new DamageLogDamageModifier(Mod_Egotism, "Egotism", "5% if target hp% lower than self hp%", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.TemporalEnchanter, SelfHigherHPChecker, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.October2018Balance, GW2Builds.February2023Balance)
+            .UsingApproximate(true),
+        new DamageLogDamageModifier(Mod_Egotism, "Egotism", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.TemporalEnchanter, SelfHigherHPChecker, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.February2023Balance)
+            .UsingApproximate(true),
         new BuffOnFoeDamageModifier(Mod_Fragility, Vulnerability, "Fragility", "0.5% per stack vuln on target", DamageSource.NoPets, 0.5, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.Fragility, DamageModifierMode.All),
         // Dueling
-        // Superiority Complex can all the conditions be tracked?
+        new DamageLogDamageModifier(Mod_SuperiorityComplex, "Superiority Complex", "15% always", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, (x, log) => x.HasCrit && !SuperiorityComplexBonusChecker(x, log), DamageModifierMode.All)
+            .WithEvtcBuilds(ArcDPSBuilds.StartOfLife, ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents)
+            .UsingApproximate(true),
+        new DamageLogDamageModifier(Mod_SuperiorityComplex, "Superiority Complex", "15% always", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, (x, log) => x.HasCrit && !SuperiorityComplexBonusChecker(x, log), DamageModifierMode.All)
+            .WithEvtcBuilds(ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents),
+        new DamageLogDamageModifier(Mod_SuperiorityComplexBonus, "Superiority Complex", "25% against disabled foes or below 50% hp", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, SuperiorityComplexBonusChecker, DamageModifierMode.All)
+            .WithEvtcBuilds(ArcDPSBuilds.StartOfLife, ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents)
+            .UsingApproximate(true),
+        new DamageLogDamageModifier(Mod_SuperiorityComplexBonus, "Superiority Complex", "25% against disabled foes or below 50% hp", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, SuperiorityComplexBonusChecker, DamageModifierMode.All)
+            .WithEvtcBuilds(ArcDPSBuilds.WeaponSwapValueIsPrevious_CrowdControlEvents_GliderEvents),
         // Illusions
-        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.All).WithBuilds(GW2Builds.StartOfLife, GW2Builds.November2023Balance),
-        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.All).WithBuilds(GW2Builds.November2023Balance),
-        // Phantasmal Force: the current infrastructure is not capable of checking buffs on minions, once we have that, this does not require knowing illusion species id
-        // Chaos       
-        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, Regeneration, "Illusionary Membrane", "10% under regeneration", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.All).WithBuilds(GW2Builds.May2021Balance, GW2Builds.November2023Balance),
-        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "10% under chaos aura", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.All).WithBuilds(GW2Builds.November2023Balance, GW2Builds.January2024Balance),
-        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "10% under chaos aura", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.sPvPWvW).WithBuilds(GW2Builds.January2024Balance),
-        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "7% under chaos aura", DamageSource.NoPets, 7.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.PvE).WithBuilds(GW2Builds.January2024Balance),
+        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.November2023Balance),
+        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.November2023Balance),
+        new BuffOnActorDamageModifier(Mod_PhantasmalForce, PhantasmalForce, "Phantasmal Force", "1% per stack of might when creating an illusion", DamageSource.PetsOnly, 1.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.PhantasmalForce_Mistrust, DamageModifierMode.PvE)
+            .UsingChecker(WithIllusionsChecker),
+        // Chaos
+        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, Regeneration, "Illusionary Membrane", "10% under regeneration", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.May2021Balance, GW2Builds.November2023Balance),
+        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "10% under chaos aura", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.November2023Balance, GW2Builds.January2024Balance),
+        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "10% under chaos aura", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.January2024Balance),
+        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "7% under chaos aura", DamageSource.NoPets, 7.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.January2024Balance),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =
@@ -151,7 +214,7 @@ internal static class MesmerHelper
         new Buff("Fencer's Finesse", FencersFinesse , Source.Mesmer, BuffStackType.Stacking, 10, BuffClassification.Other, TraitImages.FencersFinesse),
         new Buff("Illusionary Defense", IllusionaryDefense, Source.Mesmer, BuffStackType.Stacking, 5, BuffClassification.Other, TraitImages.IllusionaryDefense),
         new Buff("Compounding Power", CompoundingPower, Source.Mesmer, BuffStackType.Stacking, 5, BuffClassification.Other, TraitImages.CompoundingPower),
-        new Buff("Phantasmal Force", PhantasmalForce, Source.Mesmer, BuffStackType.Stacking, 25, BuffClassification.Other, TraitImages.Mistrust),
+        new Buff("Phantasmal Force", PhantasmalForce, Source.Mesmer, BuffStackType.Stacking, 25, BuffClassification.Other, TraitImages.PhantasmalForce_Mistrust),
         new Buff("Reflection", Reflection, Source.Mesmer, BuffStackType.Queue, 9, BuffClassification.Other, SkillImages.ArcaneShield),
         new Buff("Reflection 2", Reflection2, Source.Mesmer, BuffStackType.Queue, 9, BuffClassification.Other, SkillImages.ArcaneShield),
         // Transformations
@@ -161,7 +224,7 @@ internal static class MesmerHelper
         new Buff("Clarity", Clarity, Source.Mesmer, BuffClassification.Other, SkillImages.Clarity),
     ];
 
-    private static readonly HashSet<int> _cloneIDs =
+    private static readonly HashSet<int> _clones =
     [
         (int)MinionID.CloneSword,
         (int)MinionID.CloneScepter,
@@ -273,15 +336,10 @@ internal static class MesmerHelper
         {
             return false;
         }
-        return _cloneIDs.Contains(agentItem.ID);
+        return _clones.Contains(agentItem.ID);
     }
 
-    private static bool IsClone(int id)
-    {
-        return _cloneIDs.Contains(id);
-    }
-
-    private static HashSet<int> NonCloneMinions =
+    private static readonly HashSet<int> _phantasms =
     [
         (int)MinionID.IllusionaryWarlock,
         (int)MinionID.IllusionaryWarden,
@@ -298,9 +356,14 @@ internal static class MesmerHelper
         (int)MinionID.IllusionarySharpShooter,
     ];
 
+    private static IEnumerable<int> Illusions()
+    {
+        return _phantasms.Concat(_clones);
+    }
+
     internal static bool IsKnownMinionID(int id)
     {
-        return NonCloneMinions.Contains(id) || IsClone(id);
+        return _phantasms.Contains(id) || _clones.Contains(id);
     }
 
     internal static void ComputeProfessionCombatReplayActors(PlayerActor player, ParsedEvtcLog log, CombatReplay replay)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -102,7 +102,7 @@ internal static class MesmerHelper
 
     private static bool WithIllusionsChecker(DamageEvent x, ParsedEvtcLog log)
     {
-        return x.From == x.CreditedFrom || x.From.IsAnySpecies(Illusions());
+        return x.From == x.CreditedFrom || x.From.IsAnySpecies(_clones) || x.From.IsAnySpecies(_phantasms);
     }
 
     private static bool SuperiorityComplexBonusChecker(HealthDamageEvent x, ParsedEvtcLog log)
@@ -356,11 +356,6 @@ internal static class MesmerHelper
         (int)MinionID.IllusionarySharpShooter,
         (int)MinionID.IllusionaryLancer,
     ];
-
-    private static IEnumerable<int> Illusions()
-    {
-        return _phantasms.Concat(_clones);
-    }
 
     internal static bool IsKnownMinionID(int id)
     {

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
@@ -13,8 +13,7 @@ internal static class MirageHelper
     internal static readonly List<InstantCastFinder> InstantCastFinder =
     [
         new DamageCastFinder(Jaunt, Jaunt),
-        // new EffectCastFinderByDst(Jaunt, EffectGUIDs.MirageJaunt).UsingDstSpecChecker(Spec.Mirage),
-        new BuffGainCastFinder(MirageCloakDodge, MirageCloak), // Mirage Cloak
+        new BuffGainCastFinder(MirageCloakDodge, MirageCloak),
         //new EffectCastFinderByDst(IllusionaryAmbush, EffectGUIDs.MirageIllusionaryAmbush).UsingChecker((evt, log) => evt.Dst.Spec == Spec.Mirage),
     ];
 
@@ -39,7 +38,7 @@ internal static class MirageHelper
         new Buff("Sharp Edges", SharpEdges, Source.Mirage, BuffClassification.Other, TraitImages.MirageMantle),
     ];
 
-    private static HashSet<int> Minions = [];
+    private static readonly HashSet<int> Minions = [];
     internal static bool IsKnownMinionID(int id)
     {
         return Minions.Contains(id);

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
@@ -31,7 +31,8 @@ internal static class VirtuosoHelper
             })
             .WithBuilds(GW2Builds.October2022Balance),
         new EffectCastFinder(BladeturnRequiem, EffectGUIDs.VirtuosoBladeturnRequiem)
-            .UsingSrcSpecChecker(Spec.Virtuoso).WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
+            .UsingSrcSpecChecker(Spec.Virtuoso)
+            .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
         new EffectCastFinder(ThousandCuts, EffectGUIDs.VirtuosoThousandCuts)
             .UsingSrcSpecChecker(Spec.Virtuoso),
     ];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -43,34 +43,46 @@ internal static class NecromancerHelper
         new BuffLossCastFinder(SpectralRecallSkill, SpectralWalkTeleportBuff)
             .UsingChecker((evt, combatData, skillData, agentData) => !CombatData.FindRelatedEvents(combatData.GetBuffData(SpectralWalkBuff).OfType<BuffRemoveAllEvent>(), evt.Time + 120).Any())
             .WithBuilds(GW2Builds.December2018Balance),
-        new EffectCastFinderByDst(PlagueSignetSkill, EffectGUIDs.NecromancerPlagueSignet).UsingDstBaseSpecChecker(Spec.Necromancer),
-        new EXTHealingCastFinder(SpitefulRenewal, SpitefulRenewal).UsingOrigin(EIData.InstantCastFinder.InstantCastOrigin.Trait),
+        new EffectCastFinderByDst(PlagueSignetSkill, EffectGUIDs.NecromancerPlagueSignet)
+            .UsingDstBaseSpecChecker(Spec.Necromancer),
+        new EXTHealingCastFinder(SpitefulRenewal, SpitefulRenewal)
+            .UsingOrigin(EIData.InstantCastFinder.InstantCastOrigin.Trait),
         // Minions
         new MinionCommandCastFinder(RigorMortisSkill, (int) MinionID.BoneFiend),
         new MinionCommandCastFinder(HauntSkill, (int) MinionID.ShadowFiend),
         new MinionCommandCastFinder(NecroticTraversal, (int) MinionID.FleshWurm),
-        // new BuffGainWithMinionsCastFinder(RigorMortisSkill, RigorMortisEffect),
-        // new EffectCastFinder(NecroticTraversal, EffectGUIDs.NecromancerNecroticTraversal),
         // Spear
-        new EffectCastFinder(DistressSkill, EffectGUIDs.NecromancerSpearDistress).UsingChecker((effectEvent, combatData, agentData, skillData) => CombatData.FindRelatedEvents(combatData.GetBuffRemoveAllData(DistressBuff).OfType<BuffRemoveAllEvent>(), effectEvent.Time).Any()),
+        new EffectCastFinder(DistressSkill, EffectGUIDs.NecromancerSpearDistress)
+            .UsingChecker((effectEvent, combatData, agentData, skillData) => CombatData.FindRelatedEvents(combatData.GetBuffRemoveAllData(DistressBuff).OfType<BuffRemoveAllEvent>(), effectEvent.Time).Any()),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
         // Spite
         new BuffOnFoeDamageModifier(Mod_SpitefulTalisman, NumberOfBoons, "Spiteful Talisman", "10% on boonless target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByAbsence, TraitImages.SpitefulTalisman, DamageModifierMode.All),
-        new BuffOnActorDamageModifier(Mod_DeathsEmbrace, Downed, "Death's Embrace", "25% on while downed", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathsEmbrace, DamageModifierMode.All).WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2020Balance),
-        new BuffOnActorDamageModifier(Mod_DeathsEmbrace, Downed, "Death's Embrace", "25% on while downed", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathsEmbrace, DamageModifierMode.PvE).WithBuilds(GW2Builds.February2020Balance),
-        new BuffOnActorDamageModifier(Mod_DeathsEmbrace, Downed, "Death's Embrace", "5% on while downed", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathsEmbrace, DamageModifierMode.sPvPWvW).WithBuilds(GW2Builds.February2020Balance),
-        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "20% on feared target", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.PvE).WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2018Balance),
-        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "33% on feared target", DamageSource.NoPets, 33.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.All).WithBuilds(GW2Builds.August2018Balance, GW2Builds.February2020Balance),
-        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "33% on feared target", DamageSource.NoPets, 33.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.PvE).WithBuilds(GW2Builds.February2020Balance, GW2Builds.July2020Balance),
-        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "15% on feared target", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.sPvPWvW).WithBuilds(GW2Builds.February2020Balance, GW2Builds.July2020Balance),
+        new BuffOnActorDamageModifier(Mod_DeathsEmbrace, Downed, "Death's Embrace", "25% on while downed", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathsEmbrace, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2020Balance),
+        new BuffOnActorDamageModifier(Mod_DeathsEmbrace, Downed, "Death's Embrace", "25% on while downed", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathsEmbrace, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.February2020Balance),
+        new BuffOnActorDamageModifier(Mod_DeathsEmbrace, Downed, "Death's Embrace", "5% on while downed", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathsEmbrace, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.February2020Balance),
+        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "20% on feared target", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2018Balance),
+        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "33% on feared target", DamageSource.NoPets, 33.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.August2018Balance, GW2Builds.February2020Balance),
+        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "33% on feared target", DamageSource.NoPets, 33.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.February2020Balance, GW2Builds.July2020Balance),
+        new BuffOnFoeDamageModifier(Mod_Dread, Fear, "Dread", "15% on feared target", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.UnholyFervor, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.February2020Balance, GW2Builds.July2020Balance),
         new DamageLogDamageModifier(Mod_CloseToDeath, "Close to Death", "20% below 50% HP", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Necromancer, TraitImages.CloseToDeath, (x, log) => x.AgainstUnderFifty, DamageModifierMode.All),
         // Soul Reaping
-        new BuffOnActorDamageModifier(Mod_SoulBarbs, SoulBarbs, "Soul Barbs", "10% after entering or exiting shroud", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.SoulBarbs, DamageModifierMode.All).WithBuilds(GW2Builds.December2018Balance, GW2Builds.May2021Balance),
-        new BuffOnActorDamageModifier(Mod_SoulBarbs, SoulBarbs, "Soul Barbs", "10% after entering or exiting shroud", DamageSource.NoPets, 10.0, DamageType.StrikeAndConditionAndLifeLeech, DamageType.All, Source.Necromancer, ByPresence, TraitImages.SoulBarbs, DamageModifierMode.All).WithBuilds(GW2Builds.May2021Balance),
-        new BuffOnActorDamageModifier(Mod_DeathPerception, [DeathShroud, ReapersShroud, HarbingerShroud], "Death Perception", "15% crit damage while in shroud", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathPerception, DamageModifierMode.All).UsingChecker((x, log) => x.HasCrit).WithBuilds(GW2Builds.June2022Balance), // no tracked for Scourge
+        new BuffOnActorDamageModifier(Mod_SoulBarbs, SoulBarbs, "Soul Barbs", "10% after entering or exiting shroud", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.SoulBarbs, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.December2018Balance, GW2Builds.May2021Balance),
+        new BuffOnActorDamageModifier(Mod_SoulBarbs, SoulBarbs, "Soul Barbs", "10% after entering or exiting shroud", DamageSource.NoPets, 10.0, DamageType.StrikeAndConditionAndLifeLeech, DamageType.All, Source.Necromancer, ByPresence, TraitImages.SoulBarbs, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.May2021Balance),
+        new BuffOnActorDamageModifier(Mod_DeathPerception, [DeathShroud, ReapersShroud, HarbingerShroud], "Death Perception", "15% crit damage while in shroud", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathPerception, DamageModifierMode.All)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.June2022Balance), // no tracked for Scourge
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =
@@ -101,18 +113,25 @@ internal static class NecromancerHelper
         new Buff("Signet of Undeath", SignetOfUndeathBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SignetOfUndeath),
         new Buff("Signet of Undeath (Shroud)", SignetOfUndeathShroud, Source.Necromancer, BuffClassification.Other, SkillImages.SignetOfUndeath),
         // Skills
-        new Buff("Spectral Walk", SpectralWalkOldBuff, Source.Necromancer, BuffClassification.Other, SkillImages.NecroticTraversal).WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2018Balance),
-        new Buff("Spectral Walk", SpectralWalkOldBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SpectralWalk).WithBuilds(GW2Builds.July2018Balance, GW2Builds.December2018Balance),
-        new Buff("Spectral Walk", SpectralWalkBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SpectralWalk).WithBuilds(GW2Builds.December2018Balance),
-        new Buff("Spectral Walk (Teleport)", SpectralWalkTeleportBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SpectralWalk).WithBuilds(GW2Builds.December2018Balance),
+        new Buff("Spectral Walk", SpectralWalkOldBuff, Source.Necromancer, BuffClassification.Other, SkillImages.NecroticTraversal)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2018Balance),
+        new Buff("Spectral Walk", SpectralWalkOldBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SpectralWalk)
+            .WithBuilds(GW2Builds.July2018Balance, GW2Builds.December2018Balance),
+        new Buff("Spectral Walk", SpectralWalkBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SpectralWalk)
+            .WithBuilds(GW2Builds.December2018Balance),
+        new Buff("Spectral Walk (Teleport)", SpectralWalkTeleportBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SpectralWalk)
+            .WithBuilds(GW2Builds.December2018Balance),
         new Buff("Spectral Armor", SpectralArmorBuff, Source.Necromancer, BuffClassification.Other, SkillImages.SpectralArmor),
         new Buff("Locust Swarm", LocustSwarm, Source.Necromancer, BuffClassification.Other, SkillImages.LocustSwarm),
         new Buff("Grim Specter", GrimSpecterBuff, Source.Necromancer, BuffStackType.Stacking, 25, BuffClassification.Other, SkillImages.GrimSpecter),
         new Buff("Grim Specter (Target)", GrimSpecterTargetBuff, Source.Necromancer, BuffStackType.Stacking, 25, BuffClassification.Other, SkillImages.GrimSpecter),
         // Traits
-        new Buff("Corrupter's Defense", CorruptersDefense, Source.Necromancer, BuffStackType.Stacking, 10, BuffClassification.Other, TraitImages.CorruptersFervor).WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2019Balance),
-        new Buff("Death's Carapace", DeathsCarapace, Source.Necromancer, BuffStackType.Stacking, 30, BuffClassification.Other, TraitImages.DeathsCarapace).WithBuilds(GW2Builds.October2019Balance),
-        new Buff("Flesh of the Master", FleshOfTheMaster, Source.Necromancer, BuffStackType.Stacking, 25, BuffClassification.Other, TraitImages.FleshOfTheMaster).WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2019Balance),
+        new Buff("Corrupter's Defense", CorruptersDefense, Source.Necromancer, BuffStackType.Stacking, 10, BuffClassification.Other, TraitImages.CorruptersFervor)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2019Balance),
+        new Buff("Death's Carapace", DeathsCarapace, Source.Necromancer, BuffStackType.Stacking, 30, BuffClassification.Other, TraitImages.DeathsCarapace)
+            .WithBuilds(GW2Builds.October2019Balance),
+        new Buff("Flesh of the Master", FleshOfTheMaster, Source.Necromancer, BuffStackType.Stacking, 25, BuffClassification.Other, TraitImages.FleshOfTheMaster)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2019Balance),
         new Buff("Vampiric Aura", VampiricAura, Source.Necromancer, BuffClassification.Defensive, TraitImages.VampiricPresence),
         new Buff("Vampiric Strikes", VampiricStrikes, Source.Necromancer, BuffClassification.Other, TraitImages.VampiricPresence),
         new Buff("Last Rites", LastRites, Source.Necromancer, BuffClassification.Defensive, TraitImages.LastRites),
@@ -142,7 +161,7 @@ internal static class NecromancerHelper
             || HarbingerHelper.IsHarbingerShroudTransform(id);
     }
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.BloodFiend,
         (int)MinionID.FleshGolem,

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/ReaperHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/ReaperHelper.cs
@@ -27,7 +27,6 @@ internal static class ReaperHelper
             .UsingDisableWithEffectData(),
         new EffectCastFinder(Suffer, EffectGUIDs.ReaperSuffer)
             .UsingSrcSpecChecker(Spec.Reaper),
-        // new BuffGainCastFinder(Rise, DarkBond).UsingICD(500), // buff reapplied on every minion attack
         new MinionSpawnCastFinder(Rise, (int)MinionID.ShamblingHorror)
             .UsingChecker((evt, combatData, agentData, skillData) => evt.Src.GetFinalMaster().Spec == Spec.Reaper),
         new DamageCastFinder(ChillingNova, ChillingNova)
@@ -53,9 +52,12 @@ internal static class ReaperHelper
     [
         new BuffOnActorDamageModifier(Mod_ReapersShroud, ReapersShroud, "Reaper's Shroud", "-33%", DamageSource.Incoming, -33, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.ReapersShroud, DamageModifierMode.PvE),
         new BuffOnActorDamageModifier(Mod_ReapersShroud, ReapersShroud, "Reaper's Shroud", "-50%", DamageSource.Incoming, -50, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.ReapersShroud, DamageModifierMode.sPvPWvW),
-        new BuffOnActorDamageModifier(Mod_InfusingTerror, InfusingTerrorBuff, "Infusing Terror", "-20%", DamageSource.Incoming, -20, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.InfusingTerror, DamageModifierMode.All).WithBuilds(GW2Builds.StartOfLife, GW2Builds.May2023Balance),
-        new BuffOnActorDamageModifier(Mod_InfusingTerror, InfusingTerrorBuff, "Infusing Terror", "-20%", DamageSource.Incoming, -20, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.InfusingTerror, DamageModifierMode.sPvPWvW).WithBuilds(GW2Builds.May2023Balance),
-        new BuffOnActorDamageModifier(Mod_InfusingTerror, InfusingTerrorBuff, "Infusing Terror", "-66%", DamageSource.Incoming, -66, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.InfusingTerror, DamageModifierMode.PvE).WithBuilds(GW2Builds.May2023Balance), 
+        new BuffOnActorDamageModifier(Mod_InfusingTerror, InfusingTerrorBuff, "Infusing Terror", "-20%", DamageSource.Incoming, -20, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.InfusingTerror, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.May2023Balance),
+        new BuffOnActorDamageModifier(Mod_InfusingTerror, InfusingTerrorBuff, "Infusing Terror", "-20%", DamageSource.Incoming, -20, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.InfusingTerror, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.May2023Balance),
+        new BuffOnActorDamageModifier(Mod_InfusingTerror, InfusingTerrorBuff, "Infusing Terror", "-66%", DamageSource.Incoming, -66, DamageType.StrikeAndCondition, DamageType.All, Source.Reaper, ByPresence, SkillImages.InfusingTerror, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.May2023Balance), 
         // Rise is unclear, I don't see any inc damage reducing fact for Dark Bond
     ];
 
@@ -78,7 +80,7 @@ internal static class ReaperHelper
         return _reaperShroudTransform.Contains(id);
     }
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.ShamblingHorror,
     ];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/ScourgeHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/ScourgeHelper.cs
@@ -15,8 +15,6 @@ internal static class ScourgeHelper
     internal static readonly List<InstantCastFinder> InstantCastFinder =
     [
         new BuffGainCastFinder(TrailOfAnguish, TrailOfAnguishBuff),
-        // Trail of Anguish? Unique effect?
-        // new EffectCastFinder(TrailOfAnguish, EffectGUIDs.ScourgeTrailOfAnguish).UsingSrcSpecChecker(Spec.Scourge).UsingICD(6100),
         new DamageCastFinder(NefariousFavorSkill, NefariousFavorShadeHit),
         new DamageCastFinder(GarishPillarSkill, GarishPillarHit),
         new BuffGainCastFinder(DesertShroud, DesertShroudBuff)
@@ -48,6 +46,7 @@ internal static class ScourgeHelper
     [
         new Buff("Sadistic Searing", SadisticSearing, Source.Scourge, BuffClassification.Other, TraitImages.SadisticSearing),
         new Buff("Path Uses", PathUses, Source.Scourge, BuffStackType.Stacking, 25, BuffClassification.Other, SkillImages.SandSwell),
+        new Buff("Trail of Anguish", TrailOfAnguishBuff, Source.Scourge, BuffClassification.Other, SkillImages.TrailofAnguish),
     ];
 
     internal static void ComputeProfessionCombatReplayActors(PlayerActor player, ParsedEvtcLog log, CombatReplay replay)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -826,4 +826,18 @@ internal static class ProfHelper
         replay.Decorations.Add(new DoughnutDecoration(innerRadius, outerRadius, lifespan, color, 0.5, connector).UsingFilled(false).UsingSkillMode(skill));
         replay.Decorations.Add(new IconDecoration(icon, CombatReplaySkillDefaultSizeInPixel, CombatReplaySkillDefaultSizeInWorld, 0.5f, lifespan, connector).UsingSkillMode(skill));
     }
+
+    /// <summary>
+    /// Checks for self HP to be higher than the target HP.
+    /// </summary>
+    internal static bool SelfHigherHPChecker(DamageEvent x, ParsedEvtcLog log)
+    {
+        double selfHP = x.From.GetCurrentHealthPercent(log, x.Time);
+        double dstHP = x.To.GetCurrentHealthPercent(log, x.Time);
+        if (selfHP < 0.0 || dstHP < 0.0)
+        {
+            return false;
+        }
+        return selfHP > dstHP;
+    }
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/SoulbeastHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/SoulbeastHelper.cs
@@ -54,7 +54,9 @@ internal static class SoulbeastHelper
             .WithBuilds(GW2Builds.May2021BalanceHotFix, GW2Builds.September2023Balance),
         new BuffOnActorDamageModifier(Mod_FuriousStrength, Fury, "Furious Strength", "10% under fury", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Soulbeast, ByStack, TraitImages.FuriousStrength, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.September2023Balance),
-        new BuffOnActorDamageModifier(Mod_LoudWhistle, [Stout, Deadly, Ferocious, Supportive, Versatile], "Loud Whistle", "10% while merged and hp >=90%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Soulbeast, ByPresence, TraitImages.LoudWhistle, DamageModifierMode.All).UsingChecker((x,log) => x.IsOverNinety).WithBuilds(GW2Builds.May2018Balance),
+        new BuffOnActorDamageModifier(Mod_LoudWhistle, [Stout, Deadly, Ferocious, Supportive, Versatile], "Loud Whistle", "10% while merged and hp >=90%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Soulbeast, ByPresence, TraitImages.LoudWhistle, DamageModifierMode.All)
+            .UsingChecker((x,log) => x.IsOverNinety)
+            .WithBuilds(GW2Builds.May2018Balance),
         new DamageLogDamageModifier(Mod_OppressiveSuperiority, "Oppressive Superiority", "10% if target hp% lower than self hp%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Soulbeast, TraitImages.OppressiveSuperiority, (x,log) =>
             {
                 double selfHP = x.From.GetCurrentHealthPercent(log, x.Time);

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/UntamedHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/UntamedHelper.cs
@@ -15,9 +15,12 @@ internal static class UntamedHelper
     [
         new BuffGainCastFinder(UnleashPet, PetUnleashed),
         new BuffGainCastFinder(UnleashRanger, Unleashed),
-        new BuffGainCastFinder(RestorativeStrikes, RestorativeStrikes).UsingOrigin(EIData.InstantCastFinder.InstantCastOrigin.Trait),
-        new EffectCastFinderByDst(MutateConditions, EffectGUIDs.UntamedMutateConditions).UsingDstSpecChecker(Spec.Untamed),
-        new EffectCastFinderByDst(UnnaturalTraversal, EffectGUIDs.UntamedUnnaturalTraversal).UsingDstSpecChecker(Spec.Untamed),
+        new BuffGainCastFinder(RestorativeStrikes, RestorativeStrikes)
+            .UsingOrigin(EIData.InstantCastFinder.InstantCastOrigin.Trait),
+        new EffectCastFinderByDst(MutateConditions, EffectGUIDs.UntamedMutateConditions)
+            .UsingDstSpecChecker(Spec.Untamed),
+        new EffectCastFinderByDst(UnnaturalTraversal, EffectGUIDs.UntamedUnnaturalTraversal)
+            .UsingDstSpecChecker(Spec.Untamed),
 
         // Pet
         new EffectCastFinder(VenomousOutburst, EffectGUIDs.UntamedVenomousOutburst)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/HeraldHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/HeraldHelper.cs
@@ -72,8 +72,10 @@ internal static class HeraldHelper
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =
     [
-        new BuffOnActorDamageModifier(Mod_FacetOfNatureDwarf, FacetOfNatureDwarf, "Facet of Nature - Dwarf", "-10%", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Common, ByPresence, SkillImages.FacetOfNatureDwarf, DamageModifierMode.All).WithBuilds(GW2Builds.August2018Balance),
-        new BuffOnActorDamageModifier(Mod_HardeningPersistence, HardeningPersistence, "Hardening Persistence", "-1% per stack", DamageSource.Incoming, -1.0, DamageType.Strike, DamageType.All, Source.Herald, ByStack, TraitImages.HardeningPersistence, DamageModifierMode.All).WithBuilds(GW2Builds.August2018Balance, GW2Builds.July2019Balance),
+        new BuffOnActorDamageModifier(Mod_FacetOfNatureDwarf, FacetOfNatureDwarf, "Facet of Nature - Dwarf", "-10%", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Common, ByPresence, SkillImages.FacetOfNatureDwarf, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.August2018Balance),
+        new BuffOnActorDamageModifier(Mod_HardeningPersistence, HardeningPersistence, "Hardening Persistence", "-1% per stack", DamageSource.Incoming, -1.0, DamageType.Strike, DamageType.All, Source.Herald, ByStack, TraitImages.HardeningPersistence, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.August2018Balance, GW2Builds.July2019Balance),
         new BuffOnActorDamageModifier(Mod_HardeningPersistence, HardeningPersistence, "Hardening Persistence", "-1.5% per stack", DamageSource.Incoming, -1.5, DamageType.Strike, DamageType.All, Source.Herald, ByStack, TraitImages.HardeningPersistence, DamageModifierMode.All)
             .WithBuilds(GW2Builds.July2019Balance),
     ];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RenegadeHelper.cs
@@ -90,7 +90,7 @@ internal static class RenegadeHelper
         new Buff("All for One", AllForOne, Source.Renegade, BuffStackType.Queue, 99, BuffClassification.Other, TraitImages.AllForOne),
     ];
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.JasRazorclaw,
         (int)MinionID.ViskIcerazor,

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -95,9 +95,12 @@ internal static class RevenantHelper
             .WithBuilds(GW2Builds.August2022Balance),
         new BuffOnActorDamageModifier(Mod_FerociousAggression, Fury, "Ferocious Aggression", "10% under fury", DamageSource.NoPets, 10.0, DamageType.StrikeAndConditionAndLifeLeech, DamageType.All, Source.Revenant, ByPresence, TraitImages.FerociousAggression, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.August2022Balance),
-        new DamageLogDamageModifier(Mod_RisingTide, "Rising Tide", "7% if hp >=90%", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.RisingTide, (x, log) => x.IsOverNinety, DamageModifierMode.All).WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2022Balance),
-        new DamageLogDamageModifier(Mod_RisingTide, "Rising Tide", "7% if hp >=90%", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.RisingTide, (x, log) => x.IsOverNinety, DamageModifierMode.sPvPWvW).WithBuilds(GW2Builds.August2022Balance),
-        new DamageLogDamageModifier(Mod_RisingTide, "Rising Tide", "10% if hp >=90%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.RisingTide, (x, log) => x.IsOverNinety, DamageModifierMode.PvE).WithBuilds(GW2Builds.August2022Balance, GW2Builds.November2022Balance),
+        new DamageLogDamageModifier(Mod_RisingTide, "Rising Tide", "7% if hp >=90%", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.RisingTide, (x, log) => x.IsOverNinety, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2022Balance),
+        new DamageLogDamageModifier(Mod_RisingTide, "Rising Tide", "7% if hp >=90%", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.RisingTide, (x, log) => x.IsOverNinety, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.August2022Balance),
+        new DamageLogDamageModifier(Mod_RisingTide, "Rising Tide", "10% if hp >=90%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.RisingTide, (x, log) => x.IsOverNinety, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.August2022Balance, GW2Builds.November2022Balance),
         new DamageLogDamageModifier(Mod_RisingTide, "Rising Tide", "10% if hp >=75%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.RisingTide, (x, log) => x.From.GetCurrentHealthPercent(log, x.Time) >= 75.0, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.November2022Balance).UsingApproximate(true),
         // Devastation
@@ -206,13 +209,13 @@ internal static class RevenantHelper
 
     private static readonly HashSet<long> _legendSwaps =
     [
-        LegendaryAssassinStanceSkill, // Assassin
-        LegendaryDemonStanceSkill, // Demon
-        LegendaryDwarfStanceSkill, // Dwarf
-        LegendaryCentaurStanceSkill, // Centaur
-        LegendaryDragonStanceSkill, // Dragon
-        LegendaryRenegadeStanceSkill, // Renegade
-        LegendaryAllianceStanceSkill, // Alliance
+        LegendaryAssassinStanceSkill,
+        LegendaryDemonStanceSkill,
+        LegendaryDwarfStanceSkill,
+        LegendaryCentaurStanceSkill,
+        LegendaryDragonStanceSkill,
+        LegendaryRenegadeStanceSkill,
+        LegendaryAllianceStanceSkill,
         //LegendaryAllianceStanceUWSkill, // Alliance (UW)
     ];
 
@@ -221,7 +224,7 @@ internal static class RevenantHelper
         return _legendSwaps.Contains(id);
     }
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.VentariTablet
     ];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/DeadeyeHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/DeadeyeHelper.cs
@@ -87,7 +87,7 @@ internal static class DeadeyeHelper
         new Buff("Deadeye's Gaze", DeadeyesGaze, Source.Deadeye, BuffClassification.Other, SkillImages.DeadeyesMark),
     ];
 
-    private static HashSet<int> Minions =
+    private static readonly HashSet<int> Minions =
     [
         (int)MinionID.DeadeyeSylvari1,
         (int)MinionID.DeadeyeHuman1,

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/ThiefHelper.cs
@@ -29,18 +29,22 @@ internal static class ThiefHelper
         new BuffGiveCastFinder(SpiderVenomSkill,SpiderVenomBuff).
             UsingChecker((evt, combatData, agentData, skillData) => evt.To != evt.By || Math.Abs(evt.AppliedDuration - 24000) < ServerDelayConstant)
             .UsingNotAccurate(true), // same id as leeching venom trait?
-        new EffectCastFinder(Pitfall, EffectGUIDs.ThiefPitfallAoE).UsingSrcBaseSpecChecker(Spec.Thief),
+        new EffectCastFinder(Pitfall, EffectGUIDs.ThiefPitfallAoE)
+            .UsingSrcBaseSpecChecker(Spec.Thief),
         new BuffLossCastFinder(ThousandNeedles, ThousandNeedlesArmedBuff)
             .UsingChecker((evt, combatData, agentData, skillData) => combatData.HasRelatedEffect(EffectGUIDs.ThiefThousandNeedlesAoE1, evt.To, evt.Time + 280))
             .UsingChecker((evt, combatData, agentData, skillData) => combatData.HasRelatedEffect(EffectGUIDs.ThiefThousandNeedlesAoE2, evt.To, evt.Time + 280))
             .UsingNotAccurate(true),
-        new EffectCastFinder(SealArea, EffectGUIDs.ThiefSealAreaAoE).UsingSrcBaseSpecChecker(Spec.Thief),
+        new EffectCastFinder(SealArea, EffectGUIDs.ThiefSealAreaAoE)
+            .UsingSrcBaseSpecChecker(Spec.Thief),
         new BuffGainCastFinder(ShadowPortal, ShadowPortalOpenedBuff),
         new EffectCastFinderByDst(InfiltratorsSignetSkill, EffectGUIDs.ThiefInfiltratorsSignet1)
             .UsingDstBaseSpecChecker(Spec.Thief)
             .UsingSecondaryEffectChecker(EffectGUIDs.ThiefInfiltratorsSignet2),
-        new EffectCastFinderByDst(SignetOfAgilitySkill, EffectGUIDs.ThiefSignetOfAgility).UsingDstBaseSpecChecker(Spec.Thief),
-        new EffectCastFinderByDst(SignetOfShadowsSkill, EffectGUIDs.ThiefSignetOfShadows).UsingDstBaseSpecChecker(Spec.Thief),
+        new EffectCastFinderByDst(SignetOfAgilitySkill, EffectGUIDs.ThiefSignetOfAgility)
+            .UsingDstBaseSpecChecker(Spec.Thief),
+        new EffectCastFinderByDst(SignetOfShadowsSkill, EffectGUIDs.ThiefSignetOfShadows)
+            .UsingDstBaseSpecChecker(Spec.Thief),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
@@ -60,7 +60,8 @@ internal static class BerserkerHelper
         new Buff("Blood Reckoning", BloodReckoning , Source.Berserker, BuffStackType.Queue, 9, BuffClassification.Other, SkillImages.BloodReckoning)
             .WithBuilds(GW2Builds.October2022Balance),
         new Buff("Rock Guard", RockGuard , Source.Berserker, BuffClassification.Other, SkillImages.ShatteringBlow),
-        new Buff("Feel No Pain (Savage Instinct)", FeelNoPainSavageInstinct, Source.Berserker, BuffClassification.Other, TraitImages.SavageInstinct).WithBuilds(GW2Builds.April2019Balance),
+        new Buff("Feel No Pain (Savage Instinct)", FeelNoPainSavageInstinct, Source.Berserker, BuffClassification.Other, TraitImages.SavageInstinct)
+            .WithBuilds(GW2Builds.April2019Balance),
         new Buff("Always Angry", AlwaysAngry, Source.Berserker, BuffClassification.Other, TraitImages.AlwaysAngry)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.April2019Balance),
         new Buff("Heat the Soul", HeatTheSoulBuff, Source.Berserker, BuffClassification.Other, TraitImages.HeatTheSoul),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BladeswornHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BladeswornHelper.cs
@@ -11,7 +11,7 @@ namespace GW2EIEvtcParser.EIData;
 
 internal static class BladeswornHelper
 {
-    /////////////////////
+
     internal static readonly List<InstantCastFinder> InstantCastFinder =
     [
         new BuffLossCastFinder(GunsaberSheath, GunsaberMode)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
@@ -13,7 +13,7 @@ namespace GW2EIEvtcParser.EIData;
 
 internal static class SpellbreakerHelper
 {
-    /////////////////////
+
     internal static readonly List<InstantCastFinder> InstantCastFinder =
     [
         new BuffGainCastFinder(SightBeyondSightSkill, SightBeyondSightBuff),

--- a/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Agents/AgentItem.cs
@@ -394,6 +394,14 @@ public class AgentItem
         return log.FindActor(this).HasBuff(log, by, buffId, time);
     }
 
+    /// <summary>
+    /// Checks if the buffs are present on the actor.  Given buff id must be in the buff simulator, throws <see cref="InvalidOperationException"/> otherwise.
+    /// </summary>
+    public bool HasAnyBuff(ParsedEvtcLog log, IEnumerable<long> buffIds, long time, long window = 0)
+    {
+        return buffIds.Any(id => log.FindActor(this).HasBuff(log, id, time, window));
+    }
+
     public Segment GetBuffStatus(ParsedEvtcLog log, long buffId, long time)
     {
         return log.FindActor(this).GetBuffStatus(log, buffId, time);

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -1396,7 +1396,12 @@ public class SkillItem
     //public int Range { get; private set; } = 0;
     private readonly bool AA;
 
-    public bool IsSwap => ID == WeaponSwap || ElementalistHelper.IsElementalSwap(ID) || RevenantHelper.IsLegendSwap(ID) || NecromancerHelper.IsDeathShroudTransform(ID) || HarbingerHelper.IsHarbingerShroudTransform(ID);
+    public bool IsSwap => ID == WeaponSwap 
+        || ElementalistHelper.IsAttunementSwap(ID)
+        || WeaverHelper.IsAttunementSwap(ID)
+        || RevenantHelper.IsLegendSwap(ID)
+        || NecromancerHelper.IsDeathShroudTransform(ID)
+        || HarbingerHelper.IsHarbingerShroudTransform(ID);
     public bool IsDodge(SkillData skillData) => IsAnimatedDodge(skillData) || ID == MirageCloakDodge;
     public bool IsAnimatedDodge(SkillData skillData) => ID == skillData.DodgeId || VindicatorHelper.IsVindicatorDodge(ID);
     public bool IsAutoAttack(ParsedEvtcLog log) => AA || FirebrandHelper.IsAutoAttack(log, ID) || BladeswornHelper.IsAutoAttack(log, ID);

--- a/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
@@ -338,5 +338,12 @@ public static class DamageModifierIDs
     public const int Mod_ImprovedKallasFervorConditionLifeLeech = 325;
     public const int Mod_Wolfsong = 326;
     public const int Mod_BeastlyWardenPetOnly = 327;
+    public const int Mod_EmpoweredIllusions = 328;
+    public const int Mod_ViciousExpressionWithIllusions = 329;
+    public const int Mod_SuperiorityComplex = 330;
+    public const int Mod_SuperiorityComplexBonus = 331;
+    public const int Mod_PhantasmalForce = 332;
+    public const int Mod_SicEmPet = 333;
+    public const int Mod_BountifulHunterWithPet = 334;
 }
 

--- a/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
@@ -333,6 +333,7 @@ internal static class SkillImages
     public const string TaintedShackles = "https://render.guildwars2.com/file/CBEB3C180F343DC0CBA9BD5A3E09642C1D73599C/598947.png";
     public const string ShamblingSlash = "https://wiki.guildwars2.com/images/a/ad/Shambling_Slash.png";
     public const string SoulSpiral = "https://render.guildwars2.com/file/4BFAEBD27404BDCB3A0255F1441560D3772F0CF5/1012937.png";
+    public const string TrailofAnguish = "https://render.guildwars2.com/file/707877465DF8AD08E7E7F30EC908CAA4684D203B/1770544.png";
     #endregion Necromancer
     #region Ranger
     public const string SicEm = "https://wiki.guildwars2.com/images/9/9d/%22Sic_%27Em%21%22.png";

--- a/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
@@ -111,7 +111,7 @@ internal static class TraitImages
     public const string MentalFocus = "https://render.guildwars2.com/file/B32B3E90552D3AE773E403D6D7AA00F50F750580/2479328.png";
     public const string DeadlyBlades = "https://render.guildwars2.com/file/C4AFBAAA039152A302C15B805CAD980EA9B5D006/2479337.png";
     public const string FencersFinesse = "https://render.guildwars2.com/file/4DEE67F2B54D37C8ACEC0F235C94D0C140A77E0F/1012503.png";
-    public const string Mistrust = "https://render.guildwars2.com/file/E002FB5DEC3A010F03F2E8A7D5000DF778215F6C/1012505.png";
+    public const string PhantasmalForce_Mistrust = "https://render.guildwars2.com/file/E002FB5DEC3A010F03F2E8A7D5000DF778215F6C/1012505.png";
     public const string IllusionaryDefense = "https://render.guildwars2.com/file/0E25FD2E32E05D360DB1785818965A4439C1F445/1012463.png";
     public const string HealingPrism = "https://render.guildwars2.com/file/090D289158520416A4402EBE9C92257E1309020D/1012533.png";
     public const string IllusionaryInspiration = HealingPrism;
@@ -119,6 +119,8 @@ internal static class TraitImages
     public const string PowerBlock = "https://render.guildwars2.com/file/E029766272E10A957B954B12B20FD916474D5A01/1012494.png";
     public const string PersistenceOfMemory = "https://render.guildwars2.com/file/F225A021EB41754E4E0C9FCB46F40F7212DA41CE/1012511.png";
     public const string NomadsEndurance = "https://render.guildwars2.com/file/EC4E5BEAD50EC6A5A91C312EE521B7C6EC56393B/1769961.png";
+    public const string EmpoweredIllusions = "https://render.guildwars2.com/file/4337F2F9DCC4F7A6022997409400423F7A1BB946/1012487.png";
+    public const string SuperiorityComplex = "https://render.guildwars2.com/file/AAD25BD0F7753D5B447E9654A4AE6A35057B2932/1012504.png";
     #endregion
     #region Necromancer
     public const string VampiricPresence = "https://render.guildwars2.com/file/22B370D754AC1D69A8FE66DCCB36BE940455E5EA/1012539.png";


### PR DESCRIPTION
# Mesmer
- Added Superiority Complex damage modifiers
- Added Empowered Illusions damage modifier
- Updated Vicious Expression to include illusions
- Added Phantasmal Force damage modifier
- Added missing Illusionary Lancer to phantasms list

# Elementalist
- Moved weaver attunement swaps to WeaverHelper

# Ranger
- Added Sic 'Em damage modifier for pets
- Moved Juvenile Warclaw to Feline family as stated on the wiki
- Updated Bountiful Hunter to include pets

# General
- Added HasAnyBuff to AgentItem
- Moved SelfHigherHPChecker from Mesmer and Engineer to ProfHelper
- Formatted chaining methods to be equal for all files
- Added readonly to missing Minions lists
- Cleaned up some outdated commented things