### PR TITLE
Eparch combat replay and mechanics

### DIFF
--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDecorationContainer.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDecorationContainer.cs
@@ -306,7 +306,7 @@ internal class CombatReplayDecorationContainer
     /// <param name="firstAwareThreshold">Time threshold in case the agent spawns before the buff application.</param>
     internal void AddTetherByThirdPartySrcBuff(ParsedEvtcLog log, PlayerActor player, long buffId, int buffSrcAgentId, int toTetherAgentId, string color, int firstAwareThreshold = 2000)
     {
-        var buffEvents = log.CombatData.GetBuffDataByIDByDst(buffId, player.AgentItem).Where(x => x.CreditedBy.IsSpecies(buffSrcAgentId)).ToList();
+        var buffEvents = log.CombatData.GetBuffDataByIDByDst(buffId, player.AgentItem).Where(x => x.CreditedBy.IsSpecies(buffSrcAgentId));
         var buffApplies = buffEvents.OfType<BuffApplyEvent>();
         var buffRemoves = buffEvents.OfType<BuffRemoveAllEvent>();
         var agentsToTether = log.AgentData.GetNPCsByID(toTetherAgentId);
@@ -385,6 +385,7 @@ internal class CombatReplayDecorationContainer
     /// <param name="color">Color.</param>
     /// <param name="opacity">Opacity of the <paramref name="color"/>.</param>
     /// <param name="radius">Radius of the shockwave.</param>
+    /// <param name="reverse">If the shockwave grows outwards or inwards, outwards is set by default.</param>
     /// <remarks>Uses <see cref="GeographicalConnector"/> which allows us to use <see cref="AgentConnector"/> and <see cref="PositionConnector"/>.</remarks>
     internal void AddShockwave(GeographicalConnector connector, (long start, long end) lifespan, Color color, double opacity, uint radius, bool reverse = false)
     {
@@ -398,6 +399,7 @@ internal class CombatReplayDecorationContainer
     /// <param name="lifespan">Lifespan of the shockwave.</param>
     /// <param name="color">Color.</param>
     /// <param name="radius">Radius of the shockwave.</param>
+    /// <param name="reverse">If the shockwave grows outwards or inwards, outwards is set by default.</param>
     /// <remarks>Uses <see cref="GeographicalConnector"/> which allows us to use <see cref="AgentConnector"/> and <see cref="PositionConnector"/>.</remarks>
     internal void AddShockwave(GeographicalConnector connector, (long start, long end) lifespan, string color, uint radius, bool reverse = false)
     {

--- a/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDecorationContainer.cs
+++ b/GW2EIEvtcParser/EIData/CombatReplay/CombatReplayDecorationContainer.cs
@@ -306,7 +306,7 @@ internal class CombatReplayDecorationContainer
     /// <param name="firstAwareThreshold">Time threshold in case the agent spawns before the buff application.</param>
     internal void AddTetherByThirdPartySrcBuff(ParsedEvtcLog log, PlayerActor player, long buffId, int buffSrcAgentId, int toTetherAgentId, string color, int firstAwareThreshold = 2000)
     {
-        var buffEvents = log.CombatData.GetBuffDataByIDByDst(buffId, player.AgentItem).Where(x => x.CreditedBy.IsSpecies(buffSrcAgentId));
+        var buffEvents = log.CombatData.GetBuffDataByIDByDst(buffId, player.AgentItem).Where(x => x.CreditedBy.IsSpecies(buffSrcAgentId)).ToList();
         var buffApplies = buffEvents.OfType<BuffApplyEvent>();
         var buffRemoves = buffEvents.OfType<BuffRemoveAllEvent>();
         var agentsToTether = log.AgentData.GetNPCsByID(toTetherAgentId);
@@ -386,9 +386,9 @@ internal class CombatReplayDecorationContainer
     /// <param name="opacity">Opacity of the <paramref name="color"/>.</param>
     /// <param name="radius">Radius of the shockwave.</param>
     /// <remarks>Uses <see cref="GeographicalConnector"/> which allows us to use <see cref="AgentConnector"/> and <see cref="PositionConnector"/>.</remarks>
-    internal void AddShockwave(GeographicalConnector connector, (long start, long end) lifespan, Color color, double opacity, uint radius)
+    internal void AddShockwave(GeographicalConnector connector, (long start, long end) lifespan, Color color, double opacity, uint radius, bool reverse = false)
     {
-        AddShockwave(connector, lifespan, color.WithAlpha(opacity).ToString(true), radius);
+        AddShockwave(connector, lifespan, color.WithAlpha(opacity).ToString(true), radius, reverse);
     }
 
     /// <summary>
@@ -399,9 +399,9 @@ internal class CombatReplayDecorationContainer
     /// <param name="color">Color.</param>
     /// <param name="radius">Radius of the shockwave.</param>
     /// <remarks>Uses <see cref="GeographicalConnector"/> which allows us to use <see cref="AgentConnector"/> and <see cref="PositionConnector"/>.</remarks>
-    internal void AddShockwave(GeographicalConnector connector, (long start, long end) lifespan, string color, uint radius)
+    internal void AddShockwave(GeographicalConnector connector, (long start, long end) lifespan, string color, uint radius, bool reverse = false)
     {
-        Add(new CircleDecoration(radius, lifespan, color, connector).UsingFilled(false).UsingGrowingEnd(lifespan.end));
+        Add(new CircleDecoration(radius, lifespan, color, connector).UsingFilled(false).UsingGrowingEnd(lifespan.end, reverse));
     }
 
 

--- a/GW2EIEvtcParser/EncounterLogic/Fractals/TheLonelyTower/Eparch.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Fractals/TheLonelyTower/Eparch.cs
@@ -18,6 +18,49 @@ internal class Eparch : LonelyTower
     {
         MechanicList.AddRange(
         [
+            // Player Attunements
+            new MechanicGroup([
+                new PlayerDstBuffApplyMechanic(DespairAttunement, new MechanicPlotlySetting(Symbols.Circle, Colors.Blue), "Desp.Att", "Collected Despair Attunement", "Despair Attunement", 0),
+                new PlayerDstBuffApplyMechanic(EnvyAttunement, new MechanicPlotlySetting(Symbols.Circle, Colors.Green), "Emvy.Att", "Collected Envy Attunement", "Envy Attunement", 0),
+                new PlayerDstBuffApplyMechanic(GluttonyAttunement, new MechanicPlotlySetting(Symbols.Circle, Colors.Orange), "Glut.Att", "Collected Gluttony Attunement", "Gluttony Attunement", 0),
+                new PlayerDstBuffApplyMechanic(MaliceAttunement, new MechanicPlotlySetting(Symbols.Circle, Colors.Purple), "Mali.Att", "Collected Malice Attunement", "Malice Attunement", 0),
+                new PlayerDstBuffApplyMechanic(RageAttunement, new MechanicPlotlySetting(Symbols.Circle, Colors.Red), "Rage.Att", "Collected Rage Attunement", "Rage Attunement", 0),
+                new PlayerDstBuffApplyMechanic(RegretAttunement, new MechanicPlotlySetting(Symbols.Circle, Colors.Yellow), "Regr.Att", "Collected Regret Attunement", "Regret Attunement", 0),
+            ]),
+            // Eparch Empowerments
+            new MechanicGroup([
+                new EnemyDstBuffApplyMechanic(DespairEmpowerment, new MechanicPlotlySetting(Symbols.CircleCross, Colors.Blue), "Desp.Emp", "Eparch Absorbed Despair Empowerment", "Despair Empowerment", 0),
+                new EnemyDstBuffApplyMechanic(EnvyEmpowerment, new MechanicPlotlySetting(Symbols.CircleCross, Colors.Green), "Emvy.Emp", "Eparch Absorbed Envy Empowerment", "Envy Empowerment", 0),
+                new EnemyDstBuffApplyMechanic(GluttonyEmpowerment, new MechanicPlotlySetting(Symbols.CircleCross, Colors.Orange), "Glut.Emp", "Eparch Absorbed Gluttony Empowerment", "Gluttony Empowerment", 0),
+                new EnemyDstBuffApplyMechanic(MaliceEmpowerment, new MechanicPlotlySetting(Symbols.CircleCross, Colors.Purple), "Mali.Emp", "Eparch Absorbed Malice Empowerment", "Malice Empowerment", 0),
+                new EnemyDstBuffApplyMechanic(RageEmpowerment, new MechanicPlotlySetting(Symbols.CircleCross, Colors.Red), "Rage.Emp", "Eparch Absorbed Rage Empowerment", "Rage Empowerment", 0),
+                new EnemyDstBuffApplyMechanic(RegretEmpowerment, new MechanicPlotlySetting(Symbols.CircleCross, Colors.Yellow), "Regr.Emp", "Eparch Absorbed Regret Empowerment", "Regret Empowerment", 0),
+            ]),
+            // Eparch Attacks
+            new MechanicGroup([
+                new PlayerDstHitMechanic([RainOfDespair, RainOfDespairPool], new MechanicPlotlySetting(Symbols.TriangleDown, Colors.RedSkin), "Desp.H", "Hit by Rain of Despair", "Rain of Despair Hit", 0),
+                new PlayerDstHitMechanic(WaveOfEnvy, new MechanicPlotlySetting(Symbols.TriangleDown, Colors.DarkGreen), "Envy.H", "Hit by Wave of Envy", "Wave of Envy Hit", 0),
+                new PlayerDstHitMechanic(Inhale, new MechanicPlotlySetting(Symbols.TriangleDown, Colors.Red), "Glut.H", "Hit by Inhile", "Inhile Hit", 0),
+                new PlayerDstHitMechanic(SpikeOfMaliceHit, new MechanicPlotlySetting(Symbols.TriangleDown, Colors.DarkPurple), "Mali.H", "Hit by Spike of Malice", "Spike of Malice Hit", 0),
+                new PlayerDstHitMechanic(RageFissure, new MechanicPlotlySetting(Symbols.TriangleDown, Colors.DarkRed), "Rage.H", "Hit by Rage Fissure", "Rage Fissure Hit", 0),
+            ]),
+            // Consume
+            new MechanicGroup([
+                new PlayerDstBuffApplyMechanic(Consumed, new MechanicPlotlySetting(Symbols.Pentagon, Colors.DarkGreen), "Consumed", "Consumed by Eparch", "Consumed", 0),
+            ]),
+            // Split Phase
+            new MechanicGroup([
+                new PlayerDstHitMechanic([CruelDetonation1, CruelDetonation2], new MechanicPlotlySetting(Symbols.Square, Colors.Ice), "CruDeto.H", "Hit by Cruel Detonation", "Cruel Detonation Hit", 0),
+                new PlayerDstHitMechanic(WallOfTalons, new MechanicPlotlySetting(Symbols.Octagon, Colors.Grey), "Wall.H", "Hit by Wall of Talons", "Wall of Talons Hit", 0),
+                new PlayerDstHitMechanic(PoolOfDraining, new MechanicPlotlySetting(Symbols.CircleX, Colors.LightOrange), "PoolDra.H", "Hit by Pool of Draining (Boonstrip)", "Pool of Draining Hit", 0),
+                new PlayerDstHitMechanic(UnliddedEye, new MechanicPlotlySetting(Symbols.CircleOpen, Colors.Yellow), "EyeWave.H", "Hit by Unlidded Eye (Shockwave)", "Unlidded Eye Hit", 0),
+                new PlayerDstHitMechanic(EyeOfJudgment, new MechanicPlotlySetting(Symbols.DiamondWideOpen, Colors.LightOrange), "EyeArrow.H", "Hit by Eye of Judgment (Arrows)", "Eye of Judgment Hit", 0),
+            ]),
+            // Eparch Casts
+            new MechanicGroup([
+                new EnemyCastStartMechanic(BreakbarEparch, new MechanicPlotlySetting(Symbols.PentagonOpen, Colors.DarkGreen), "Breakbar", "Cast Breakbar", "Cast Breakbar", 0),
+                new EnemyCastStartMechanic(RegretSkillEparch, new MechanicPlotlySetting(Symbols.StarDiamondOpen, Colors.Yellow), "Regret", "Cast Regret Skill", "Cast Regret Skill", 0),
+            ])
         ]);
         Extension = "eparch";
         Icon = EncounterIconEparch;
@@ -94,7 +137,7 @@ internal class Eparch : LonelyTower
         if (fightData.IsCM && determinedApplies.Count >= 3)
         {
             fightData.SetSuccess(true, determinedApplies[2].Time);
-        } 
+        }
         else if (!fightData.IsCM && determinedApplies.Count >= 1)
         {
             fightData.SetSuccess(true, determinedApplies[0].Time);
@@ -179,9 +222,9 @@ internal class Eparch : LonelyTower
     {
         base.ComputePlayerCombatReplayActors(player, log, replay);
 
-        // consume fixations
-        var  consumes = player.GetBuffStatus(log, Consume, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
-        var consumeEvents = GetFilteredList(log.CombatData, [ Consume ], player, true, true);
+        // Consume fixations
+        var consumes = player.GetBuffStatus(log, Consume, log.FightData.LogStart, log.FightData.LogEnd).Where(x => x.Value > 0);
+        var consumeEvents = GetFilteredList(log.CombatData, [Consume], player, true, true);
         replay.Decorations.AddOverheadIcons(consumes, player, ParserIcons.FixationRedOverhead);
         replay.Decorations.AddTether(consumeEvents, Colors.Red, 0.5);
     }
@@ -189,14 +232,80 @@ internal class Eparch : LonelyTower
     internal override void ComputeNPCCombatReplayActors(NPC target, ParsedEvtcLog log, CombatReplay replay)
     {
         base.ComputeNPCCombatReplayActors(target, log, replay);
+
+        (long start, long end) lifespan;
+        long duration;
+
         switch (target.ID)
         {
+            case (int)TargetID.EparchLonelyTower:
+                // Pool of Despair - Indicator
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.EparchDespairPoolIndicator, out var poolsIndicators))
+                {
+                    foreach (EffectEvent effect in poolsIndicators)
+                    {
+                        lifespan = effect.ComputeLifespan(log, 2000);
+                        var circle = new CircleDecoration(110, lifespan, Colors.Red, 0.2, new PositionConnector(effect.Position)).UsingFilled(false);
+                        replay.Decorations.Add(circle);
+                        if (target.TryGetCurrentPosition(log, effect.Time, out var eparchPos))
+                        {
+                            replay.Decorations.AddProjectile(eparchPos, effect.Position, lifespan, Colors.Black, 0.4);
+                        }
+                    }
+                }
+
+                // Consume Breakbar
+                var breakbarUpdates = target.GetBreakbarPercentUpdates(log);
+                var (breakbarNones, breakbarActives, breakbarImmunes, breakbarRecoverings) = target.GetBreakbarStatus(log);
+                foreach (var segment in breakbarActives)
+                {
+                    replay.Decorations.AddActiveBreakbar(segment.TimeSpan, target, breakbarUpdates);
+                }
+                break;
             case (int)TargetID.KryptisRift:
                 {
-                    var events = GetFilteredList(log.CombatData, [ KryptisRiftIncarnationTether ], target, true, true);
+                    var events = GetFilteredList(log.CombatData, [KryptisRiftIncarnationTether], target, true, true);
                     replay.Decorations.AddTether(events, Colors.Red, 0.5);
                     break;
                 }
+            case (int)TargetID.IncarnationOfJudgement:
+                // Unlidded Eye - Reverse Shockwave - Wave Warning
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.EparchJudgmentUnliddedEyeWarning, out var eyeWarning))
+                {
+                    foreach (EffectEvent effect in eyeWarning)
+                    {
+                        lifespan = effect.ComputeLifespan(log, 2000);
+                        replay.Decorations.AddShockwave(new PositionConnector(effect.Position), lifespan, Colors.LightOrange, 0.3, 600, true);
+                    }
+                }
+
+                // Unlidded Eye - Reverse Shockwave - Wave Hit
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.EparchJudgmentUnliddedEyeWave, out var eyeWave))
+                {
+                    foreach (EffectEvent effect in eyeWave)
+                    {
+                        lifespan = effect.ComputeLifespan(log, 2400);
+                        replay.Decorations.AddShockwave(new AgentConnector(target), lifespan, Colors.Yellow, 0.5, 1200, true);
+                    }
+                }
+
+                // Pool of Draining - AoE underneath boon removal
+                if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.EparchJudgmentPoolOfDraining, out var drainingPools))
+                {
+                    foreach (EffectEvent effect in drainingPools)
+                    {
+                        duration = 1266;
+                        long growing = effect.Time + duration;
+                        lifespan = effect.ComputeLifespan(log, duration);
+                        lifespan.end = ComputeEndCastTimeByBuffApplication(log, target, Stun, effect.Time, duration);
+                        var circle = new CircleDecoration(200, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position));
+                        replay.Decorations.AddWithGrowing(circle, growing);
+                    }
+                }
+                break;
+            default:
+                break;
+
         }
     }
 
