### PR TITLE
Professions cleanup 3

### DIFF
--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -188,9 +188,13 @@ internal static class MesmerHelper
         new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "10% under chaos aura", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.All)
             .WithBuilds(GW2Builds.November2023Balance, GW2Builds.January2024Balance),
         new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "10% under chaos aura", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.January2024Balance),
+            .WithBuilds(GW2Builds.January2024Balance, GW2Builds.April2025BalancePatch),
         new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, ChaosAura, "Illusionary Membrane", "7% under chaos aura", DamageSource.NoPets, 7.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.January2024Balance),
+            .WithBuilds(GW2Builds.January2024Balance, GW2Builds.April2025BalancePatch),
+        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, IllusionaryMembrane, "Illusionary Membrane", "10%", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2025BalancePatch),
+        new BuffOnActorDamageModifier(Mod_IllusionaryMembrane, IllusionaryMembrane, "Illusionary Membrane", "7%", DamageSource.NoPets, 7.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.IllusionaryMembrane, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2025BalancePatch),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =
@@ -220,7 +224,8 @@ internal static class MesmerHelper
         new Buff("Portal Weaving", PortalWeaving, Source.Mesmer, BuffClassification.Other, SkillImages.PortalEnter),
         new Buff("Portal Uses", PortalUses, Source.Mesmer, BuffStackType.Stacking, 25, BuffClassification.Other, SkillImages.PortalEnter),
         new Buff("Illusion of Life", IllusionOfLifeBuff, Source.Mesmer, BuffClassification.Support, SkillImages.IllusionOfLife),
-        new Buff("Time Echo", TimeEcho, Source.Mesmer, BuffClassification.Other, SkillImages.DejaVu).WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
+        new Buff("Time Echo", TimeEcho, Source.Mesmer, BuffClassification.Other, SkillImages.DejaVu)
+            .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
         new Buff("Dimensional Aperture", DimensionalAperturePortalBuff, Source.Mesmer, BuffClassification.Other, SkillImages.DimensionalAperture),
         // Traits
         new Buff("Fencer's Finesse", FencersFinesse , Source.Mesmer, BuffStackType.Stacking, 10, BuffClassification.Other, TraitImages.FencersFinesse),
@@ -229,6 +234,7 @@ internal static class MesmerHelper
         new Buff("Phantasmal Force", PhantasmalForce, Source.Mesmer, BuffStackType.Stacking, 25, BuffClassification.Other, TraitImages.PhantasmalForce_Mistrust),
         new Buff("Reflection", Reflection, Source.Mesmer, BuffStackType.Queue, 9, BuffClassification.Other, SkillImages.ArcaneShield),
         new Buff("Reflection 2", Reflection2, Source.Mesmer, BuffStackType.Queue, 9, BuffClassification.Other, SkillImages.ArcaneShield),
+        new Buff("Illusionary Membrane", IllusionaryMembrane, Source.Mesmer, BuffStackType.Queue, 9, BuffClassification.Other, TraitImages.IllusionaryMembrane),
         // Transformations
         new Buff("Morphed (Polymorph Moa)", MorphedPolymorphMoa, Source.Mesmer, BuffClassification.Debuff, SkillImages.MorphedPolymorphMoa),
         new Buff("Morphed (Polymorph Tuna)", MorphedPolymorphTuna, Source.Mesmer, BuffClassification.Debuff, SkillImages.MorphedPolymorphTuna),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
