### PR TITLE
Fix C# Dev Kit error on Linux

### DIFF
--- a/GW2EIParser/GW2EIParser.csproj
+++ b/GW2EIParser/GW2EIParser.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>net8-windows</TargetFramework>
         <LangVersion>12.0</LangVersion>
+        <EnableWindowsTargeting>true</EnableWindowsTargeting>
         <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 


### PR DESCRIPTION
The VSC C# Dev Kit errors out on GW2EIParser.csproj because of this tag not being set.