### PR TITLE
Move trigonometry methods to their own class in MathUtils

### DIFF
--- a/GW2EIEvtcParser/EIData/MathUtils/Trigonometry.cs
+++ b/GW2EIEvtcParser/EIData/MathUtils/Trigonometry.cs
@@ -1,0 +1,46 @@
+﻿namespace GW2EIEvtcParser.EIData;
+
+public static class Trigonometry
+{
+    internal static double RadianToDegree(double radian)
+    {
+        return radian * 180.0 / Math.PI;
+    }
+
+    internal static float RadianToDegreeF(double radian)
+    {
+        return (float)RadianToDegree(radian);
+    }
+
+    internal static double DegreeToRadian(double degree)
+    {
+        return degree * Math.PI / 180.0;
+    }
+
+    internal static float DegreeToRadianF(double degree)
+    {
+        return (float)DegreeToRadian(degree);
+    }
+
+    /// <summary>
+    /// Given a <paramref name="degree"/>, calculates the <see cref="Math.Cos(double)"/> and <see cref="Math.Sin(double)"/> values.
+    /// </summary>
+    /// <param name="degree"></param>
+    /// <returns>(<see cref="float"/>, <see cref="float"/>) tuple containing the resulting X and Y values.</returns>
+    internal static (float, float) DegreeToRadiansTrigonometricF(double degree)
+    {
+        return ((float, float))DegreeToRadiansTrigonometric(degree);
+    }
+
+    /// <summary>
+    /// Given a <paramref name="degree"/>, calculates the <see cref="Math.Cos(double)"/> and <see cref="Math.Sin(double)"/> values.
+    /// </summary>
+    /// <param name="degree"></param>
+    /// <returns>(<see cref="double"/>, <see cref="double"/>) tuple containing the resulting X and Y values.</returns>
+    internal static (double, double) DegreeToRadiansTrigonometric(double degree)
+    {
+        double x = Math.Cos(DegreeToRadian(degree));
+        double y = Math.Sin(DegreeToRadian(degree));
+        return (x, y);
+    }
+}

--- a/GW2EIEvtcParser/EIData/MathUtils/VectorExtensions.cs
+++ b/GW2EIEvtcParser/EIData/MathUtils/VectorExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System.Numerics;
 using System.Runtime.CompilerServices;
+using static GW2EIEvtcParser.EIData.Trigonometry;
+using static GW2EIEvtcParser.ParserHelper;
 
 namespace GW2EIEvtcParser.EIData;
 
@@ -144,6 +146,6 @@ static class Vector
 
     public static float GetRoundedZRotationDeg(this in Vector3 facing)
     {
-        return (float)Math.Round(ParserHelper.RadianToDegree(Math.Atan2(facing.Y, facing.X)), ParserHelper.CombatReplayDataDigit);
+        return (float)Math.Round(RadianToDegree(Math.Atan2(facing.Y, facing.X)), CombatReplayDataDigit);
     }
 }

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W3/KeepConstruct.cs
@@ -3,6 +3,7 @@ using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.Extensions;
 using GW2EIEvtcParser.ParsedData;
 using GW2EIEvtcParser.ParserHelpers;
+using static GW2EIEvtcParser.EIData.Trigonometry;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicPhaseUtils;
 using static GW2EIEvtcParser.EncounterLogic.EncounterLogicUtils;
 using static GW2EIEvtcParser.ParserHelper;
