### PR TITLE
Added MarkerCastFinder and Dragonhunter + Isgarren relic proc finders

### DIFF
--- a/GW2EIEvtcParser/EIData/InstantCastFinders/MarkerCastFinder/MarkerCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/MarkerCastFinder/MarkerCastFinder.cs
@@ -1,0 +1,113 @@
+﻿using GW2EIEvtcParser.ParsedData;
+using static GW2EIEvtcParser.ParserHelper;
+
+namespace GW2EIEvtcParser.EIData;
+
+internal class MarkerCastFinder : CheckedCastFinder<MarkerEvent>
+{
+    protected bool Minions = false;
+    private readonly GUID _markerGUID;
+    private int _speciesID = 0;
+
+    public MarkerCastFinder WithMinions()
+    {
+        Minions = true;
+        return this;
+    }
+
+    protected AgentItem GetAgent(MarkerEvent markerEvent)
+    {
+        return Minions ? GetKeyAgent(markerEvent).GetFinalMaster() : GetKeyAgent(markerEvent);
+    }
+
+    protected virtual AgentItem GetKeyAgent(MarkerEvent markerEvent)
+    {
+        return markerEvent.Src;
+    }
+
+    public MarkerCastFinder(long skillID, GUID markerGUID) : base(skillID)
+    {
+        UsingNotAccurate();
+        UsingEnable((combatData) => combatData.HasEffectData);
+        _markerGUID = markerGUID;
+    }
+
+    internal MarkerCastFinder UsingSrcBaseSpecChecker(Spec spec)
+    {
+        UsingChecker((evt, combatData, agentData, skillData) => evt.Src.BaseSpec == spec);
+        return this;
+    }
+
+    internal MarkerCastFinder UsingSrcNotBaseSpecChecker(Spec spec)
+    {
+        UsingChecker((evt, combatData, agentData, skillData) => evt.Src.BaseSpec != spec);
+        return this;
+    }
+
+    internal MarkerCastFinder UsingSrcSpecChecker(Spec spec)
+    {
+        UsingChecker((evt, combatData, agentData, skillData) => evt.Src.Spec == spec);
+        return this;
+    }
+
+    internal MarkerCastFinder UsingSrcNotSpecChecker(Spec spec)
+    {
+        UsingChecker((evt, combatData, agentData, skillData) => evt.Src.Spec != spec);
+        return this;
+    }
+
+    internal MarkerCastFinder UsingSrcSpecsChecker(HashSet<Spec> specs)
+    {
+        UsingChecker((evt, combatData, agentData, skillData) => specs.Contains(evt.Src.Spec));
+        return this;
+    }
+    internal MarkerCastFinder UsingSrcNotSpecsChecker(HashSet<Spec> specs)
+    {
+        UsingChecker((evt, combatData, agentData, skillData) => !specs.Contains(evt.Src.Spec));
+        return this;
+    }
+
+    internal MarkerCastFinder UsingAgentRedirectionIfUnknown(int speciesID)
+    {
+        _speciesID = speciesID;
+        return this;
+    }
+
+    public override List<InstantCastEvent> ComputeInstantCast(CombatData combatData, SkillData skillData, AgentData agentData)
+    {
+        var res = new List<InstantCastEvent>();
+        var markerGUIDEvent = combatData.GetMarkerGUIDEvent(_markerGUID);
+        var markers = combatData.GetMarkerEventsByMarkerID(markerGUIDEvent.ContentID).GroupBy(GetAgent);
+        foreach (var group in markers)
+        {
+            if (group.Key.IsUnknown)
+            {
+                continue;
+            }
+            long lastTime = int.MinValue;
+            foreach (MarkerEvent markerEvent in group)
+            {
+                if (CheckCondition(markerEvent, combatData, agentData, skillData))
+                {
+                    if (markerEvent.Time - lastTime < ICD)
+                    {
+                        lastTime = markerEvent.Time;
+                        continue;
+                    }
+                    lastTime = markerEvent.Time;
+                    var caster = group.Key;
+                    if (_speciesID > 0 && caster.IsUnamedSpecies())
+                    {
+                        AgentItem? agent = agentData.GetNPCsByID(_speciesID).FirstOrDefault(x => x.LastAware >= markerEvent.Time && x.FirstAware <= markerEvent.Time);
+                        if (agent != null)
+                        {
+                            caster = agent;
+                        }
+                    }
+                    res.Add(new InstantCastEvent(GetTime(markerEvent, GetKeyAgent(markerEvent), combatData), skillData.Get(SkillID), caster));
+                }
+            }
+        }
+        return res;
+    }
+}

