### PR TITLE
Balance Patch

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/UtilityBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/UtilityBuffs.cs
@@ -64,6 +64,7 @@ internal static class UtilityBuffs
         new Buff("Decade Enhancement", DecadeEnhancement, Source.Item, BuffClassification.Enhancement, ItemImages.DecadeEnhancement),
         new Buff("Sharpening Golem", SharpeningGolem, Source.Item, BuffClassification.Enhancement, ItemImages.NourishmentEffect),
         new Buff("Snow Diamond Ornament", SnowDiamondOrnament, Source.Item, BuffClassification.Enhancement, ItemImages.SnowDiamondOrnament),
+        new Buff("Super Sharpening Polygon", SuperSharpeningPolygon, Source.Item, BuffClassification.Enhancement, ItemImages.SnowDiamondOrnament),
     ];
 
     internal static readonly IReadOnlyList<Buff> OtherConsumables =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/CatalystHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/CatalystHelper.cs
@@ -67,9 +67,13 @@ internal static class CatalystHelper
         new BuffOnActorDamageModifier(Mod_EmpoweringAuras, EmpoweringAuras, "Empowering Auras", "2% per stack", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Catalyst, ByStack, TraitImages.EmpoweringAuras, DamageModifierMode.All)
             .WithBuilds(GW2Builds.September2023Balance, GW2Builds.February2026GuardiansGladeCMReleaseAndMinorBalance),
         new BuffOnActorDamageModifier(Mod_EmpoweringAuras, EmpoweringAuras, "Empowering Auras", "2% per stack", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Catalyst, ByStack, TraitImages.EmpoweringAuras, DamageModifierMode.PvEsPvP)
-            .WithBuilds(GW2Builds.February2026GuardiansGladeCMReleaseAndMinorBalance),
+            .WithBuilds(GW2Builds.February2026GuardiansGladeCMReleaseAndMinorBalance, GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_EmpoweringAuras, EmpoweringAuras, "Empowering Auras", "1% per stack", DamageSource.NoPets, 1.0, DamageType.StrikeAndCondition, DamageType.All, Source.Catalyst, ByStack, TraitImages.EmpoweringAuras, DamageModifierMode.WvW)
-            .WithBuilds(GW2Builds.February2026GuardiansGladeCMReleaseAndMinorBalance),
+            .WithBuilds(GW2Builds.February2026GuardiansGladeCMReleaseAndMinorBalance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_EmpoweringAuras, EmpoweringAuras, "Empowering Auras", "1% per stack", DamageSource.NoPets, 1.0, DamageType.StrikeAndCondition, DamageType.All, Source.Catalyst, ByStack, TraitImages.EmpoweringAuras, DamageModifierMode.PvEWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_EmpoweringAuras, EmpoweringAuras, "Empowering Auras", "2% per stack", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Catalyst, ByStack, TraitImages.EmpoweringAuras, DamageModifierMode.sPvP)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -128,28 +128,32 @@ internal static class ElementalistHelper
         // - Aquamancer's Training
         new DamageLogDamageModifier(Mod_AquamancersTraining, "Aquamancer's Training", "10% if hp >=90%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, TraitImages.AquamancersTraining, (x, log) => x.IsOverNinety, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
-        // - Piercing Shards
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards", "20% on vuln target while on water", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
-            .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "5% on vuln target", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.sPvPWvW)
-            .UsingActorCheckerByAbsence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.July2019Balance),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards w/ Water", "10% on vuln target while on water", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.sPvPWvW)
-            .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.July2019Balance),
+        // - Piercing Shards - Water
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards", "20% on vuln target while on water", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.All)
+            .UsingActorCheckerByPresence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2020Balance),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards", "20% on vuln target while on water", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+            .UsingActorCheckerByPresence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
+            .WithBuilds(GW2Builds.February2020Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards", "14% on vuln target while on water", DamageSource.NoPets, 14.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+            .UsingActorCheckerByPresence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards", "10% on vuln target while on water", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.sPvPWvW)
+            .UsingActorCheckerByPresence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
+            .WithBuilds(GW2Builds.February2020Balance),
+        // - Piercing Shards - No Water
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "10% on vuln target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.All)
+            .UsingActorCheckerByAbsence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
+            .WithBuilds(GW2Builds.July2019Balance, GW2Builds.February2020Balance),
         new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "10% on vuln target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