@@ -12,9 +12,14 @@ internal static class MirageHelper
 
     internal static readonly List<InstantCastFinder> InstantCastFinder =
     [
-        new DamageCastFinder(Jaunt, Jaunt),
+        new DamageCastFinder(Jaunt, Jaunt)
+            .UsingDisableWithEffectData(),
+        new EffectCastFinder(Jaunt, EffectGUIDs.MirageJaunt)
+            .UsingSecondaryEffectChecker(EffectGUIDs.MirageJauntConflict1)
+            .UsingSecondaryEffectChecker(EffectGUIDs.MirageJauntConflict2)
+            .UsingSrcSpecChecker(Spec.Mirage),
         new BuffGainCastFinder(MirageCloakDodge, MirageCloak),
-        //new EffectCastFinderByDst(IllusionaryAmbush, EffectGUIDs.MirageIllusionaryAmbush).UsingChecker((evt, log) => evt.Dst.Spec == Spec.Mirage),
+        // Illusionary Ambush not trackable due to conflicting effects with Jaunt and Axe of Symmetry
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/DaredevilHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/DaredevilHelper.cs
@@ -20,7 +20,6 @@ internal static class DaredevilHelper
             .UsingOrigin(InstantCastOrigin.Trait),
         new BuffGainCastFinder(Dash, UnhinderedCombatant)
             .UsingOrigin(InstantCastOrigin.Trait),
-        //new DamageCastFinder(30520, 30520), // Debilitating Arc
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
@@ -26,7 +26,7 @@ internal static class SpellbreakerHelper
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers =
     [
-        // Pure Strike
+        // Pure Strike (Boons)
         new BuffOnFoeDamageModifier(Mod_PureStrikeBoons, NumberOfBoons, "Pure Strike (boons)", "7% crit damage", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByPresence, TraitImages.PureStrike, DamageModifierMode.All)
             .UsingChecker((x, log) => x.HasCrit)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2022Balance),
@@ -36,6 +36,7 @@ internal static class SpellbreakerHelper
         new BuffOnFoeDamageModifier(Mod_PureStrikeBoons, NumberOfBoons, "Pure Strike (boons)", "7.5% crit damage", DamageSource.NoPets, 7.5, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByPresence, TraitImages.PureStrike, DamageModifierMode.PvE)
             .UsingChecker((x, log) => x.HasCrit)
             .WithBuilds(GW2Builds.August2022Balance),
+        // Pure Strike (No Boons)
         new BuffOnFoeDamageModifier(Mod_PureStrikeNoBoons, NumberOfBoons, "Pure Strike (no boons)", "14% crit damage", DamageSource.NoPets, 14.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByAbsence, TraitImages.PureStrike, DamageModifierMode.All)
             .UsingChecker( (x, log) => x.HasCrit)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2022Balance),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/WarriorHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/WarriorHelper.cs
@@ -19,7 +19,7 @@ internal static class WarriorHelper
             .WithBuilds(GW2Builds.December2017Balance)
             .UsingOrigin(EIData.InstantCastFinder.InstantCastOrigin.Trait),
         new BuffGainCastFinder(BerserkersStanceSkill, BerserkersStanceBuff),
-        new BuffGainCastFinder(BalancedStanceSill, BalancedStanceBuff),
+        new BuffGainCastFinder(BalancedStanceSkill, BalancedStanceBuff),
         new BuffGainCastFinder(EndurePainSkill, EnduringPainBuff),
         new BuffGainCastFinder(SignetOfFurySkill, SignetOfFuryActive),
         new EffectCastFinderByDst(SignetOfMightSkill, EffectGUIDs.WarriorSignetOfMight)
@@ -144,8 +144,10 @@ internal static class WarriorHelper
 
         // Defense
         // - Hardened Armor
+        new BuffOnActorDamageModifier(Mod_HardenedArmor, Retaliation, "Hardened Armor", "-10% under retaliation", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.HardenedArmor, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.March2020Balance, GW2Builds.May2021Balance),
         new BuffOnActorDamageModifier(Mod_HardenedArmor, Resolution, "Hardened Armor", "-10% under resolution", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.HardenedArmor, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.March2020Balance),
+            .WithBuilds(GW2Builds.May2021Balance),
     ];
 
     internal static readonly IReadOnlyList<Buff> Buffs =

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -233,6 +233,7 @@ public class SkillItem
         { BoundHit, "Bound (Hit)" },
         { BarbedSpearMelee, "Barbed Spear (Melee)" },
         { BarbedSpearRanged, "Barbed Spear (Ranged)" },
+        { DebilitatingArcRoll, "Debilitating Arc (Roll backwards)" },
         #endregion Thief
         #region Warrior
         { RushDamage, "Rush (Hit)" },
@@ -956,6 +957,7 @@ public class SkillItem
             { TraversingDuskHeal, TraitImages.TraversingDusk },
             { DarkSaviorHealing, TraitImages.ShadowSavior },
             { ShieldingRestorationBarrier, TraitImages.ShieldingRestoration },