@@ -204,23 +313,22 @@ internal class Eparch : LonelyTower
     {
         base.ComputeEnvironmentCombatReplayDecorations(log);
 
+        (long start, long end) lifespan;
+
         AddGlobuleDecorations(log);
 
-        // rain of despair pools
+        // Rain of Despair - Pools
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchDespairPool, out var pools))
         {
             foreach (EffectEvent effect in pools)
             {
-                // TODO: pools are differently sized?
-                (long, long) lifespan = effect.ComputeDynamicLifespan(log, 15000);
-                var position = new PositionConnector(effect.Position);
-                var circle = new CircleDecoration(110, lifespan, Colors.RedSkin, 0.2, position);
-                EnvironmentDecorations.Add(circle);
-                EnvironmentDecorations.Add(circle.GetBorderDecoration(Colors.Red, 0.2));
+                lifespan = effect.ComputeDynamicLifespan(log, 15000);
+                var circle = new CircleDecoration(110, lifespan, Colors.RedSkin, 0.2, new PositionConnector(effect.Position));
+                EnvironmentDecorations.AddWithBorder(circle, Colors.Red, 0.2);
             }
         }
 
-        // rage wave
+        // Rage Fissure - Shockwave
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchRageImpact, out var rageWaves))
         {
             const float velocity = 450.0f; // units per second
@@ -228,74 +336,92 @@ internal class Eparch : LonelyTower
             const long duration = (long)(1000.0f * maxRange / velocity);
             foreach (EffectEvent effect in rageWaves)
             {
-                var start = effect.Time;
-                var end = start + duration;
-                var position = new PositionConnector(effect.Position);
-                EnvironmentDecorations.Add(new CircleDecoration(maxRange, (start, end), Colors.Orange, 0.3, position).UsingFilled(false).UsingGrowingEnd(end));
+                lifespan = (effect.Time, effect.Time + duration);
+                EnvironmentDecorations.AddShockwave(new PositionConnector(effect.Position), lifespan, Colors.Orange, 0.3, maxRange);
             }
         }
 