--- a/GW2EIEvtcParser/EIData/InstantCastFinders/MarkerCastFinder/MarkerCastFinder.cs
+++ b/GW2EIEvtcParser/EIData/InstantCastFinders/MarkerCastFinder/MarkerCastFinder.cs
@@ -28,7 +28,7 @@ internal class MarkerCastFinder : CheckedCastFinder<MarkerEvent>
     public MarkerCastFinder(long skillID, GUID markerGUID) : base(skillID)
     {
         UsingNotAccurate();
-        UsingEnable((combatData) => combatData.HasEffectData);
+        UsingEnable((combatData) => combatData.HasMarkerData);
         _markerGUID = markerGUID;
     }
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -128,14 +128,12 @@ internal static class ProfHelper
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffGiveCastFinder(RelicOfDagdaHit, RelicOfDagdaBuff)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-        //new BuffGainCastFinder(RelicOfIsgarrenTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
-        //{
-        //    return combatData.GetBuffData(RelicOfIsgarrenTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
-        //}).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-        //new BuffGainCastFinder(RelicOfTheDragonhunterTargetBuff, RelicTargetPlayerBuff).UsingChecker((bae, combatData, agentData, skillData) =>
-        //{
-        //    return combatData.GetBuffData(RelicOfTheDragonhunterTargetBuff).Where(x => x.CreditedBy == bae.To && Math.Abs(x.Time - bae.Time) < ServerDelayConstant).Any();
-        //}).UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+        new BuffGiveCastFinder(RelicOfIsgarrenTargetBuff, RelicOfIsgarrenTargetBuff)
+            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear)
+            .UsingICD(), // Preventing multi triggers on initial proc from evading
+        new BuffGiveCastFinder(RelicOfTheDragonhunterTargetBuff, RelicOfTheDragonhunterTargetBuff)
+            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear)
+            .UsingICD(), // Preventing multi triggers on initial cast of a trap
         new BuffLossCastFinder(RelicOfFireworksBuffLoss, RelicOfFireworks)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffLossCastFinder(RelicOfTheClawBuffLoss, RelicOfTheClaw)
@@ -177,7 +175,7 @@ internal static class ProfHelper
         new EffectCastFinder(RelicOfSorrowBuff, EffectGUIDs.RelicOfSorrow3)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new EffectCastFinder(RelicOfTheStormsingerChain, EffectGUIDs.RelicOfTheStormsinger)
-            .UsingChecker((effectEvent, combatData, agentData, skillData) => 
+            .UsingChecker((effectEvent, combatData, agentData, skillData) =>
             {
                 return combatData.HasLostBuff(RelicOfTheStormsingerBuff, effectEvent.Src, effectEvent.Time);
             })

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -129,9 +129,9 @@ internal static class ProfHelper
         new BuffGiveCastFinder(RelicOfDagdaHit, RelicOfDagdaBuff)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffGiveCastFinder(RelicOfIsgarrenTargetBuff, RelicOfIsgarrenTargetBuff)
-            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear)
+            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffGiveCastFinder(RelicOfTheDragonhunterTargetBuff, RelicOfTheDragonhunterTargetBuff)
-            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear)
+            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffLossCastFinder(RelicOfFireworksBuffLoss, RelicOfFireworks)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffLossCastFinder(RelicOfTheClawBuffLoss, RelicOfTheClaw)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -130,10 +130,8 @@ internal static class ProfHelper
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffGiveCastFinder(RelicOfIsgarrenTargetBuff, RelicOfIsgarrenTargetBuff)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear)
-            .UsingICD(), // Preventing multi triggers on initial proc from evading
         new BuffGiveCastFinder(RelicOfTheDragonhunterTargetBuff, RelicOfTheDragonhunterTargetBuff)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear)