+            { DebilitatingArcRoll, SkillImages.DebilitatingArc },
             #endregion ThiefIcons
             #region WarriorIcons
             { MendingMight, TraitImages.MendingMight },

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -105,7 +105,9 @@ public static class EffectGUIDs
     public static readonly GUID ChronomancerGravityWellExplosion = new("E0D03976A4BC034E8ABFBBECCC828932"); // 1 second after final pulse
     public static readonly GUID MirageCloak = new("4C7A5E148F7FD642B34EE4996DDCBBAB");
     public static readonly GUID MirageMirror = new("1370CDF5F2061445A656A1D77C37A55C");
-    public static readonly GUID MirageJaunt = new("3A5A38C26A1FFB438EAD734F3ED42E5E"); // may have collisions! not known which
+    public static readonly GUID MirageJaunt = new("3A5A38C26A1FFB438EAD734F3ED42E5E"); // Src Mirage, Dst Mirage
+    public static readonly GUID MirageJauntConflict1 = new("B6557C336041B24FA7CC198B6EBDAD9A"); // Src Mirage, Dst Mirage - used with e.g. jaunt & axes of symmetry
+    public static readonly GUID MirageJauntConflict2 = new("D7A05478BA0E164396EB90C037DCCF42"); // Src Mirage, Dst Mirage - used with e.g. jaunt, axes of symmetry, illusionary ambush
     public static readonly GUID VirtuosoUnstableBladestorm = new("DEF12997FAEA6847A8786CD2920ACA91"); // has effect end
     public static readonly GUID VirtuosoUnstableBladestorm2 = new("242B1513FCF07842B658A56CDE4851C8");
     public static readonly GUID VirtuosoBladeturnRequiem = new("87B761200637AC48B71469F553BA6F60");
@@ -116,9 +118,7 @@ public static class EffectGUIDs
     public static readonly GUID MesmerRifleInspiringImagery3 = new ("116644F736CDFE4F8FF3E1EB5C5C57A2"); // 2000 Duration - Src Mesmer - Ground AoE
     public static readonly GUID MesmerRifleAbstraction = new ("6E2B9CF3E5C95846B15BBD1EAA9B3E98"); // 3300 Default Duration - Src Mesmer - Ground Effect
     public static readonly GUID MesmerRifleAbstraction2 = new ("593E668A006AB24D84999AED68F2E4C4"); // 2000 Default Duration - Src Mesmer - Ground Effect
-    // public static readonly GUID MirageJauntConflict1                    = new("B6557C336041B24FA7CC198B6EBDAD9A"); // used with e.g. jaunt & axes of symmetry
-    // public static readonly GUID MirageJauntConflict2                    = new("D7A05478BA0E164396EB90C037DCCF42"); // used with e.g. jaunt, axes of symmetry, illusionary ambush
-    // public static readonly GUID MesmerTrail                             = new("73414BA39AFCF540A90CF91DE961CCEF"); // used with e.g. mirror images, phase retreat, illusionary ambush - likely the trail left behind
+    // public static readonly GUID MesmerTrail = new("73414BA39AFCF540A90CF91DE961CCEF"); // used with e.g. mirror images, phase retreat, illusionary ambush - likely the trail left behind
     #endregion
       
     #region Necromancer

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -1575,6 +1575,7 @@ public static class SkillIDs
     public const long InvigoratedBulwark = 30207;
     public const long JusticeDragonhunter = 30232;
     public const long MedBlasterHeal = 30235;
+    public const long DebilitatingArcRoll = 30246;
     public const long LesserSignetOfWrath = 30255;
     public const long Outrage = 30258;
     public const long VampiricAura = 30285;
@@ -1598,6 +1599,7 @@ public static class SkillIDs
     public const long SoulSpiral = 30504;
     public const long SelflessAmplification = 30509;
     public const long PulmonaryImpactBuff = 30510;
+    public const long DebilitatingArc = 30520;
     public const long WellOfCalamity = 30525;
     public const long SoulEater = 30539;
     public const long FragmentsOfFaith = 30553;