-        // rage fissures
+        // Rage Fissures
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchRageFissure, out var fissures))
         {
             const uint width = 40;
             const uint length = 220;
             foreach (EffectEvent effect in fissures)
             {
-                (long, long) lifespan = effect.ComputeDynamicLifespan(log, 24000);
+                lifespan = effect.ComputeDynamicLifespan(log, 24000);
                 GeographicalConnector position = new PositionConnector(effect.Position).WithOffset(new(0.0f, 0.5f * length, 0), true);
-                var rotation = new AngleConnector(effect.Rotation.Z);
-                EnvironmentDecorations.Add(new RectangleDecoration(width, length, lifespan, Colors.Red, 0.2, position).UsingRotationConnector(rotation));
+                EnvironmentDecorations.Add(new RectangleDecoration(width, length, lifespan, Colors.Red, 0.2, position).UsingRotationConnector(new AngleConnector(effect.Rotation.Z)));
             }
         }
 
-        // envy arrow indicators
+        // Wave of Envy - Arrows
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchArrowIndicator, out var envyArrows))
         {
             const uint width = 60;
             const uint length = 800;
             foreach (EffectEvent effect in envyArrows)
             {
-                (long start, long end)= effect.ComputeLifespan(log, 1500);
+                lifespan = effect.ComputeLifespan(log, 1500);
                 var rotation = new AngleConnector(effect.Rotation.Z);
                 GeographicalConnector position = new PositionConnector(effect.Position).WithOffset(new(0.0f, 0.5f * length, 0), true);
-                EnvironmentDecorations.Add(new RectangleDecoration(width, length, (start, end), Colors.Orange, 0.2, position).UsingRotationConnector(rotation));
-                EnvironmentDecorations.Add(new RectangleDecoration(width, length, (end, end + 300), Colors.Red, 0.2, position).UsingRotationConnector(rotation));
+                EnvironmentDecorations.Add(new RectangleDecoration(width, length, lifespan, Colors.Orange, 0.2, position).UsingRotationConnector(rotation));
+                if (effect.Src.IsSpecies(TargetID.EparchLonelyTower))
+                {
+                    EnvironmentDecorations.Add(new RectangleDecoration(width, length, (lifespan.end, lifespan.end + 300), Colors.DarkGreen, 0.2, position).UsingRotationConnector(rotation));
+                }
             }
         }
 
