### PR TITLE
Breakbar improvments

### DIFF
--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStats.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayTargetStats.html
@@ -4,12 +4,12 @@
         <div class="d-flex mb-1 mt-1">
             <combat-replay-target-status-component :time="time" :targetindex="targetindex"/>
             <combat-replay-actor-rotation-component :time="time" :actorindex="targetindex" :enemy="true"/>
-        </div> 
-        <div v-if="hasBreakbarPercent" class="cr-breakbar-phase-display mb-1">         
+        </div>
+        <div v-if="hasBreakbarPercent" class="cr-breakbar-phase-display mb-1">
             <ul class="nav nav-pills d-flex flex-row flex-wrap justify-content-center">
                 <li class="nav-item" v-for="(phase, id) in breakbarPhases"
                     @click="updatePhaseTime(phase.start * 1000, phase.end * 1000, phase.name)"
-                    :data-original-title="phase.durationS + ' seconds <br /> Start: ' + phase.start + '<br /> End: ' + phase.end">
+                    :data-original-title="getTooltip(phase)">
                     <a class="nav-link">{{id + 1}} </a>
                 </li>
             </ul>
@@ -21,15 +21,21 @@
     Vue.component("combat-replay-target-stats-component", {
         props: ["targetindex", "time", "buffstoshow"],
         template: `${template}`,
-        methods: {       
+        methods: {
             updatePhaseTime: function (min, max, name) {
                 animator.updateTime(min);
                 sliderDelimiter.min = min;
                 sliderDelimiter.max = max;
                 sliderDelimiter.name = name;
             },
+            getTooltip: function(phase) {
+                var target = logData.targets[this.targetindex];
+                var phaseId = logData.phases.indexOf(phase);
+                var breakbarTaken = target.details.dmgDistributionsTaken[phaseId].contributedBreakbarDamage;
+                return phase.durationS + ' seconds <br /> Start: ' + phase.start + '<br /> End: ' + phase.end + '<br /> Breakbar Damage: ' + breakbarTaken;
+            },
         },
-        computed: {           
+        computed: {
             breakbarPhases: function () {
                 if (!this.hasBreakbarPercent) {
                     return [];

--- a/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplPhase.html
+++ b/GW2EIBuilders/Resources/htmlTemplates/Headers/tmplPhase.html
@@ -2,7 +2,7 @@
     <div>
         <ul v-if="showNormalPhases" class="nav nav-pills d-flex flex-row justify-content-center">
             <li class="nav-item" v-for="(phase, id) in phases" v-show="!getPhaseData(id).breakbarPhase"
-                :data-original-title="getPhaseData(id).durationS + ' seconds <br /> Start: ' + getPhaseData(id).start + '<br /> End: ' + getPhaseData(id).end">
+                :data-original-title="getPhaseTooltip(id)">
                 <a class="nav-link" @click="select(phase)" :class="{active: phase.active}">{{getPhaseData(id).name}}</a>
             </li>
         </ul>
@@ -17,7 +17,7 @@
                 <ul class="nav nav-pills d-flex flex-row flex-nowrap">
                     <li class="nav-item" v-for="(phaseId, id) in data.phaseIds"
                         v-show="getPhaseData(phaseId).breakbarPhase"
-                        :data-original-title="getPhaseData(phaseId).durationS + ' seconds <br /> Start: ' + getPhaseData(phaseId).start + '<br /> End: ' + getPhaseData(phaseId).end">
+                        :data-original-title="getBreakbarPhaseTooltip(phaseId)">
                         <a class="nav-link" @click="select(getReactivePhaseData(phaseId))"
                             :class="{active: getReactivePhaseData(phaseId).active}">{{id + 1}}</a>
                     </li>
@@ -74,6 +74,16 @@
             },
             getTargetData: function (id) {
                 return logData.targets[id];
+            },
+            getPhaseTooltip: function(id) {
+                var phase = this.getPhaseData(id);
+                return phase.durationS + ' seconds <br /> Start: ' + phase.start + '<br /> End: ' + phase.end;
+            },
+            getBreakbarPhaseTooltip: function(id) {
+                var phase = this.getPhaseData(id);
+                var target = this.getTargetData(phase.targets[0]);
+                var breakbarTaken = target.details.dmgDistributionsTaken[id].contributedBreakbarDamage;
+                return this.getPhaseTooltip(id) + '<br /> Breakbar Damage: ' + breakbarTaken;
             }
         }
     });

--- a/GW2EIEvtcParser/ParsedData/CombatEvents/DamageEvents/BreakbarDamageEvent.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatEvents/DamageEvents/BreakbarDamageEvent.cs
@@ -6,5 +6,11 @@ public class BreakbarDamageEvent : SkillEvent
     internal BreakbarDamageEvent(CombatItem evtcItem, AgentData agentData, SkillData skillData) : base(evtcItem, agentData, skillData)
     {
         BreakbarDamage = Math.Round(evtcItem.Value / 10.0, 1);
+
+        // generic breakbar damage is changed amount rather than damage, need to flip sign
+        if (SkillId == skillData.GenericBreakbarId)
+        {
+            BreakbarDamage *= -1.0;
+        }
     }
 }


### PR DESCRIPTION
This fixes the breakbar damage values from generic breakbar damage events, which combines regeneration + soft CC. Positive values are healing and negative values are damage.

It also adds the total breakbar damage dealt to the tooltip of breakbar phases.