@@ -4824,6 +4826,7 @@ public static class SkillIDs
     public const long SparkingAuraTier2CM = 76034;
     public const long AchievementEligibilityThisBugCanDance = 76042;
     public const long ForeshockCM4 = 76048;
+    public const long IllusionaryMembrane = 76074;
     //
     #endregion
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -73,6 +73,28 @@ public static class SkillIDs
     internal const long ArcDPSGenericBreakbar = 65002;
     internal const long ArcDPSDodge20220307 = 23275;
     internal const long ArcDPSGenericBreakbar20220307 = 23276;
+    internal const long ArcDPSSelfCast1 = 23277;
+    internal const long ArcDPSEnemyCast1 = 23278;
+    internal const long ArcDPSSelfCast2 = 23279;
+    internal const long ArcDPSEnemyCast2 = 23280;
+    internal const long ArcDPSSelfCast3 = 23281;
+    internal const long ArcDPSEnemyCast3 = 23282;
+    internal const long ArcDPSBreakbarDefunc = 23283;
+    public const long WeaponDraw = 23284;
+    public const long WeaponStow = 23285;
+    internal const long ArcDPSGenericKill = 23288;
+    internal const long ArcDPSGenericDown = 23289;
+    internal const long ArcDPSGenericEvade = 23290;
+    internal const long ArcDPSGenericInterrupt = 23291;
+    internal const long ArcDPSGenericAbsorb = 23292;
+    internal const long ArcDPSGenericMiss = 23293;
+    internal const long ArcDPSGenericKnockdown = 23294;
+    internal const long ArcDPSGenericKnockbackPull = 23295;
+    internal const long ArcDPSGenericFloat = 23296;
+    internal const long ArcDPSGenericLaunch = 23297;
+    internal const long ArcDPSGenericWaterFloatSink = 23298;
+    internal const long ArcDPSGenericCCBuff = 23299;
+    internal const long ArcDPSGenericStagger = 23300;
     #endregion
     #region Core
     public const long Protection = 717;
@@ -990,7 +1012,7 @@ public static class SkillIDs
     public const long BannerOfDisciplineSkill = 14407;
     public const long BannerOfTacticsSkill = 14408;
     public const long SignetOfFurySkill = 14410;
-    public const long BalancedStanceSill = 14412;
+    public const long BalancedStanceSkill = 14412;
     public const long DolyakSignetSkill = 14413;
     public const long SkullCrack1 = 14414;
     public const long TremorMace = 14415;
@@ -1358,9 +1380,6 @@ public static class SkillIDs
     public const long PowerfulPotionOfSlayingScarletsArmies = 23228;
     public const long Enraged2_Unknown = 23235;
     public const long SwiftMoaFeather = 23239;
-    public const long WeaponDraw = 23284;
-    public const long WeaponStow = 23285;
-    public const long GenericKill = 23288;
     public const long GuildShieldFinisher = 23978;
     public const long HiddenMinstrelFinisher = 23996;
     public const long GolemPummelerFinisher = 23997;

--- a/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
@@ -559,6 +559,7 @@ internal static class SkillImages
     public const string InfiltratorsStrike = "https://render.guildwars2.com/file/2A5C30A8FE579C0169BE3B6FEC05C7E4AFE7FB1D/104067.png";
     public const string BarbedSpear = "https://render.guildwars2.com/file/3A5C3F7697DAE8C90B450B92323937A396EDC4EC/3379188.png";
     public const string BolaShot = "https://render.guildwars2.com/file/C203DEA0472BEEA173A60DF41C66F75E7FC0D80A/2261529.png";
+    public const string DebilitatingArc = "https://render.guildwars2.com/file/5AC578E641FC79E9B2F11F43EAF857140F937CF3/1058626.png";
     #endregion Thief
     #region Warrior
     public const string Riposte = "https://wiki.guildwars2.com/images/d/de/Riposte.png";


### PR DESCRIPTION
Added Illusionary Membrane new buff simulation and related damage modifier
Updated Jaunt to be using effect events and locked old damage finder
Added icon for Debilitating Arc roll missing since arcdps can detect movement skills
Added older version of Hardened Armor
Documented ArcDPS skillIDs