-        // inhale indicator
+        // Inhale - Gluttony Indicator
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchInhale, out var inhales))
         {
             foreach (EffectEvent effect in inhales)
             {
-                (long, long) lifespan = effect.ComputeDynamicLifespan(log, 5000);
-                GeographicalConnector position = new PositionConnector(effect.Position);
-                EnvironmentDecorations.Add(new CircleDecoration(400, lifespan, Colors.Red, 0.2, position));
+                lifespan = effect.ComputeDynamicLifespan(log, 5000);
+                EnvironmentDecorations.Add(new CircleDecoration(400, lifespan, Colors.Red, 0.2, new PositionConnector(effect.Position)));
             }
         }
 
-        // spike of malice
+        // Spike of Malice - Indicator
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchCircleIndicator, out var spikeIndicators))
         {
             foreach (EffectEvent effect in spikeIndicators)
             {
-                (long start, long end) = effect.ComputeDynamicLifespan(log, 1000);
-                GeographicalConnector position = new PositionConnector(effect.Position);
-                var circle = new CircleDecoration(100, (start, end), Colors.Orange, 0.2, position);
-                FormDecoration circleBorder = circle.Copy().UsingFilled(false);
-                FormDecoration circleFiller = circle.UsingGrowingEnd(end);
-                EnvironmentDecorations.Add(circleBorder);
-                EnvironmentDecorations.Add(circleFiller);
+                lifespan = effect.ComputeDynamicLifespan(log, 1000);
+                var circle = new CircleDecoration(100, lifespan, Colors.Orange, 0.2, new PositionConnector(effect.Position)).UsingFilled(false);
+                EnvironmentDecorations.AddWithGrowing(circle, lifespan.end);
             }
         }