-            .UsingActorCheckerByAbsence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.July2019Balance, GW2Builds.April2026Balancepocalypse),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards w/ Water", "20% on vuln target while on water", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
-            .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.July2019Balance, GW2Builds.April2026Balancepocalypse),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "10% on vuln target", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
-            .UsingActorCheckerByAbsence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
+            .UsingActorCheckerByAbsence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
+            .WithBuilds(GW2Builds.February2020Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "7% on vuln target", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+            .UsingActorCheckerByAbsence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
             .WithBuilds(GW2Builds.April2026Balancepocalypse),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards w/ Water", "20% on vuln target while on water", DamageSource.NoPets, 14.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
-            .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "5% on vuln target", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.sPvPWvW)
+            .UsingActorCheckerByAbsence([WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement])
+            .WithBuilds(GW2Builds.February2020Balance),
         // - Flow like Water
         new DamageLogDamageModifier(Mod_FlowLikeWater, "Flow like Water", "10% if hp >=75%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, TraitImages.FlowLikeWater, FromHPChecker(75), DamageModifierMode.All)
             .WithBuilds(GW2Builds.July2019Balance, GW2Builds.February2020Balance)
@@ -215,7 +219,7 @@ internal static class ElementalistHelper
         // - Stone Flesh
         new BuffOnActorDamageModifier(Mod_StoneFlesh, [EarthAttunementBuff, FireEarthAttunement, WaterEarthAttunement, EarthAirAttunement, DualEarthAttunement], "Stone Flesh", "-7% damage while attuned to earth", DamageSource.Incoming, -7, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.StoneFlesh, DamageModifierMode.All),
         // - Stone Heart
-        new BuffOnActorDamageModifier(Mod_StoneHeart, StoneHeart, "Stone Heart", "-40% strike damage", DamageSource.Incoming, -40, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.StoneHeart, DamageModifierMode.All),
+        new BuffOnActorDamageModifier(Mod_StoneHeart, StoneHeart, "Stone Heart", "-40% damage", DamageSource.Incoming, -40, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.StoneHeart, DamageModifierMode.All),
         // - Geomancer's Training
         new DamageLogDamageModifier(Mod_GeomancersTraining, "Geomancer's Training", "-10% damage from foes within 360 range", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Elementalist, TraitImages.GeomancersTraining, (x, log) => TargetWithinRangeChecker(x, log, 360), DamageModifierMode.All)
             .UsingApproximate()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/ElementalistHelper.cs
@@ -107,7 +107,11 @@ internal static class ElementalistHelper
         new BuffOnActorDamageModifier(Mod_PyromancersTraining, [FireAttunementBuff, FireWaterAttunement, FireAirAttunement, FireEarthAttunement, DualFireAttunement], "Pyromancer's Training", "10% while fire attuned", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PyromancersTraining, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
         new BuffOnFoeDamageModifier(Mod_PyromancersTraining, Burning, "Pyromancer's Training", "10% on burning target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PyromancersTraining, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.July2019Balance),
+            .WithBuilds(GW2Builds.July2019Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PyromancersTraining, Burning, "Pyromancer's Training", "7% on burning target", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PyromancersTraining, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PyromancersTraining, Burning, "Pyromancer's Training", "10% on burning target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PyromancersTraining, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Burning Rage
         new BuffOnFoeDamageModifier(Mod_BurningRage, Burning, "Burning Rage", "10% on burning target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.BurningRage, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
@@ -125,21 +129,27 @@ internal static class ElementalistHelper
         new DamageLogDamageModifier(Mod_AquamancersTraining, "Aquamancer's Training", "10% if hp >=90%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, TraitImages.AquamancersTraining, (x, log) => x.IsOverNinety, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
         // - Piercing Shards
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards w/ Water", "20% on vuln target while on water", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards", "20% on vuln target while on water", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
             .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.July2019Balance),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "10% on vuln target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "5% on vuln target", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.sPvPWvW)
             .UsingActorCheckerByAbsence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
             .WithBuilds(GW2Builds.July2019Balance),
         new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards w/ Water", "10% on vuln target while on water", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.sPvPWvW)
             .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
             .WithBuilds(GW2Builds.July2019Balance),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "5% on vuln target", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.sPvPWvW)
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "10% on vuln target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
             .UsingActorCheckerByAbsence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.July2019Balance),
-        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards", "20% on vuln target while on water", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.July2019Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards w/ Water", "20% on vuln target while on water", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
             .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.July2019Balance),
+            .WithBuilds(GW2Builds.July2019Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsNoWater, Vulnerability, "Piercing Shards", "10% on vuln target", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+            .UsingActorCheckerByAbsence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PiercingShardsWater, Vulnerability, "Piercing Shards w/ Water", "20% on vuln target while on water", DamageSource.NoPets, 14.0, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.PiercingShards, DamageModifierMode.PvE)
+            .UsingActorCheckerByPresence([ WaterAttunementBuff, WaterAirAttunement, WaterEarthAttunement, WaterFireAttunement, DualWaterAttunement ])
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Flow like Water
         new DamageLogDamageModifier(Mod_FlowLikeWater, "Flow like Water", "10% if hp >=75%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Elementalist, TraitImages.FlowLikeWater, FromHPChecker(75), DamageModifierMode.All)
             .WithBuilds(GW2Builds.July2019Balance, GW2Builds.February2020Balance)
@@ -169,7 +179,15 @@ internal static class ElementalistHelper
             .UsingApproximate(),
         new BuffOnFoeDamageModifier(Mod_StormSoulDefiant, [Stun, Daze, Knockdown, Fear, Taunt], "Stormsoul", "10% to defiant foes", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.Strike, Source.Elementalist, ByAbsence, TraitImages.Stormsoul, DamageModifierMode.All)
             .UsingChecker((x, log) => x.To.GetCurrentBreakbarState(log, x.Time) != BreakbarState.None)
-            .WithBuilds(GW2Builds.November2022Balance)
+            .WithBuilds(GW2Builds.November2022Balance, GW2Builds.April2026Balancepocalypse)
+            .UsingApproximate(),
+        new BuffOnFoeDamageModifier(Mod_StormSoulDefiant, [Stun, Daze, Knockdown, Fear, Taunt], "Stormsoul", "7% to defiant foes", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.Strike, Source.Elementalist, ByAbsence, TraitImages.Stormsoul, DamageModifierMode.PvE)
+            .UsingChecker((x, log) => x.To.GetCurrentBreakbarState(log, x.Time) != BreakbarState.None)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse)
+            .UsingApproximate(),
+        new BuffOnFoeDamageModifier(Mod_StormSoulDefiant, [Stun, Daze, Knockdown, Fear, Taunt], "Stormsoul", "10% to defiant foes", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.Strike, Source.Elementalist, ByAbsence, TraitImages.Stormsoul, DamageModifierMode.sPvPWvW)
+            .UsingChecker((x, log) => x.To.GetCurrentBreakbarState(log, x.Time) != BreakbarState.None)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse)
             .UsingApproximate(),
 
         // Hammer
@@ -184,7 +202,7 @@ internal static class ElementalistHelper
 
         // Pistol
         new BuffOnActorDamageModifier(Mod_RagingRicochet, RagingRichochetBuff, "Raging Ricochet", "5%", DamageSource.NoPets, 5.0, DamageType.Condition, DamageType.All, Source.Elementalist, ByPresence, SkillImages.RagingRicochet, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.February2024NewWeapons),
+            .WithBuilds(GW2Builds.February2024NewWeapons, GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =
@@ -196,6 +214,8 @@ internal static class ElementalistHelper
         // Earth
         // - Stone Flesh
         new BuffOnActorDamageModifier(Mod_StoneFlesh, [EarthAttunementBuff, FireEarthAttunement, WaterEarthAttunement, EarthAirAttunement, DualEarthAttunement], "Stone Flesh", "-7% damage while attuned to earth", DamageSource.Incoming, -7, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.StoneFlesh, DamageModifierMode.All),
+        // - Stone Heart
+        new BuffOnActorDamageModifier(Mod_StoneHeart, StoneHeart, "Stone Heart", "-40% strike damage", DamageSource.Incoming, -40, DamageType.Strike, DamageType.All, Source.Elementalist, ByPresence, TraitImages.StoneHeart, DamageModifierMode.All),
         // - Geomancer's Training
         new DamageLogDamageModifier(Mod_GeomancersTraining, "Geomancer's Training", "-10% damage from foes within 360 range", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Elementalist, TraitImages.GeomancersTraining, (x, log) => TargetWithinRangeChecker(x, log, 360), DamageModifierMode.All)
             .UsingApproximate()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/EvokerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/EvokerHelper.cs
@@ -56,7 +56,9 @@ internal static class EvokerHelper
         new BuffOnActorDamageModifier(Mod_FamiliarsProwessFocusFox, FamiliarsProwessFox, "Familiar's Prowess + Focus (Fox)", "20% after familiar skill (Familiar's Focus)", DamageSource.NoPets, 20.0, DamageType.Condition, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_FamiliarsProwessFocusFox, FamiliarsProwessFox, "Familiar's Prowess + Focus (Fox)", "15% after familiar skill (Familiar's Focus)", DamageSource.NoPets, 15.0, DamageType.Condition, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.December2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_FamiliarsProwessFocusFox, FamiliarsProwessFox, "Familiar's Prowess + Focus (Fox)", "10% after familiar skill (Familiar's Focus)", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Familiar's Prowess (Hare)
         new BuffOnActorDamageModifier(Mod_FamiliarsProwessHare, FamiliarsProwessHare, "Familiar's Prowess (Hare)", "10% after familiar skill", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.All)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.OctoberVoERelease),
@@ -86,9 +88,11 @@ internal static class EvokerHelper
         new BuffOnActorDamageModifier(Mod_FamiliarsProwessFocusHare, FamiliarsProwessHare, "Familiar's Prowess + Focus (Hare)", "15% after familiar skill (Familiar's Focus)", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.PvEsPvP)
             .WithBuilds(GW2Builds.December2025Balance, GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
         new BuffOnActorDamageModifier(Mod_FamiliarsProwessFocusHare, FamiliarsProwessHare, "Familiar's Prowess + Focus (Hare)", "15% after familiar skill (Familiar's Focus)", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
+            .WithBuilds(GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance, GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_FamiliarsProwessFocusHare, FamiliarsProwessHare, "Familiar's Prowess + Focus (Hare)", "12% after familiar skill (Familiar's Focus)", DamageSource.NoPets, 12.0, DamageType.Strike, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.sPvP)
             .WithBuilds(GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
+        new BuffOnActorDamageModifier(Mod_FamiliarsProwessFocusHare, FamiliarsProwessHare, "Familiar's Prowess + Focus (Hare)", "10% after familiar skill (Familiar's Focus)", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Evoker, ByPresence, TraitImages.FamiliarsProwess, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse, GW2Builds.April2026Balancepocalypse),
         // Zap
         new BuffOnFoeDamageModifier(Mod_Zap, ZapBuffPlayerToTarget, "Zap", "7% crit damage", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Evoker, ByPresence, SkillImages.Zap, DamageModifierMode.PvE)
             .WithBuffOnFoeFromActor()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/TempestHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/TempestHelper.cs
@@ -33,7 +33,11 @@ internal static class TempestHelper
         new BuffOnActorDamageModifier(Mod_TranscendentTempest, TranscendentTempest, "Transcendent Tempest", "15% after overload", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Tempest, ByPresence, TraitImages.TranscendentTempest, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.August2022Balance, GW2Builds.SOTOReleaseAndBalance),
         new BuffOnActorDamageModifier(Mod_TranscendentTempest, TranscendentTempest, "Transcendent Tempest", "25% after overload", DamageSource.NoPets, 25.0, DamageType.StrikeAndCondition, DamageType.All, Source.Tempest, ByPresence, TraitImages.TranscendentTempest, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.SOTOReleaseAndBalance),
+            .WithBuilds(GW2Builds.SOTOReleaseAndBalance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_TranscendentTempestStrike, TranscendentTempest, "Transcendent Tempest", "25% after overload", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Tempest, ByPresence, TraitImages.TranscendentTempest, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_TranscendentTempestCondition, TranscendentTempest, "Transcendent Tempest", "20% after overload", DamageSource.NoPets, 20.0, DamageType.Condition, DamageType.All, Source.Tempest, ByPresence, TraitImages.TranscendentTempest, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Tempestuous Aria
         new BuffOnActorDamageModifier(Mod_TempestuousAria, TempestuousAria, "Tempestuous Aria", "7% after giving aura", DamageSource.NoPets, 7.0, DamageType.StrikeAndCondition, DamageType.All, Source.Tempest, ByPresence, TraitImages.TempestuousAria, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/WeaverHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Elementalist/WeaverHelper.cs
@@ -241,9 +241,9 @@ internal static class WeaverHelper
         new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "10% cDam (8s) after switching element",  DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.All)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.September2023Balance),
         new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "5% cDam (8s) after switching element",  DamageSource.NoPets, 5.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.September2023Balance),
+            .WithBuilds(GW2Builds.September2023Balance, GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_WeaversProwess, WeaversProwess, "Weaver's Prowess", "10% cDam (8s) after switching element",  DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.WeaversProwess, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.September2023Balance),
+            .WithBuilds(GW2Builds.September2023Balance, GW2Builds.April2026Balancepocalypse),
         // Elements of Rage
         new BuffOnActorDamageModifier(Mod_ElementsOfRage, ElementsOfRage, "Elements of Rage", "10% (8s) after double attuning", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.All)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.May2021Balance),
@@ -252,7 +252,11 @@ internal static class WeaverHelper
         new BuffOnActorDamageModifier(Mod_ElementsOfRage, ElementsOfRage, "Elements of Rage", "10% (8s) after double attuning", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.November2022Balance, GW2Builds.September2023Balance),
         new BuffOnActorDamageModifier(Mod_ElementsOfRage, ElementsOfRage, "Elements of Rage", "7% (8s) after double attuning", DamageSource.NoPets, 7.0, DamageType.StrikeAndCondition, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.September2023Balance),
+            .WithBuilds(GW2Builds.September2023Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_ElementsOfRageStrike, ElementsOfRage, "Elements of Rage", "7% (8s) after double attuning", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_ElementsOfRageCondition, ElementsOfRage, "Elements of Rage", "5% (8s) after double attuning", DamageSource.NoPets, 5.0, DamageType.Condition, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_ElementsOfRage, ElementsOfRage, "Elements of Rage", "5% (8s) after double attuning", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Weaver, ByPresence, TraitImages.ElementsOfRage, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.November2022Balance),
         // Woven Fire
@@ -274,7 +278,11 @@ internal static class WeaverHelper
         new BuffOnActorDamageModifier(Mod_SwiftRevenge, [Swiftness, Superspeed], "Swift Revenge", "10% under swiftness/superspeed", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, TraitImages.SwiftRevenge, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.November2022Balance, GW2Builds.SOTOReleaseAndBalance),
         new BuffOnActorDamageModifier(Mod_SwiftRevenge, [Swiftness, Superspeed], "Swift Revenge", "10% under swiftness/superspeed", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, TraitImages.SwiftRevenge, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.SOTOReleaseAndBalance)
+            .WithBuilds(GW2Builds.SOTOReleaseAndBalance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_SwiftRevenge, [Swiftness, Superspeed], "Swift Revenge", "7% under swiftness/superspeed", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, TraitImages.SwiftRevenge, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_SwiftRevenge, [Swiftness, Superspeed], "Swift Revenge", "10% under swiftness/superspeed", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Weaver, ByPresence, TraitImages.SwiftRevenge, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/AmalgamHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/AmalgamHelper.cs
@@ -25,7 +25,7 @@ internal static class AmalgamHelper
         new BuffOnActorDamageModifier(Mod_WillingHost_StrikeCondition, WillingHost, "Willing Host", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Amalgam, ByPresence, TraitImages.WillingHost, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.OctoberVoERelease),
         new BuffOnActorDamageModifier(Mod_WillingHost_Condition, WillingHost, "Willing Host (Condition)", "7%", DamageSource.NoPets, 7.0, DamageType.Condition, DamageType.All, Source.Amalgam, ByPresence, TraitImages.WillingHost, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.OctoberVoERelease),
+            .WithBuilds(GW2Builds.OctoberVoERelease, GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_WillingHost_Strike, WillingHost, "Willing Host (Strike)", "15%", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Amalgam, ByPresence, TraitImages.WillingHost, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.OctoberVoERelease, GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_WillingHost_Strike, WillingHost, "Willing Host (Strike)", "5%", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Amalgam, ByPresence, TraitImages.WillingHost, DamageModifierMode.PvE)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/AmalgamHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/AmalgamHelper.cs
@@ -30,6 +30,8 @@ internal static class AmalgamHelper
             .WithBuilds(GW2Builds.OctoberVoERelease, GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_WillingHost_Strike, WillingHost, "Willing Host (Strike)", "5%", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Amalgam, ByPresence, TraitImages.WillingHost, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.December2025Balance),
+        new BuffOnActorDamageModifier(Mod_WillingHost_Condition, WillingHost, "Willing Host (Condition)", "5%", DamageSource.NoPets, 5.0, DamageType.Condition, DamageType.All, Source.Amalgam, ByPresence, TraitImages.WillingHost, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_WillingHost_StrikeCondition, WillingHost, "Willing Host", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Amalgam, ByPresence, TraitImages.WillingHost, DamageModifierMode.sPvPWvW),
         // Plasmatic State
         new BuffOnActorDamageModifier(Mod_PlasmaticState, PlasmaticStateBuff, "Plasmatic State", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Amalgam, ByPresence, SkillImages.PlasmaticState, DamageModifierMode.All)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Engineer/EngineerHelper.cs
@@ -195,10 +195,16 @@ internal static class EngineerHelper
             .WithBuilds(GW2Builds.May2021Balance, GW2Builds.January2026Balance),
         new DamageLogDamageModifier(Mod_GlassCannon, "Glass Cannon", "10% if hp >=75%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Engineer, TraitImages.GlassCannon, FromHPChecker(75), DamageModifierMode.PvEsPvP)
             .UsingApproximate()
-            .WithBuilds(GW2Builds.January2026Balance),
+            .WithBuilds(GW2Builds.January2026Balance, GW2Builds.April2026Balancepocalypse),
         new DamageLogDamageModifier(Mod_GlassCannon, "Glass Cannon", "5% if hp >=75%", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Engineer, TraitImages.GlassCannon, FromHPChecker(75), DamageModifierMode.WvW)
             .UsingApproximate()
             .WithBuilds(GW2Builds.January2026Balance),
+        new DamageLogDamageModifier(Mod_GlassCannon, "Glass Cannon", "10% if hp >=75%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Engineer, TraitImages.GlassCannon, FromHPChecker(75), DamageModifierMode.sPvP)
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new DamageLogDamageModifier(Mod_GlassCannon, "Glass Cannon", "7% if hp >=75%", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Engineer, TraitImages.GlassCannon, FromHPChecker(75), DamageModifierMode.PvE)
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Shaped Charge
         new BuffOnFoeDamageModifier(Mod_ShapedCharge, Vulnerability, "Shaped Charge", "10% on vulnerable enemies", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Engineer, ByPresence, TraitImages.ExplosivePowder, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2019Balance),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/GuardianHelper.cs
@@ -157,17 +157,30 @@ internal static class GuardianHelper
         new BuffOnActorDamageModifier(Mod_UnscathedContenderAegis, Aegis, "Unscathed Contender", "20% under aegis", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Guardian, ByPresence, TraitImages.UnscathedContender, DamageModifierMode.All)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2023Balance),
         new BuffOnActorDamageModifier(Mod_UnscathedContenderAegis, Aegis, "Unscathed Contender (Aegis)", "7% under aegis", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Guardian, ByPresence, TraitImages.UnscathedContender, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.February2023Balance),
+            .WithBuilds(GW2Builds.February2023Balance, GW2Builds.April2026Balancepocalypse),
         new DamageLogDamageModifier(Mod_UnscathedContenderHP, "Unscathed Contender (HP)", "7% if hp >=90%", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Guardian, TraitImages.UnscathedContender, (x, log) => x.IsOverNinety, DamageModifierMode.All)
-            .WithBuilds( GW2Builds.February2023Balance),
+            .WithBuilds( GW2Builds.February2023Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_UnscathedContenderAegis, Aegis, "Unscathed Contender (Aegis)", "7% under aegis", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Guardian, ByPresence, TraitImages.UnscathedContender, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new DamageLogDamageModifier(Mod_UnscathedContenderHP, "Unscathed Contender (HP)", "7% if hp >=90%", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Guardian, TraitImages.UnscathedContender, (x, log) => x.IsOverNinety, DamageModifierMode.sPvPWvW)
+            .WithBuilds( GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_UnscathedContenderAegis, Aegis, "Unscathed Contender (Aegis)", "5% under aegis", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Guardian, ByPresence, TraitImages.UnscathedContender, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new DamageLogDamageModifier(Mod_UnscathedContenderHP, "Unscathed Contender (HP)", "5% if hp >=90%", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Guardian, TraitImages.UnscathedContender, (x, log) => x.IsOverNinety, DamageModifierMode.PvE)
+            .WithBuilds( GW2Builds.April2026Balancepocalypse),
         // - Power of the Virtuous
         new BuffOnActorDamageModifier(Mod_PowerOfTheVirtuous, NumberOfBoons, "Power of the Virtuous", "1% per boon", DamageSource.NoPets, 1.0, DamageType.Strike, DamageType.All, Source.Guardian, ByStack, TraitImages.PowerOfTheVirtuous,  DamageModifierMode.All)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.May2021Balance),
         // - Inspiring Virtue
-        new BuffOnActorDamageModifier(Mod_InspiredVirtue, NumberOfBoons, "Inspired Virtue", "1% per boon", DamageSource.NoPets, 1.0, DamageType.Strike, DamageType.All, Source.Guardian, ByStack, TraitImages.InspiredVirtue, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.May2021Balance),
         new BuffOnActorDamageModifier(Mod_InspiringVirtue, InspiringVirtue, "Inspiring Virtue", "10% (6s) after activating a virtue ", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Guardian, ByPresence, TraitImages.VirtuousSolace, DamageModifierMode.All)
             .WithBuilds(GW2Builds.February2020Balance),
+        // - Inspired Virtue
+        new BuffOnActorDamageModifier(Mod_InspiredVirtue, NumberOfBoons, "Inspired Virtue", "1% per boon", DamageSource.NoPets, 1.0, DamageType.Strike, DamageType.All, Source.Guardian, ByStack, TraitImages.InspiredVirtue, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.May2021Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_InspiredVirtue, NumberOfBoons, "Inspired Virtue", "0.5% per boon", DamageSource.NoPets, 0.5, DamageType.Strike, DamageType.All, Source.Guardian, ByStack, TraitImages.InspiredVirtue, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_InspiredVirtue, NumberOfBoons, "Inspired Virtue", "1% per boon", DamageSource.NoPets, 1.0, DamageType.Strike, DamageType.All, Source.Guardian, ByStack, TraitImages.InspiredVirtue, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/WillbenderHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Guardian/WillbenderHelper.cs
@@ -76,7 +76,12 @@ internal static class WillbenderHelper
             .UsingEarlyExit((a, log) => LethalTempoEarlyExit(a, log, 4000))
             .UsingChecker((x, log) => LethalTempoChecker(x, log, 4000))
             .UsingApproximate()
-            .WithBuilds(GW2Builds.April2025Balance),
+            .WithBuilds(GW2Builds.April2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_TyrantsLethalTempoCondition, LethalTempo, "Tyrant's Lethal Tempo (Condition)", "3% per stack", DamageSource.NoPets, 3.0, DamageType.Condition, DamageType.All, Source.Willbender, ByStack, TraitImages.TyrantsMomentum, DamageModifierMode.PvE)
+            .UsingEarlyExit((a, log) => LethalTempoEarlyExit(a, log, 4000))
+            .UsingChecker((x, log) => LethalTempoChecker(x, log, 4000))
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Lethal Tempo Competitive modes
         new BuffOnActorDamageModifier(Mod_LethalTempo, LethalTempo, "Lethal Tempo", "2% per stack", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Willbender, ByStack, TraitImages.LethalTempo, DamageModifierMode.sPvPWvW)
             .UsingEarlyExit((a, log) => LethalTempoEarlyExit(a, log, 6000))

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
@@ -46,7 +46,17 @@ internal static class ChronomancerHelper
             .UsingChecker((x, log) => x.HasCrit)
             .UsingChecker(MesmerHelper.IllusionsWithMesmerChecker)
             .UsingActorFetchIsAlwaysMaster()
-            .WithBuilds(GW2Builds.January2026Balance),
+            .WithBuilds(GW2Builds.January2026Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_DangerTime, DangerTime, "Danger Time", "10%", DamageSource.All, 10.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.DangerTime, DamageModifierMode.sPvPWvW)
+            .UsingChecker((x, log) => x.HasCrit)
+            .UsingChecker(MesmerHelper.IllusionsWithMesmerChecker)
+            .UsingActorFetchIsAlwaysMaster()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_DangerTime, DangerTime, "Danger Time", "5%", DamageSource.All, 5.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.DangerTime, DamageModifierMode.PvE)
+            .UsingChecker((x, log) => x.HasCrit)
+            .UsingChecker(MesmerHelper.IllusionsWithMesmerChecker)
+            .UsingActorFetchIsAlwaysMaster()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Time Bomb
         new BuffOnFoeDamageModifier(Mod_TimeBomb, TimeBombBuff, "Time Bomb", "15%", DamageSource.All, 15.0, DamageType.Strike, DamageType.All, Source.Chronomancer, ByPresence, TraitImages.TimeBomb, DamageModifierMode.All)
             .WithBuffOnFoeFromActor()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/ChronomancerHelper.cs
@@ -79,6 +79,8 @@ internal static class ChronomancerHelper
         new Buff("Danger Time", DangerTime, Source.Chronomancer, BuffClassification.Other, TraitImages.DangerTime),
         new Buff("Time Bomb", TimeBombBuff, Source.Chronomancer, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, TraitImages.TimeBomb),
         new Buff("Temporal Stasis", TemporalStasis, Source.Chronomancer, BuffClassification.Other, BuffImages.Stun),
+        new Buff("Chronophantasma", ChronophantasmaBuff, Source.Chronomancer, BuffClassification.Other, TraitImages.Chronophantasma),
+        new Buff("Chronophantasma Resummon", ChronophantasmaResummonBuff, Source.Chronomancer, BuffStackType.StackingConditionalLoss, 25, BuffClassification.Other, TraitImages.Chronophantasma),
     ];
 
     private static readonly HashSet<int> NonCloneMinions = [];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -189,11 +189,21 @@ internal static class MesmerHelper
         
         // Illusions
         // - Compounding Power
-        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.November2023Balance),
-        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
+        new BuffOnActorDamageModifier(Mod_CompoundingPowerStrike, CompoundingPower, "Compounding Power", "3% per stack after creating an illusion", DamageSource.NoPets, 3.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.February2018Balance, GW2Builds.March2018Balance),
+        new BuffOnActorDamageModifier(Mod_CompoundingPowerStrike, CompoundingPower, "Compounding Power", "3% per stack after creating an illusion", DamageSource.NoPets, 3.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.March2018Balance, GW2Builds.May2018Balance),
+        new BuffOnActorDamageModifier(Mod_CompoundingPowerStrike, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.March2018Balance, GW2Builds.May2018Balance),
+        new BuffOnActorDamageModifier(Mod_CompoundingPowerStrike, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.May2018Balance, GW2Builds.November2023Balance),
+        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.All)
             .WithBuilds(GW2Builds.November2023Balance, GW2Builds.April2026Balancepocalypse),
-        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 1.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
+        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_CompoundingPowerStrike, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_CompoundingPowerCondition, CompoundingPower, "Compounding Power", "1% per stack after creating an illusion", DamageSource.NoPets, 1.0, DamageType.Condition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Phantasmal Force
         new BuffOnActorDamageModifier(Mod_PhantasmalForce, PhantasmalForce, "Phantasmal Force", "1% per stack of might when creating an illusion", DamageSource.PetsOnly, 1.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.PhantasmalForce_Mistrust, DamageModifierMode.PvE)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MesmerHelper.cs
@@ -170,7 +170,10 @@ internal static class MesmerHelper
         new BuffOnActorDamageModifier(Mod_PowerBlock, PowerBlockBuff, "Power Block", "25%", DamageSource.NoPets, 25.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.PowerBlock, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.June2025Balance),
         new BuffOnActorDamageModifier(Mod_PowerBlock, PowerBlockBuff, "Power Block", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.PowerBlock, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.June2025Balance),
+            .WithBuilds(GW2Builds.June2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_PowerBlock, PowerBlockBuff, "Power Block", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByPresence, TraitImages.PowerBlock, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+
         // Dueling
         // - Superiority Complex
         new DamageLogDamageModifier(Mod_SuperiorityComplex, "Superiority Complex", "15% on crit", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Mesmer, TraitImages.SuperiorityComplex, (x, log) => x.HasCrit && !SuperiorityComplexBonusChecker(x, log), DamageModifierMode.PvEInstanceOnly)
@@ -189,7 +192,9 @@ internal static class MesmerHelper
         new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.November2023Balance),
         new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.November2023Balance),
+            .WithBuilds(GW2Builds.November2023Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_CompoundingPower, CompoundingPower, "Compounding Power", "2% per stack after creating an illusion", DamageSource.NoPets, 1.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mesmer, ByStack, TraitImages.CompoundingPower, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Phantasmal Force
         new BuffOnActorDamageModifier(Mod_PhantasmalForce, PhantasmalForce, "Phantasmal Force", "1% per stack of might when creating an illusion", DamageSource.PetsOnly, 1.0, DamageType.Strike, DamageType.All, Source.Mesmer, ByStack, TraitImages.PhantasmalForce_Mistrust, DamageModifierMode.PvE)
             .UsingEarlyExit((a, log) => !a.GetMinions(log).Any(x => IsPhantasm(x.ReferenceAgentItem)))

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/MirageHelper.cs
@@ -42,7 +42,11 @@ internal static class MirageHelper
             .WithBuilds(GW2Builds.July2025BalanceHotFix),
         // Nomad's Endurance
         new BuffOnActorDamageModifier(Mod_NomadsEndurance, Vigor, "Nomad's Endurance", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Mirage, ByPresence, TraitImages.NomadsEndurance, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.February2025Balance),
+            .WithBuilds(GW2Builds.February2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_NomadsEndurance, Vigor, "Nomad's Endurance", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mirage, ByPresence, TraitImages.NomadsEndurance, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_NomadsEndurance, Vigor, "Nomad's Endurance", "5%", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Mirage, ByPresence, TraitImages.NomadsEndurance, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers = [];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
@@ -43,10 +43,17 @@ internal static class VirtuosoHelper
         // Mental Focus
         new DamageLogDamageModifier(Mod_MentalFocus, "Mental Focus", "10% to foes within 600 range", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Virtuoso, TraitImages.MentalFocus, (x, log) => TargetWithinRangeChecker(x, log, 600), DamageModifierMode.PvE)
             .UsingApproximate()
-            .WithBuilds(GW2Builds.EODBeta4),
+            .WithBuilds(GW2Builds.EODBeta4, GW2Builds.April2026Balancepocalypse),
+        new DamageLogDamageModifier(Mod_MentalFocus, "Mental Focus", "5% to foes within 600 range", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Virtuoso, TraitImages.MentalFocus, (x, log) => TargetWithinRangeChecker(x, log, 600), DamageModifierMode.PvE)
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Deadly Blades
         new BuffOnActorDamageModifier(Mod_DeadlyBlades, DeadlyBlades, "Deadly Blades", "5%", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Virtuoso, ByPresence, TraitImages.DeadlyBlades, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.EODBeta4),
+            .WithBuilds(GW2Builds.EODBeta4, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_DeadlyBlades, DeadlyBlades, "Deadly Blades", "5%", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Virtuoso, ByPresence, TraitImages.DeadlyBlades, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_DeadlyBlades, DeadlyBlades, "Deadly Blades", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Virtuoso, ByPresence, TraitImages.DeadlyBlades, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers = [];

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Mesmer/VirtuosoHelper.cs
@@ -43,7 +43,10 @@ internal static class VirtuosoHelper
         // Mental Focus
         new DamageLogDamageModifier(Mod_MentalFocus, "Mental Focus", "10% to foes within 600 range", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Virtuoso, TraitImages.MentalFocus, (x, log) => TargetWithinRangeChecker(x, log, 600), DamageModifierMode.PvE)
             .UsingApproximate()
-            .WithBuilds(GW2Builds.EODBeta4, GW2Builds.April2026Balancepocalypse),
+            .WithBuilds(GW2Builds.EODBeta1, GW2Builds.April2026Balancepocalypse),
+        new DamageLogDamageModifier(Mod_MentalFocus, "Mental Focus", "7% to foes within 600 range", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Virtuoso, TraitImages.MentalFocus, (x, log) => TargetWithinRangeChecker(x, log, 600), DamageModifierMode.sPvPWvW)
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.EODBeta1),
         new DamageLogDamageModifier(Mod_MentalFocus, "Mental Focus", "5% to foes within 600 range", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Virtuoso, TraitImages.MentalFocus, (x, log) => TargetWithinRangeChecker(x, log, 600), DamageModifierMode.PvE)
             .UsingApproximate()
             .WithBuilds(GW2Builds.April2026Balancepocalypse),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/HarbingerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/HarbingerHelper.cs
@@ -55,7 +55,10 @@ internal static class HarbingerHelper
             .WithBuilds(GW2Builds.March2024BalanceAndCerusLegendary),
         new BuffOnFoeDamageModifier(Mod_WickedCorruptionCrit, Torment, "Wicked Corruption (Crit)", "12.5% critical to foes with torment", DamageSource.NoPets, 12.5, DamageType.Strike, DamageType.All, Source.Harbinger, ByPresence, TraitImages.WickedCorruption, DamageModifierMode.PvE)
             .UsingChecker((evt, log) => evt.HasCrit)
-            .WithBuilds(GW2Builds.March2024BalanceAndCerusLegendary),
+            .WithBuilds(GW2Builds.March2024BalanceAndCerusLegendary, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_WickedCorruptionCrit, Torment, "Wicked Corruption (Crit)", "10% critical to foes with torment", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Harbinger, ByPresence, TraitImages.WickedCorruption, DamageModifierMode.PvE)
+            .UsingChecker((evt, log) => evt.HasCrit)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Septic Corruption
         new BuffOnActorDamageModifier(Mod_SepticCorruption, Blight, "Septic Corruption", "1% per blight stack", DamageSource.NoPets, 1.0, DamageType.Condition, DamageType.All, Source.Harbinger, ByStack, TraitImages.SepticCorruption, DamageModifierMode.All)
             .WithBuilds(GW2Builds.EODBeta1, GW2Builds.EODBeta4),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/NecromancerHelper.cs
@@ -63,7 +63,12 @@ internal static class NecromancerHelper
     [
         // Spite
         // - Spiteful Talisman
-        new BuffOnFoeDamageModifier(Mod_SpitefulTalisman, NumberOfBoons, "Spiteful Talisman", "10% on boonless target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByAbsence, TraitImages.SpitefulTalisman, DamageModifierMode.All),
+        new BuffOnFoeDamageModifier(Mod_SpitefulTalisman, NumberOfBoons, "Spiteful Talisman", "10% on boonless target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByAbsence, TraitImages.SpitefulTalisman, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_SpitefulTalisman, NumberOfBoons, "Spiteful Talisman", "10% on boonless target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByAbsence, TraitImages.SpitefulTalisman, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_SpitefulTalisman, NumberOfBoons, "Spiteful Talisman", "5% on boonless target", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByAbsence, TraitImages.SpitefulTalisman, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Death's Embrace
         new BuffOnActorDamageModifier(Mod_DeathsEmbrace, Downed, "Death's Embrace", "25% on while downed", DamageSource.NoPets, 25.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathsEmbrace, DamageModifierMode.All)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2020Balance),
@@ -96,7 +101,13 @@ internal static class NecromancerHelper
         // - Death Perception
         new BuffOnActorDamageModifier(Mod_DeathPerception, [DeathShroud, ReapersShroud, DesertShroudBuff, HarbingerShroud, RitualistsShroud], "Death Perception", "15% crit damage while in shroud", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathPerception, DamageModifierMode.All)
             .UsingChecker((x, log) => x.HasCrit)
-            .WithBuilds(GW2Builds.June2022Balance),
+            .WithBuilds(GW2Builds.June2022Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_DeathPerception, [DeathShroud, ReapersShroud, DesertShroudBuff, HarbingerShroud, RitualistsShroud], "Death Perception", "15% crit damage while in shroud", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathPerception, DamageModifierMode.sPvPWvW)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_DeathPerception, [DeathShroud, ReapersShroud, DesertShroudBuff, HarbingerShroud, RitualistsShroud], "Death Perception", "10% crit damage while in shroud", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Necromancer, ByPresence, TraitImages.DeathPerception, DamageModifierMode.PvE)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
 
         // Death Magic
         // - Necromantic Corruption

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/RitualistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/RitualistHelper.cs
@@ -56,13 +56,13 @@ internal static class RitualistHelper
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers = 
     [
         // Lingering Spirits
-        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "15%", DamageSource.NoPets, 15, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.PvE)
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "15%", DamageSource.NoPets, 15, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.Anguish, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
-        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "7%", DamageSource.NoPets, 7, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.PvE)
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "7%", DamageSource.NoPets, 7, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.Anguish, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.December2025Balance, GW2Builds.April2026Balancepocalypse),
-        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "5%", DamageSource.NoPets, 5, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.PvE)
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "5%", DamageSource.NoPets, 5, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.Anguish, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.April2026Balancepocalypse),
-        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.sPvPWvW),
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.Anguish, DamageModifierMode.sPvPWvW),
         // Explosive Growth
         new BuffOnActorDamageModifier(Mod_ExplosiveGrowth, ExplosiveGrowthBuff, "Explosive Growth", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.ExplosiveGrowth, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/RitualistHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Necromancer/RitualistHelper.cs
@@ -56,15 +56,17 @@ internal static class RitualistHelper
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers = 
     [
         // Lingering Spirits
-        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "15%", DamageSource.NoPets, 15, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.Anguish, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2025Balance),
-        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "7%", DamageSource.NoPets, 7, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.Anguish, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.December2025Balance),
-        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.Anguish, DamageModifierMode.sPvPWvW),
-        // Explosive Growth
-        new BuffOnActorDamageModifier(Mod_ExplosiveGrowth, ExplosiveGrowthBuff, "Explosive Growth", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.ResilientWeapon, DamageModifierMode.PvE)
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "15%", DamageSource.NoPets, 15, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
-        new BuffOnActorDamageModifier(Mod_ExplosiveGrowth, ExplosiveGrowthBuff, "Explosive Growth", "7%", DamageSource.NoPets, 7, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, SkillImages.ResilientWeapon, DamageModifierMode.sPvPWvW)
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "7%", DamageSource.NoPets, 7, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.December2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "5%", DamageSource.NoPets, 5, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_LingeringSpiritsAnguish, LingeringSpiritsAnguish, "Lingering Spirits (Anguish)", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.LingeringSpirits, DamageModifierMode.sPvPWvW),
+        // Explosive Growth
+        new BuffOnActorDamageModifier(Mod_ExplosiveGrowth, ExplosiveGrowthBuff, "Explosive Growth", "10%", DamageSource.NoPets, 10, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.ExplosiveGrowth, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
+        new BuffOnActorDamageModifier(Mod_ExplosiveGrowth, ExplosiveGrowthBuff, "Explosive Growth", "7%", DamageSource.NoPets, 7, DamageType.StrikeAndCondition, DamageType.All, Source.Ritualist, ByPresence, TraitImages.ExplosiveGrowth, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
     ];
 

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/DruidHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/DruidHelper.cs
@@ -47,7 +47,11 @@ internal static class DruidHelper
     [
         // Natural Balance
         new BuffOnActorDamageModifier(Mod_NaturalBalance, NaturalBalance, "Natural Balance", "10% after leaving or entering Celestial Avatar", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Druid, ByPresence, TraitImages.NaturalBalance, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
+            .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_NaturalBalance, NaturalBalance, "Natural Balance", "10% after leaving or entering Celestial Avatar", DamageSource.NoPets, 10.0, DamageType.Condition, DamageType.All, Source.Druid, ByPresence, TraitImages.NaturalBalance, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_NaturalBalance, NaturalBalance, "Natural Balance", "5% after leaving or entering Celestial Avatar", DamageSource.NoPets, 5.0, DamageType.Condition, DamageType.All, Source.Druid, ByPresence, TraitImages.NaturalBalance, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -371,7 +371,17 @@ internal static class RangerHelper
         // - Predator's Onslaught
         new BuffOnFoeDamageModifier(Mod_PredatorsOnslaught, [Stun, Taunt, Daze, Crippled, Fear, Immobile, Chilled], "Predator's Onslaught", "15% to disabled or movement-impaired foes", DamageSource.All, 15.0, DamageType.Strike, DamageType.All, Source.Ranger, ByPresence, TraitImages.PredatorsOnslaught, DamageModifierMode.All)
             .UsingChecker((x, log) => IsJuvenilePet(x.From) || x.From.GetBaseSpecAtTime(x.Time) == Spec.Ranger)
-            .UsingApproximate(),
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.January2016Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PredatorsOnslaught, [Stun, Taunt, Daze, Crippled, Fear, Immobile, Chilled], "Predator's Onslaught", "15% to disabled or movement-impaired foes", DamageSource.All, 15.0, DamageType.Strike, DamageType.All, Source.Ranger, ByPresence, TraitImages.PredatorsOnslaught, DamageModifierMode.sPvPWvW)
+            .UsingChecker((x, log) => IsJuvenilePet(x.From) || x.From.GetBaseSpecAtTime(x.Time) == Spec.Ranger)
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PredatorsOnslaught, [Stun, Taunt, Daze, Crippled, Fear, Immobile, Chilled], "Predator's Onslaught", "10% to disabled or movement-impaired foes", DamageSource.All, 10.0, DamageType.Strike, DamageType.All, Source.Ranger, ByPresence, TraitImages.PredatorsOnslaught, DamageModifierMode.PvE)
+            .UsingChecker((x, log) => IsJuvenilePet(x.From) || x.From.GetBaseSpecAtTime(x.Time) == Spec.Ranger)
+            .UsingApproximate()
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        // - Wolfsong
         new BuffOnFoeDamageModifier(Mod_Wolfsong, Vulnerability, "Wolfsong", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Ranger, ByPresence, TraitImages.Wolfsong, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.April2025Balance),
         new BuffOnFoeDamageModifier(Mod_Wolfsong, Vulnerability, "Wolfsong", "5%", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Ranger, ByPresence, TraitImages.Wolfsong, DamageModifierMode.sPvPWvW)
@@ -386,7 +396,9 @@ internal static class RangerHelper
         new DamageLogDamageModifier(Mod_HuntersTactics, "Hunter's Tactics", "15% while flanking", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Ranger, TraitImages.HuntersTactics, (x, log) => x.IsFlanking , DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.June2022Balance, GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
         new DamageLogDamageModifier(Mod_HuntersTactics, "Hunter's Tactics", "15% while flanking or against defiant", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Ranger, TraitImages.HuntersTactics, (x, log) => x.IsFlanking || x.To.GetCurrentBreakbarState(log, x.Time) != BreakbarState.None, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM),
+            .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM, GW2Builds.April2026Balancepocalypse),
+        new DamageLogDamageModifier(Mod_HuntersTactics, "Hunter's Tactics", "10% while flanking or against defiant", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Ranger, TraitImages.HuntersTactics, (x, log) => x.IsFlanking || x.To.GetCurrentBreakbarState(log, x.Time) != BreakbarState.None, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Light on your Feet
         new BuffOnActorDamageModifier(Mod_LightOnYourFeet, LightOnYourFeet, "Light on your Feet", "10% (4s) after dodging", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Ranger, ByPresence, TraitImages.LightOnYourFeet, DamageModifierMode.All),
 
@@ -414,7 +426,12 @@ internal static class RangerHelper
             .UsingEarlyExit((a, log) => {
                 return !a.GetMinions(log).Any(x => IsJuvenileUrsinePet(x.ReferenceAgentItem) || IsJuvenilePorcinePet(x.ReferenceAgentItem));
             })
-            .WithBuilds(GW2Builds.April2025Balance),
+            .WithBuilds(GW2Builds.April2025Balance, GW2Builds.April2026Balancepocalypse),
+         new DamageLogDamageModifier(Mod_BeastlyWarden_Pet, "Beastly Warden (Pets)", "67% for Ursine and Porcine pets", DamageSource.PetsOnly, 67.0, DamageType.All, DamageType.All, Source.Ranger, TraitImages.BeastlyWarden, (x, log) => IsJuvenileUrsinePet(x.From) || IsJuvenilePorcinePet(x.From), DamageModifierMode.PvE)
+            .UsingEarlyExit((a, log) => {
+                return !a.GetMinions(log).Any(x => IsJuvenileUrsinePet(x.ReferenceAgentItem) || IsJuvenilePorcinePet(x.ReferenceAgentItem));
+            })
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Loud Whistle
         new DamageLogDamageModifier(Mod_LoudWhistle_Pet, "Loud Whistle", "10% while master hp >=90%", DamageSource.PetsOnly, 10.0, DamageType.Strike, DamageType.All, Source.Soulbeast, TraitImages.LoudWhistle, (x, log) =>  IsJuvenilePet(x.From) && x.From.GetFinalMaster().GetCurrentHealthPercent(log, x.Time) >= 90.0, DamageModifierMode.All)
             .UsingEarlyExit((a, log) => {

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/SoulbeastHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/SoulbeastHelper.cs
@@ -56,7 +56,9 @@ internal static class SoulbeastHelper
         new BuffOnActorDamageModifier(Mod_TwiceAsVicious, TwiceAsVicious, "Twice as Vicious", "5% (10s) after disabling foe", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Soulbeast, ByPresence, TraitImages.TwiceAsVicious, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.July2019Balance, GW2Builds.February2020Balance),
         new BuffOnActorDamageModifier(Mod_TwiceAsVicious, TwiceAsVicious, "Twice as Vicious", "10% (10s) after disabling foe", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Soulbeast, ByPresence, TraitImages.TwiceAsVicious, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.February2020Balance),
+            .WithBuilds(GW2Builds.February2020Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_TwiceAsVicious, TwiceAsVicious, "Twice as Vicious", "7% (10s) after disabling foe", DamageSource.NoPets, 7.0, DamageType.StrikeAndCondition, DamageType.All, Source.Soulbeast, ByPresence, TraitImages.TwiceAsVicious, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_TwiceAsVicious, TwiceAsVicious, "Twice as Vicious", "5% (10s) after disabling foe", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Soulbeast, ByPresence, TraitImages.TwiceAsVicious, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.February2020Balance),
         // Furious Strength

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/UntamedHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/UntamedHelper.cs
@@ -65,7 +65,9 @@ internal static class UntamedHelper
         new BuffOnActorDamageModifier(Mod_VowOfTheUntamed, [Unleashed, VowOfTheUntamedBiorythm], "Vow of the Untamed", "10% when unleashed or biorythm proc", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Untamed, ByPresence, TraitImages.VowOfTheUntamed, DamageModifierMode.sPvP)
             .WithBuilds(GW2Builds.June2025Balance),
         new BuffOnActorDamageModifier(Mod_VowOfTheUntamed, [Unleashed, VowOfTheUntamedBiorythm], "Vow of the Untamed", "20% when unleashed or biorythm proc", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Untamed, ByPresence, TraitImages.VowOfTheUntamed, DamageModifierMode.WvW)
-            .WithBuilds(GW2Builds.June2025Balance),
+            .WithBuilds(GW2Builds.June2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_VowOfTheUntamed, [Unleashed, VowOfTheUntamedBiorythm], "Vow of the Untamed", "15% when unleashed or biorythm proc", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Untamed, ByPresence, TraitImages.VowOfTheUntamed, DamageModifierMode.WvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Revenant/RevenantHelper.cs
@@ -135,11 +135,15 @@ internal static class RevenantHelper
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2018Balance),
         // - Swift Termination
         new DamageLogDamageModifier(Mod_SwiftTermination, "Swift Termination", "20% if target <50%", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Revenant, TraitImages.SwiftTermination, (x, log) => x.AgainstUnderFifty, DamageModifierMode.All),
-        // Brutality
+        // - Brutality
         new BuffOnFoeDamageModifier(Mod_Brutality, [Stability, Protection], "Brutality", "15% against protection and stability", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Revenant, ByPresence, TraitImages.Brutality, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.June2025Balance),
+            .WithBuilds(GW2Builds.June2025Balance, GW2Builds.April2026Balancepocalypse),
         new BuffOnFoeDamageModifier(Mod_Brutality, [Stability, Protection], "Brutality", "10% against protection and stability", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Revenant, ByPresence, TraitImages.Brutality, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.June2025Balance),
+            .WithBuilds(GW2Builds.June2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_Brutality, [Stability, Protection], "Brutality", "15% against protection and stability", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Revenant, ByPresence, TraitImages.Brutality, DamageModifierMode.PvEWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_Brutality, [Stability, Protection], "Brutality", "10% against protection and stability", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Revenant, ByPresence, TraitImages.Brutality, DamageModifierMode.sPvP)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Thief/AntiquaryHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Thief/AntiquaryHelper.cs
@@ -33,15 +33,23 @@ internal static class AntiquaryHelper
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers = 
     [
         // Exhilarating Ephemera
-        new BuffOnActorDamageModifier(Mod_ExhilaratingEphemera, ExhilaratingEphemera, "Exhilarating Ephemera", "15%", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Antiquary, ByPresence, TraitImages.ExhilaratingEphemera, DamageModifierMode.PvE),
-        new BuffOnActorDamageModifier(Mod_ExhilaratingEphemera, ExhilaratingEphemera, "Exhilarating Ephemera", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Antiquary, ByPresence, TraitImages.ExhilaratingEphemera, DamageModifierMode.sPvPWvW),
+        new BuffOnActorDamageModifier(Mod_ExhilaratingEphemera, ExhilaratingEphemera, "Exhilarating Ephemera", "15%", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Antiquary, ByPresence, TraitImages.ExhilaratingEphemera, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_ExhilaratingEphemera, ExhilaratingEphemera, "Exhilarating Ephemera", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Antiquary, ByPresence, TraitImages.ExhilaratingEphemera, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_ExhilaratingEphemera, ExhilaratingEphemera, "Exhilarating Ephemera", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Antiquary, ByPresence, TraitImages.ExhilaratingEphemera, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Combat High
         new BuffOnActorDamageModifier(Mod_CombatHigh, CombatHigh, "Combat High", "3%", DamageSource.NoPets, 3.0, DamageType.StrikeAndCondition, DamageType.All, Source.Antiquary, ByStack, TraitImages.CombatHigh, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_CombatHigh, CombatHigh, "Combat High", "2%", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Antiquary, ByStack, TraitImages.CombatHigh, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_CombatHigh, CombatHigh, "Combat High", "2%", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Antiquary, ByStack, TraitImages.CombatHigh, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.December2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_CombatHigh, CombatHigh, "Combat High", "3%", DamageSource.NoPets, 3.0, DamageType.StrikeAndCondition, DamageType.All, Source.Antiquary, ByStack, TraitImages.CombatHigh, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_CombatHigh, CombatHigh, "Combat High", "2%", DamageSource.NoPets, 2.0, DamageType.StrikeAndCondition, DamageType.All, Source.Antiquary, ByStack, TraitImages.CombatHigh, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Summon Kriptis Turret
         new BuffOnFoeDamageModifier(Mod_SummonKryptisTurret, SummonKryptisTurretTargetBuff, "Kryptis Turret", "15%", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Antiquary, ByPresence, SkillImages.SummonKryptisTurret, DamageModifierMode.All)
             .UsingActorCheckerByPresence(SummonKryptisTurretPlayerBuff)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/BerserkerHelper.cs
@@ -43,12 +43,13 @@ internal static class BerserkerHelper
         new BuffOnActorDamageModifier(Mod_BloodyRoar, BerserkBuff, "Bloody Roar", "20% while in berserk", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Berserker, ByPresence, TraitImages.BloodyRoar, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.June2023BalanceAndSOTOBetaAndSilentSurfNM, GW2Builds.January2024Balance),
         new BuffOnActorDamageModifier(Mod_BloodyRoar, BerserkBuff, "Bloody Roar", "15% while in berserk", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Berserker, ByPresence, TraitImages.BloodyRoar, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.January2024Balance),
+            .WithBuilds(GW2Builds.January2024Balance, GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_BloodyRoar, BerserkBuff, "Bloody Roar", "15% while in berserk", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Berserker, ByPresence, TraitImages.BloodyRoar, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.July2019Balance, GW2Builds.October2022Balance),
         new BuffOnActorDamageModifier(Mod_BloodyRoar, BerserkBuff, "Bloody Roar", "10% while in berserk", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Berserker, ByPresence, TraitImages.BloodyRoar, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.October2022Balance),
-
+            .WithBuilds(GW2Builds.October2022Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_BloodyRoar, BerserkBuff, "Bloody Roar", "10% while in berserk", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Berserker, ByPresence, TraitImages.BloodyRoar, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
     ];
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> IncomingDamageModifiers =

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/ParagonHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/ParagonHelper.cs
@@ -17,39 +17,48 @@ internal static class ParagonHelper
 
     internal static readonly IReadOnlyList<DamageModifierDescriptor> OutgoingDamageModifiers = 
     [
-        // Chant of Action Beta
+        // Strengthening Stanzas - Chant of Action Beta
         new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas: Chant of Action", "20%", DamageSource.NoPets, 20.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.OctoberVoERelease),
         new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas: Chant of Action", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.OctoberVoERelease),
-        // Chant of Action
+        // Strengthening Stanzas - Chant of Action
         new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas: Chant of Action", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.OctoberVoERelease),
-        new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas:Chant of Action", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.OctoberVoERelease, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas: Chant of Action", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.OctoberVoERelease, GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
-        new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas:Chant of Action", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.WvW)
+        new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas: Chant of Action", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.WvW)
+            .WithBuilds(GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas: Chant of Action", "7%", DamageSource.NoPets, 7.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.sPvP)
             .WithBuilds(GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
-        new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas:Chant of Action", "7%", DamageSource.NoPets, 7.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.sPvP)
-            .WithBuilds(GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
+        new BuffOnActorDamageModifier(Mod_ChantOfAction_StrengtheningStanzas, ChantOfActionBuff, "Strengthening Stanzas: Chant of Action", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, SkillImages.ChantOfAction, DamageModifierMode.PvEWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Brisk Pacing 1
         new BuffOnActorDamageModifier(Mod_BriskPacingTier1, BriskPacingTier1, "Brisk Pacing", "7.5%", DamageSource.NoPets, 7.5, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_BriskPacingTier1, BriskPacingTier1, "Brisk Pacing", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.December2025Balance),
-        new BuffOnActorDamageModifier(Mod_BriskPacingTier1, BriskPacingTier1, "Brisk Pacing", "5.0%", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.sPvPWvW),
+            .WithBuilds(GW2Builds.December2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_BriskPacingTier1, BriskPacingTier1, "Brisk Pacing", "5.0%", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_BriskPacingTier1, BriskPacingTier1, "Brisk Pacing", "5.0%", DamageSource.NoPets, 5.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Brisk Pacing 2
         new BuffOnActorDamageModifier(Mod_BriskPacingTier2, BriskPacingTier2, "Brisk Pacing", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_BriskPacingTier2, BriskPacingTier2, "Brisk Pacing", "20%", DamageSource.NoPets, 20.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.December2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_BriskPacingTier2, BriskPacingTier2, "Brisk Pacing", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_BriskPacingTier2, BriskPacingTier2, "Brisk Pacing", "10%", DamageSource.NoPets, 10.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.sPvPWvW),
         // Brisk Pacing 3
         new BuffOnActorDamageModifier(Mod_BriskPacingTier3, BriskPacingTier3, "Brisk Pacing", "25%", DamageSource.NoPets, 25.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.December2025Balance),
         new BuffOnActorDamageModifier(Mod_BriskPacingTier3, BriskPacingTier3, "Brisk Pacing", "30%", DamageSource.NoPets, 30.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.December2025Balance),
+            .WithBuilds(GW2Builds.December2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_BriskPacingTier3, BriskPacingTier3, "Brisk Pacing", "25%", DamageSource.NoPets, 25.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         new BuffOnActorDamageModifier(Mod_BriskPacingTier3, BriskPacingTier3, "Brisk Pacing", "20%", DamageSource.NoPets, 20.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.StartOfLife, GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
+            .WithBuilds(GW2Builds.August2025VoEBeta, GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
         new BuffOnActorDamageModifier(Mod_BriskPacingTier3, BriskPacingTier3, "Brisk Pacing", "20%", DamageSource.NoPets, 20.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.WvW)
             .WithBuilds(GW2Builds.February2026GuardiansGladeReleaseAndPvPBalance),
         new BuffOnActorDamageModifier(Mod_BriskPacingTier3, BriskPacingTier3, "Brisk Pacing", "15%", DamageSource.NoPets, 15.0, DamageType.StrikeAndCondition, DamageType.All, Source.Paragon, ByPresence, TraitImages.BriskPacing, DamageModifierMode.sPvP)

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/SpellbreakerHelper.cs
@@ -35,17 +35,23 @@ internal static class SpellbreakerHelper
             .WithBuilds(GW2Builds.August2022Balance),
         new BuffOnFoeDamageModifier(Mod_PureStrikeBoons, NumberOfBoons, "Pure Strike (boons)", "7.5% crit damage", DamageSource.NoPets, 7.5, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByPresence, TraitImages.PureStrike, DamageModifierMode.PvE)
             .UsingChecker((x, log) => x.HasCrit)
-            .WithBuilds(GW2Builds.August2022Balance),
+            .WithBuilds(GW2Builds.August2022Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PureStrikeBoons, NumberOfBoons, "Pure Strike (boons)", "5% crit damage", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByPresence, TraitImages.PureStrike, DamageModifierMode.PvE)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Pure Strike (No Boons)
         new BuffOnFoeDamageModifier(Mod_PureStrikeNoBoons, NumberOfBoons, "Pure Strike (no boons)", "14% crit damage", DamageSource.NoPets, 14.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByAbsence, TraitImages.PureStrike, DamageModifierMode.All)
-            .UsingChecker( (x, log) => x.HasCrit)
+            .UsingChecker((x, log) => x.HasCrit)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.August2022Balance),
         new BuffOnFoeDamageModifier(Mod_PureStrikeNoBoons, NumberOfBoons, "Pure Strike (no boons)", "14% crit damage", DamageSource.NoPets, 14.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByAbsence, TraitImages.PureStrike, DamageModifierMode.sPvPWvW)
-            .UsingChecker( (x, log) => x.HasCrit)
+            .UsingChecker((x, log) => x.HasCrit)
             .WithBuilds(GW2Builds.August2022Balance),
         new BuffOnFoeDamageModifier(Mod_PureStrikeNoBoons, NumberOfBoons, "Pure Strike (no boons)", "15% crit damage", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByAbsence, TraitImages.PureStrike, DamageModifierMode.PvE)
-            .UsingChecker( (x, log) => x.HasCrit)
-            .WithBuilds(GW2Builds.August2022Balance),
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.August2022Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_PureStrikeNoBoons, NumberOfBoons, "Pure Strike (no boons)", "10% crit damage", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByAbsence, TraitImages.PureStrike, DamageModifierMode.PvE)
+            .UsingChecker((x, log) => x.HasCrit)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // Magebane Tether
         new BuffOnFoeDamageModifier(Mod_MagebaneTether, MagebaneTetherBuff, "Magebane Tether", "10% to tethered target", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Spellbreaker, ByPresence, TraitImages.MagebaneTether, DamageModifierMode.PvEInstanceOnly)
             .WithBuffOnFoeFromActor()

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/WarriorHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Warrior/WarriorHelper.cs
@@ -73,16 +73,22 @@ internal static class WarriorHelper
         new BuffOnActorDamageModifier(Mod_BerserkersPower, BerserkersPower, "Berserker's Power", "7% per stack", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Warrior, ByStack, TraitImages.BerserkersPower, DamageModifierMode.All)
             .WithBuilds(GW2Builds.StartOfLife, GW2Builds.October2022Balance),
         new BuffOnActorDamageModifier(Mod_BerserkersPower, BerserkersPower, "Berserker's Power", "5.25% per stack", DamageSource.NoPets, 5.25, DamageType.Strike, DamageType.All, Source.Warrior, ByStack, TraitImages.BerserkersPower, DamageModifierMode.All)
-            .WithBuilds(GW2Builds.October2022Balance),
+            .WithBuilds(GW2Builds.October2022Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_BerserkersPower, BerserkersPower, "Berserker's Power", "5.25% per stack", DamageSource.NoPets, 5.25, DamageType.Strike, DamageType.All, Source.Warrior, ByStack, TraitImages.BerserkersPower, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_BerserkersPower, BerserkersPower, "Berserker's Power", "3.75% per stack", DamageSource.NoPets, 3.75, DamageType.Strike, DamageType.All, Source.Warrior, ByStack, TraitImages.BerserkersPower, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         
         // Defense
         // - Stalwart Strength
-        new BuffOnActorDamageModifier(Mod_StalwartStrength, Stability, "Stalwart Strength", "10%", DamageSource.NoPets, 10, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.BerserkersPower, DamageModifierMode.All)
+        new BuffOnActorDamageModifier(Mod_StalwartStrength, Stability, "Stalwart Strength", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.StalwartStrength, DamageModifierMode.All)
             .WithBuilds(GW2Builds.October2022Balance, GW2Builds.June2025Balance),
-        new BuffOnActorDamageModifier(Mod_StalwartStrength, Stability, "Stalwart Strength", "12.5%", DamageSource.NoPets, 12.5, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.BerserkersPower, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.June2025Balance),
-        new BuffOnActorDamageModifier(Mod_StalwartStrength, Stability, "Stalwart Strength", "10%", DamageSource.NoPets, 10, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.BerserkersPower, DamageModifierMode.sPvPWvW)
-            .WithBuilds(GW2Builds.June2025Balance),
+        new BuffOnActorDamageModifier(Mod_StalwartStrength, Stability, "Stalwart Strength", "12.5%", DamageSource.NoPets, 12.5, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.StalwartStrength, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.June2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_StalwartStrength, Stability, "Stalwart Strength", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.StalwartStrength, DamageModifierMode.sPvPWvW)
+            .WithBuilds(GW2Builds.June2025Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnActorDamageModifier(Mod_StalwartStrength, Stability, "Stalwart Strength", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.StalwartStrength, DamageModifierMode.All)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Merciless Hammer
         new DamageLogDamageModifier(Mod_MercilessHammerDefiant, "Merciless Hammer", "20% to hammer and mace skills when hitting defiant foe", DamageSource.NoPets, 20.0, DamageType.Strike, DamageType.All, Source.Warrior, TraitImages.MercilessHammer, MercilessHammerChecker, DamageModifierMode.PvEInstanceOnly)
             .WithBuilds(GW2Builds.November2022Balance, GW2Builds.June2025Balance)
@@ -109,7 +115,9 @@ internal static class WarriorHelper
         new BuffOnFoeDamageModifier(Mod_LegSpecialist, [Crippled, Immobile, Chilled], "Leg Specialist", "7% to movement-impaired foes", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.LegSpecialist, DamageModifierMode.sPvPWvW)
             .WithBuilds(GW2Builds.May2021Balance),
         new BuffOnFoeDamageModifier(Mod_LegSpecialist, [Crippled, Immobile, Chilled], "Leg Specialist", "10% to movement-impaired foes", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.LegSpecialist, DamageModifierMode.PvE)
-            .WithBuilds(GW2Builds.May2021Balance),
+            .WithBuilds(GW2Builds.May2021Balance, GW2Builds.April2026Balancepocalypse),
+        new BuffOnFoeDamageModifier(Mod_LegSpecialist, [Crippled, Immobile, Chilled], "Leg Specialist", "5% to movement-impaired foes", DamageSource.NoPets, 5.0, DamageType.Strike, DamageType.All, Source.Warrior, ByPresence, TraitImages.LegSpecialist, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.April2026Balancepocalypse),
         // - Empowered
         new BuffOnActorDamageModifier(Mod_Empowered, NumberOfBoons, "Empowered", "1% per boon", DamageSource.NoPets, 1.0, DamageType.Strike, DamageType.All, Source.Warrior, ByStack, TraitImages.Empowered, DamageModifierMode.All),
         // - Warrior's Cunning (Barrier)

--- a/GW2EIEvtcParser/ParserHelpers/GW2Builds.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GW2Builds.cs
@@ -37,6 +37,9 @@ public static class GW2Builds
     // https://wiki.guildwars2.com/wiki/Game_updates/2018-02-06
     public const ulong February2018Balance = 86181;
 
+    // https://wiki.guildwars2.com/wiki/Game_updates/2018-03-27
+    public const ulong March2018Balance = 87476;
+
     // https://wiki.guildwars2.com/wiki/Game_updates/2018-05-08
     public const ulong May2018Balance = 88541;
 

--- a/GW2EIEvtcParser/ParserHelpers/GW2Builds.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GW2Builds.cs
@@ -10,6 +10,9 @@ public static class GW2Builds
     // https://wiki.guildwars2.com/wiki/Game_updates/2015-10-23
     public const ulong HoTRelease = 54485;
 
+    // https://wiki.guildwars2.com/wiki/Game_updates/2016-01-26
+    public const ulong January2016Balance = 57306;
+
     // https://wiki.guildwars2.com/wiki/Game_updates/2016-11-21
     public const ulong November2016NightmareRelease = 69591;
 

--- a/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
@@ -423,4 +423,10 @@ public static class DamageModifierIDs
     public const int Mod_TargetedDestruction_NuminousGift = 410;
     public const int Mod_LoveSong = 411;
     public const int Mod_ShreddedArmor = 412;
+    public const int Mod_StoneHeart = 413;
+    public const int Mod_TranscendentTempestStrike = 414;
+    public const int Mod_TranscendentTempestCondition = 415;
+    public const int Mod_ElementsOfRageStrike = 416;
+    public const int Mod_ElementsOfRageCondition = 417;
+    public const int Mod_MindStab = 418;
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
@@ -429,4 +429,6 @@ public static class DamageModifierIDs
     public const int Mod_ElementsOfRageStrike = 416;
     public const int Mod_ElementsOfRageCondition = 417;
     public const int Mod_MindStab = 418;
+    public const int Mod_CompoundingPowerStrike = 419;
+    public const int Mod_CompoundingPowerCondition = 420;
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
@@ -428,8 +428,7 @@ public static class DamageModifierIDs
     public const int Mod_TranscendentTempestCondition = 415;
     public const int Mod_ElementsOfRageStrike = 416;
     public const int Mod_ElementsOfRageCondition = 417;
-    public const int Mod_MindStab = 418;
-    public const int Mod_DaringAdvance = 419;
-    public const int Mod_CompoundingPowerStrike = 420;
-    public const int Mod_CompoundingPowerCondition = 421;
+    public const int Mod_DaringAdvance = 418;
+    public const int Mod_CompoundingPowerStrike = 419;
+    public const int Mod_CompoundingPowerCondition = 420;
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -1630,6 +1630,7 @@ public static class SkillIDs
     public const long LifeFromDeath = 29901;
     public const long ShieldOfCourageActive = 29906;
     public const long WeakeningCharge = 29911;
+    public const long ChronophantasmaBuff = 29913; // Buff on the first phantasm summoned
     public const long InfusingTerrorSkill = 29958;
     public const long HealingPrism = 29997;
     public const long ImpairingDaggersHit3 = 30017;
@@ -1681,6 +1682,7 @@ public static class SkillIDs
     public const long SoulSpiralHeal = 30591;
     public const long Vault = 30597;
     public const long HuntersWard = 30628;
+    public const long ChronophantasmaResummonBuff = 30644; // Buff on the phantasm resummoned, damage modifier
     public const long FeelTheBurn = 30662;
     public const long Suffer = 30670;
     public const long LightOnYourFeet = 30673;
@@ -5582,6 +5584,7 @@ public static class SkillIDs
     public const long AchievementEligibilitySeeYouLaterAlligator = 79542;
     public const long DefenderMoralBoost = 79544;
     public const long AchievementEligibilitySurefooted = 79546;
+    public const long SuperSharpeningPolygon = 79575;
     #endregion
 
 }

--- a/GW2EIEvtcParser/ParserHelpers/Images/ItemImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/ItemImages.cs
@@ -631,6 +631,7 @@ internal static class ItemImages
     public const string LumpOfCrystallizedNougat = "https://render.guildwars2.com/file/C70B5CFE950BDE719E1AE50C2DBAA29303231C58/888372.png";
     public const string DecadeEnhancement = "https://render.guildwars2.com/file/9C0A257380D40A5D6C1D93CA73A317035E06C9C6/2724222.png";
     public const string SnowDiamondOrnament = "https://render.guildwars2.com/file/DE210AD99255070E7638763C4EF9E8D162E42FB9/3734078.png";
+    public const string SuperSharpeningPolygon = "https://render.guildwars2.com/file/4246FCE23672F905B771F993EE009CF019705DD3/3762453.png";
     #endregion Utility
     #region Writ
     public const string WritOfBasicStrength = "https://render.guildwars2.com/file/CAF306FED00FDB05BA5C4E55D5D17E4D07C1CB75/1201921.png";

--- a/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
@@ -137,6 +137,7 @@ internal static class TraitImages
     public const string Syncopate = "https://render.guildwars2.com/file/42C9802D696B9670A0155DDF0FD2480CD9FBC473/3679969.png";
     public const string SymphonicResonance = "https://render.guildwars2.com/file/AF276ECB07996BF5343A513FF2E52F3BE1CBAD0B/3679978.png";
     public const string LoveSong = "https://render.guildwars2.com/file/1CC50D6BDDE64580522F0D396D194C020AC50DCE/3679972.png";
+    public const string Chronophantasma = "https://render.guildwars2.com/file/120E2199010315D0C1FACA9BBFB5DF9E5E47027F/1012481.png";
     #endregion
     #region Necromancer
     public const string VampiricPresence = "https://render.guildwars2.com/file/22B370D754AC1D69A8FE66DCCB36BE940455E5EA/1012539.png";

--- a/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/TraitImages.cs
@@ -322,6 +322,7 @@ internal static class TraitImages
     public const string SignetMastery = "https://render.guildwars2.com/file/3D117C0158CD7A55BE740D6B072807A3121C90A1/1012775.png";
     public const string GunsAndGlory = "https://render.guildwars2.com/file/0B2291AEBD4B3755F0CD9A38987797763AD34790/2491554.png";
     public const string BriskPacing = "https://render.guildwars2.com/file/9D35A3CED107B068AD4D20A3782BF6262FE36610/3680030.png";
+    public const string StalwartStrength = "https://render.guildwars2.com/file/630279C914D8BF414C2358281F1A37EDF86B203B/1012794.png";
     #endregion
 }
 #pragma warning restore CA1823 // Unused field


### PR DESCRIPTION
To check:
Otherworldly Bond: This skill no longer increases outgoing strike damage.
Glaring Burst: Reduced the damage bonus when hammer is equipped from 50% to 25% in PvE only.
Blinding Outburst: Reduced the ambush damage increase from 15% to 10% in WvW only.

Other:
Tyran's Momentum - Verify pvp
Chronophantasma - To add