-            .UsingICD(), // Preventing multi triggers on initial cast of a trap
         new BuffLossCastFinder(RelicOfFireworksBuffLoss, RelicOfFireworks)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffLossCastFinder(RelicOfTheClawBuffLoss, RelicOfTheClaw)

--- a/GW2EIEvtcParser/EncounterLogic/Raids/W8/Bosses/GreerTheBlightbringer.cs
+++ b/GW2EIEvtcParser/EncounterLogic/Raids/W8/Bosses/GreerTheBlightbringer.cs
@@ -588,7 +588,7 @@ internal class GreerTheBlightbringer : MountBalrior
             {
                 lifespan = effect.ComputeLifespan(log, 5000);
                 var offset = new Vector3(700, 0, 0);
-                var arrow = new RectangleDecoration(1400, 50, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position).WithOffset(offset, true)).UsingRotationConnector(new AngleConnector(effect.Rotation.Z - 90));
+                var arrow = new RectangleDecoration(1400, 100, lifespan, Colors.LightOrange, 0.2, new PositionConnector(effect.Position).WithOffset(offset, true)).UsingRotationConnector(new AngleConnector(effect.Rotation.Z - 90));
                 replay.Decorations.Add(arrow);
             }
         }
@@ -635,7 +635,7 @@ internal class GreerTheBlightbringer : MountBalrior
             foreach (EffectEvent effect in cageOfDecayWalls)
             {
                 lifespan = effect.ComputeLifespan(log, 2000);
-                var wall = (RectangleDecoration)new RectangleDecoration(100, 50, lifespan, Colors.GreenishYellow, 0.3, new PositionConnector(effect.Position)).UsingRotationConnector(new AngleConnector(effect.Rotation.Z));
+                var wall = (RectangleDecoration)new RectangleDecoration(200, 50, lifespan, Colors.GreenishYellow, 0.3, new PositionConnector(effect.Position)).UsingRotationConnector(new AngleConnector(effect.Rotation.Z));
                 replay.Decorations.AddWithBorder(wall, Colors.Purple, 0.2);
             }
         }

--- a/GW2EIEvtcParser/ParsedData/CombatData.cs
+++ b/GW2EIEvtcParser/ParsedData/CombatData.cs
@@ -72,6 +72,7 @@ public partial class CombatData
     public readonly bool HasBreakbarDamageData = false;
     public readonly bool HasCrowdControlData = false;
     public readonly bool HasEffectData = false;
+    public readonly bool HasMarkerData = false;
     public readonly bool HasSpeciesAndSkillGUIDs = false;
     public readonly bool HasMissileData = false;
 
@@ -567,6 +568,7 @@ public partial class CombatData
         HasMovementData = _statusEvents.MovementEvents.Count > 1;
         HasBreakbarDamageData = brkDamageData.Count != 0 || brkRecoveredData.Count != 0;
         HasEffectData = _statusEvents.EffectEvents.Count != 0;
+        HasMarkerData = _statusEvents.MarkerEvents.Count != 0;
         HasCrowdControlData = crowdControlData.Count != 0;
         HasSpeciesAndSkillGUIDs = evtcVersion.Build >= ArcDPSBuilds.SpeciesSkillGUIDs;
         HasMissileData = _statusEvents.MissileEvents.Count != 0;


### PR DESCRIPTION
Talked with @SaculRennorb and according to him and a friend of his, there shouldn't be any player skill that interacts with the marker system like commander tags/squad markers, so the cast finder might be not useful moving forward, maybe it will become useful for encounter casts in future.

Added Dragonhunter and Isgarren relic procs with 50ms ICD to prevent multi triggering on initial procs.