+
+        // Spike of Malice - Damage
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchSpikeOfMalice, out var spikes))
         {
             foreach (EffectEvent effect in spikes)
             {
-                (long, long) lifespan = effect.ComputeDynamicLifespan(log, 300);
-                GeographicalConnector position = new PositionConnector(effect.Position);
-                EnvironmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Red, 0.2, position));
+                lifespan = effect.ComputeDynamicLifespan(log, 300);
+                EnvironmentDecorations.Add(new CircleDecoration(100, lifespan, Colors.Red, 0.2, new PositionConnector(effect.Position)));
+            }
+        }
+
+        // Walls of Talons - Incarnation of Cruelty 
+        if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchCrueltyWallsOfTalons, out var crueltyWalls))
+        {
+            foreach (EffectEvent effect in crueltyWalls)
+            {
+                lifespan = effect.ComputeDynamicLifespan(log, 22000);
+                var wall = (RectangleDecoration)new RectangleDecoration(200, 100, lifespan, Colors.Grey, 0.3, new PositionConnector(effect.Position)).UsingRotationConnector(new AngleConnector(effect.Rotation.Z));
+                EnvironmentDecorations.AddWithBorder(wall, Colors.Red, 0.2);
+            }
+        }
+
+        // Eye of Judgment - Arrow circle hits
+        if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.EparchEyeOfJudgmentArrowHits, out var eyeHits))
+        {
+            foreach (EffectEvent effect in eyeHits)
+            {
+                lifespan = (effect.Time, effect.Time + 300);
+                var circle = new CircleDecoration(80, lifespan, Colors.Red, 0.2, new PositionConnector(effect.Position));
+                EnvironmentDecorations.Add(circle);
             }
         }
     }

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItem.cs
@@ -1086,6 +1086,8 @@ public class SkillItem
             { NovaLaunchSAK, SkillImages.CelestialDash },
             // - Arkk
             { HypernovaLaunchSAK, SkillImages.CelestialDash },
