### PR TITLE
Update Malicious Intent

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/EncounterBuffs.cs
@@ -704,6 +704,7 @@ internal static class EncounterBuffs
             // Temple of Febe
             new Buff("Insatiable", Insatiable, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.VoidCorruption),
             new Buff("Malicious Intent Target", MaliciousIntentTargetBuff, Source.FightSpecific, BuffClassification.Other, SkillImages.MonsterSkill),
+            new Buff("Malicious Intent Target (CM)", MaliciousIntentTargetBuffCM, Source.FightSpecific, BuffClassification.Other, SkillImages.MonsterSkill),
             new Buff("Empowered (Cerus)", EmpoweredCerus, Source.FightSpecific, BuffStackType.Stacking, 99, BuffClassification.Other, BuffImages.EmpoweredMursaarOverseer),
             new Buff("Empowered Despair (Cerus)", EmpoweredDespairCerus, Source.FightSpecific, BuffClassification.Other, BuffImages.ExcessMagic),
             new Buff("Empowered Envy (Cerus)", EmpoweredEnvyCerus, Source.FightSpecific, BuffClassification.Other, BuffImages.ExcessMagic),

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -4311,6 +4311,7 @@ public static class SkillIDs
     public const long WailOfDespairNM = 70633;
     public const long PoolOfDespairEmpoweredNM = 70659;
     public const long CryOfRageEmpoweredNM = 70668;
+    public const long MaliciousIntentTargetBuffCM = 70675;
     public const long EnragedSmashCM = 70681;
     public const long EmpoweredGluttonyEmbodiment = 70687;
     public const long SummonedPhantom = 70724;


### PR DESCRIPTION
Back when Cerus CM released, I couldn't find a buff applied to players targeted by malices, today I found it and it works retroactively to the very first log i have of the CM.
This cuts down a lot of extra steps that were taken to make the tethers work.