@@ -16,7 +17,7 @@ internal class KeepConstruct : StrongholdOfTheFaithful
 {
     public KeepConstruct(int triggerID) : base(triggerID)
     {
-        MechanicList.Add(new MechanicGroup([    
+        MechanicList.Add(new MechanicGroup([
             new PlayerDstBuffApplyMechanic([StatueFixated1, StatueFixated2], new MechanicPlotlySetting(Symbols.Star,Colors.Magenta), "Fixate", "Fixated by Statue","Fixated", 0),
             new PlayerDstHitMechanic(HailOfFury, new MechanicPlotlySetting(Symbols.CircleOpen,Colors.Red), "Debris", "Hail of Fury (Falling Debris)","Debris", 0),
             new EnemyDstBuffApplyMechanic(Compromised, new MechanicPlotlySetting(Symbols.Hexagon,Colors.Blue), "Rift#", "Compromised (Pushed Orb through Rifts)","Compromised", 0),
@@ -449,15 +450,15 @@ internal class KeepConstruct : StrongholdOfTheFaithful
 
         }
         // Fixated Statue tether to Player
-        var fixatedStatue = GetFilteredList(log.CombatData, [ StatueFixated1, StatueFixated2 ], p, true, true);
+        var fixatedStatue = GetFilteredList(log.CombatData, [StatueFixated1, StatueFixated2], p, true, true);
         replay.Decorations.AddTether(fixatedStatue, Colors.Magenta, 0.5);
         // Fixation Overhead
-        IEnumerable<Segment> fixations = p.GetBuffStatus(log, [ StatueFixated1, StatueFixated2 ], log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+        IEnumerable<Segment> fixations = p.GetBuffStatus(log, [StatueFixated1, StatueFixated2], log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
         replay.Decorations.AddOverheadIcons(fixations, p, ParserIcons.FixationPurpleOverhead);
         // Attunements Overhead
-        IEnumerable<Segment> crimsonAttunements = p.GetBuffStatus(log, [ CrimsonAttunementPhantasm, CrimsonAttunementOrb ], log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+        IEnumerable<Segment> crimsonAttunements = p.GetBuffStatus(log, [CrimsonAttunementPhantasm, CrimsonAttunementOrb], log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
         replay.Decorations.AddOverheadIcons(crimsonAttunements, p, ParserIcons.CrimsonAttunementOverhead);
-        IEnumerable<Segment> radiantAttunements = p.GetBuffStatus(log, [ RadiantAttunementPhantasm, RadiantAttunementOrb ], log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+        IEnumerable<Segment> radiantAttunements = p.GetBuffStatus(log, [RadiantAttunementPhantasm, RadiantAttunementOrb], log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
         replay.Decorations.AddOverheadIcons(radiantAttunements, p, ParserIcons.RadiantAttunementOverhead);
     }
 

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvents/AbstractEffectEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/StatusEvents/EffectEvents/AbstractEffectEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using static GW2EIEvtcParser.EIData.Trigonometry;
 using static GW2EIEvtcParser.ParserHelper;
 
 namespace GW2EIEvtcParser.ParsedData;

--- a/GW2EIEvtcParser/ParserHelpers/ParserHelper.cs
+++ b/GW2EIEvtcParser/ParserHelpers/ParserHelper.cs
@@ -157,48 +157,6 @@ public static class ParserHelper
         return groupByTime;
     }
 
-    internal static double RadianToDegree(double radian)
-    {
-        return radian * 180.0 / Math.PI;
-    }
-
-    internal static float RadianToDegreeF(double radian)
-    {
-        return (float)RadianToDegree(radian);
-    }
-
-    internal static double DegreeToRadian(double degree)
-    {
-        return degree * Math.PI / 180.0;
-    }
-
-    internal static float DegreeToRadianF(double degree)
-    {
-        return (float)DegreeToRadian(degree);
-    }
-
-    /// <summary>
-    /// Given a <paramref name="degree"/>, calculates the <see cref="Math.Cos(double)"/> and <see cref="Math.Sin(double)"/> values.
-    /// </summary>
-    /// <param name="degree"></param>
-    /// <returns>(<see cref="float"/>, <see cref="float"/>) tuple containing the resulting X and Y values.</returns>
-    internal static (float, float) DegreeToRadiansTrigonometricF(double degree)
-    {
-        return ((float, float))DegreeToRadiansTrigonometric(degree);
-    }
-
-    /// <summary>
-    /// Given a <paramref name="degree"/>, calculates the <see cref="Math.Cos(double)"/> and <see cref="Math.Sin(double)"/> values.
-    /// </summary>
-    /// <param name="degree"></param>
-    /// <returns>(<see cref="double"/>, <see cref="double"/>) tuple containing the resulting X and Y values.</returns>
-    internal static (double, double) DegreeToRadiansTrigonometric(double degree)
-    {
-        double x = Math.Cos(DegreeToRadian(degree));
-        double y = Math.Sin(DegreeToRadian(degree));
-        return (x, y);
-    }
-
     internal static T MaxBy<T, TComparable>(this IEnumerable<T> en, Func<T, TComparable> evaluate) where TComparable : IComparable<TComparable>
     {
         return en.Select(t => (value: t, eval: evaluate(t)))


### PR DESCRIPTION
Moved the Radian/Degree methods from ParserHelper to its own class in the MathUtils folder.
Looks like some auto formatting leaked in for KC but it's fine.