+            // - Eparch
+            { HeartOfTheObscure, "https://wiki.guildwars2.com/images/5/5a/Scan_for_Rift.png" },
             // Freezie
             { FireSnowball, "https://wiki.guildwars2.com/images/d/d0/Fire_Snowball.png" },
             // Generic Encounter Skills

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -541,15 +541,21 @@ public static class EffectGUIDs
     public static readonly GUID HarrowshotAoE = new("3AE17719B3D7374BAC4899DA0A3E7DF9");
     // Lonely Tower Fractal
     public static readonly GUID EparchRedCircle = new("0D2192849D53B4469F56B1C74542DBE9"); // owned by eparch, 2s duration, REUSED
+    public static readonly GUID EparchDespairPoolIndicator = new("0D2192849D53B4469F56B1C74542DBE9"); // Src Eparch - Duration 2000
     public static readonly GUID EparchDespairPool = new("FF359460D95C96478CE2A4415EACD312"); // owned by eparch, 15s duration
     public static readonly GUID EparchRageImpact = new("968B7C89FEF01C4298294E86800B9BA9"); // owned by eparch, no duration
     public static readonly GUID EparchRageFissure = new("797210B1B11C984AACBD2AFC80D02BC7"); // no owner, 24s duration
-    public static readonly GUID EparchArrowIndicator = new("27563132F8532847B4DD2CA7AB5B9CE8"); // owned by eparch, 1.5s duration, REUSED for envy, incarnation of judgement
+    public static readonly GUID EparchArrowIndicator = new("27563132F8532847B4DD2CA7AB5B9CE8"); // Src Eparch or Unknown - 1500 Duration - REUSED Wave of Envy has Eparch Src, Eye of Judgment has Unknown Src
     public static readonly GUID EparchInhale = new("FADE0B1FF0CAC146950DB6B69DBAFEDF"); // owned by eparch, 5s duration
     public static readonly GUID EparchCircleIndicator = new("B90A382180F3BD478F59D3DE7AA305B6"); // owned by eparch, 1s duration, REUSED for malice
     public static readonly GUID EparchSpikeOfMalice = new("4550118E2A59DB459CB8AFA3AB3F16A4"); // owned by eparch, no duration
+    public static readonly GUID EparchCrueltyWallsOfTalons = new("E8A3F145A613D2449C4FDD85EE16AD8D"); // No Src - Has end event - Duration 22000
+    public static readonly GUID EparchJudgmentPoolOfDraining = new("46E00F75A40BD448BCCBF0C02C0C26F5"); // Judgment Src - 0 Duration - Default Duration 1266
+    public static readonly GUID EparchJudgmentUnliddedEyeWarning = new("78D6E7A7FD3C1B4DACF3DE09258ED533"); // Src Judgment - 2000 Duration
+    public static readonly GUID EparchJudgmentUnliddedEyeWave = new("28FF802C476BF545AB9A4FF6D33FC6F7"); // Src Judgment - Dst Judgment - 2400 Duration
+    public static readonly GUID EparchEyeOfJudgmentArrowHits = new("564C69F260387449A354A7B37C8FEB2C"); // Src Judgment - 0 Duration - 0 Default Duration
     #endregion
-      
+
     #region Raids
     // Vale Guardian
     public static readonly GUID ValeGuardianDistributedMagic = new("43FD739499BB6040BBF9EEF37781B2CE"); // 6000 duration

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -4195,6 +4195,7 @@ public static class SkillIDs
     public const long ShootingStars = 69560;
     public const long EmpoweredRageCerus = 69576;
     public const long EnviousGazeEmpoweredNM = 69601;
+    public const long UnliddedEye = 69605;
     public const long RelicOfTheHerald = 69606;
     public const long POV_SoulFeastTargetBuff = 69616;
     public const long MabonsStrength = 69620;
@@ -4210,12 +4211,14 @@ public static class SkillIDs
     public const long RelicTargetToPlayerBuff = 69813; // Same for Dragonhunter, Isgarren and Peitha
     public const long EnviousGazeNM = 69814;
     public const long DagdaDemonicAuraTimer = 69827;
+    public const long CruelDetonation1 = 69828;
     public const long EnviousGazeEmpoweredRearNM = 69829;
     public const long RelicOfTheNightmare = 69849;
     public const long RelicOfFireworks = 69855;
     public const long InsatiableHunger8 = 69861;
     public const long RelicOfCerusBuff = 69867;
     public const long RelicOfPeithaTargetBuff = 69882;
+    public const long CruelDetonation2 = 69928;
     public const long ChargingConstellationDamage = 69950;
     public const long RelicOfVass = 69961;
     public const long SpinningNebulaCentral = 69989; // The attack when Dagda doesn't teleport off the center
@@ -4252,6 +4255,7 @@ public static class SkillIDs
     public const long InsatiableHungerSkillNM = 70385;
     public const long RelicOfTheWeaver = 70390;
     public const long EmpoweredGluttonyCerus = 70395;
+    public const long PoolOfDraining = 70410;
     public const long MaliciousIntentSpawnDamageNM = 70427;
     public const long SkyscaleFireballSkill = 70431;
     public const long RelicOfTheZephyrite = 70460;
@@ -4285,12 +4289,14 @@ public static class SkillIDs
     public const long MaliciousIntentCM = 70786;
     public const long EnviousGazeCM = 70790;
     public const long InsatiableHunger9 = 70792;
+    public const long EyeOfJudgment = 70810;
     public const long RelicOfIsgarrenTargetBuff = 70806;
     public const long EmpoweredDespairCerus = 70821;
     public const long FearOfTheKing = 70822;
     public const long RainOfComets = 70837; // Health % damage, can't be tracked
     public const long RelicOfTheDaredevil = 70839;
     public const long PlanetCrashSkill = 70840;
+    public const long WallOfTalons = 70843;
     public const long InsatiableHunger10 = 70880;
     public const long PetrifyDamage = 70909;
     public const long RelicOfTheBrawler = 70913;

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -4449,6 +4449,7 @@ public static class SkillIDs
     public const long Consumed = 72888;
     public const long EnragedLonelyTower = 72878;
     public const long BrothersUnited = 72892;
+    public const long HeartOfTheObscure = 72893;
     #endregion
     #region Janthir Wilds
     public const long EntanglingAsp = 72896;


### PR DESCRIPTION
Added all of the mechanics
Added the ability to create reverse shockwaves with the Shockwave API
Added Heart of the Obscure icon

Combat Replay:
- Added Pool of Despair indicator with animation
- Added Breakbar
- Wall of Talons
- Eye of Judgment circle hits, no longer conflicts with Eparch
- Wave of Envy only displays the red arrow decoration when Eparch is casting due to above conflict
- Unlidded Eye (warning and shockwave)
- Pool of Draining