### PR TITLE
New relics, otter pet, edge case fixes

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/CommonBuffs.cs
@@ -226,6 +226,9 @@ internal static class CommonBuffs
         new Buff("Relic of Fog", RelicOfFogBuff, Source.Gear, BuffStackType.StackingConditionalLoss, 3, BuffClassification.Gear, ItemImages.RelicOfFog),
         new Buff("Relic of the Forest Dweller (Float)", RelicOfTheForestDwellerFloatBuff, Source.Gear, BuffClassification.Gear, ItemImages.RelicOfTheForestDweller),
         new Buff("Relic of Shackles (Application)", RelicOfShacklesApplicationBuff, Source.Gear, BuffClassification.Gear, ItemImages.RelicOfShackles),
+        new Buff("Relic of the Director", RelicOfTheDirector, Source.Gear, BuffClassification.Gear, ItemImages.RelicOfTheDirector),
+        new Buff("Kuda's Cruelty (Stacks)", KudasCrueltyStacksBuff, Source.Gear, BuffStackType.StackingConditionalLoss, 10, BuffClassification.Gear, ItemImages.RelicOfTheCruelOverseer),
+        new Buff("Kuda's Cruelty (Modifier)", KudasCrueltyModifierBuff, Source.Gear, BuffClassification.Gear, ItemImages.RelicOfTheCruelOverseer),
     ];
 
 }

--- a/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/GearDamageModifiers.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/GearDamageModifiers.cs
@@ -104,8 +104,11 @@ internal static class GearDamageModifiers
         new BuffOnActorDamageModifier(Mod_RelicOfSorrow, RelicOfSorrowBuff, "Relic of Sorrow", "-20%", DamageSource.Incoming, -20.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheSorrow, DamageModifierMode.All),
         new BuffOnActorDamageModifier(Mod_RelicOfTheFirstRevenant, Resistance, "Relic of the First Revenant", "-33% under resistance", DamageSource.Incoming, -33.0, DamageType.Condition, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheFirstRevenant, DamageModifierMode.All)
             .WithBuilds(GW2Builds.OctoberVoERelease),
-        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-15% (not stacking with similar damage mods)", DamageSource.Incoming, -15.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.PvE),
-        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-10% (not stacking with similar damage mods)", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.WvW),
-        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-7% (not stacking with similar damage mods)", DamageSource.Incoming, -7.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.sPvP),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-15% (not stacking with similar damage mods)", DamageSource.Incoming, -15.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.PvE)
+            .WithBuilds(GW2Builds.May2026NewRelicsAndOtter),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-10% (not stacking with similar damage mods)", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.WvW)
+            .WithBuilds(GW2Builds.May2026NewRelicsAndOtter),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-7% (not stacking with similar damage mods)", DamageSource.Incoming, -7.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.sPvP)
+            .WithBuilds(GW2Builds.May2026NewRelicsAndOtter),
     ];
 }

--- a/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/GearDamageModifiers.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/GearDamageModifiers.cs
@@ -69,6 +69,7 @@ internal static class GearDamageModifiers
             .WithBuilds(GW2Builds.March2025W8CMReleaseAndNewCoreRelics),
         new BuffOnActorDamageModifier(Mod_RelicOfFire, FireAura, "Relic of Fire", "7% under fire aura", DamageSource.NoPets, 7.0, DamageType.Strike, DamageType.Strike, Source.Gear, ByPresence, ItemImages.RelicOfFire, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.March2025W8CMReleaseAndNewCoreRelics),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDirector, RelicOfTheDirector, "Relic of the Director", "10%", DamageSource.NoPets, 10.0, DamageType.Strike, DamageType.Strike, Source.Gear, ByPresence, ItemImages.RelicOfTheDirector, DamageModifierMode.All),
         // Relic of Bloodstone
         new BuffOnActorDamageModifier(Mod_RelicOfBloodstone, BloodstoneFervor, "Bloodstone Fervor", "15%", DamageSource.NoPets, 15.0, DamageType.Strike, DamageType.Strike, Source.Gear, ByPresence, ItemImages.RelicOfBloodstone, DamageModifierMode.PvE)
             .WithBuilds(GW2Builds.June2025Balance, GW2Builds.July2025BalanceHotFix),
@@ -103,5 +104,9 @@ internal static class GearDamageModifiers
         new BuffOnActorDamageModifier(Mod_RelicOfSorrow, RelicOfSorrowBuff, "Relic of Sorrow", "-20%", DamageSource.Incoming, -20.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheSorrow, DamageModifierMode.All),
         new BuffOnActorDamageModifier(Mod_RelicOfTheFirstRevenant, Resistance, "Relic of the First Revenant", "-33% under resistance", DamageSource.Incoming, -33.0, DamageType.Condition, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheFirstRevenant, DamageModifierMode.All)
             .WithBuilds(GW2Builds.OctoberVoERelease),
+        // TODO Verify what damage modifiers collide with this relic. Description: "This does not stack with other sources of the same effect." https://wiki.guildwars2.com/wiki/Relic_of_the_Doyen
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-15%", DamageSource.Incoming, -15.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.PvE),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-10%", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.WvW),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-7%", DamageSource.Incoming, -7.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.sPvP),
     ];
 }

--- a/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/GearDamageModifiers.cs
+++ b/GW2EIEvtcParser/EIData/DamageModifiers/CommonDamageModifiers/GearDamageModifiers.cs
@@ -104,9 +104,8 @@ internal static class GearDamageModifiers
         new BuffOnActorDamageModifier(Mod_RelicOfSorrow, RelicOfSorrowBuff, "Relic of Sorrow", "-20%", DamageSource.Incoming, -20.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheSorrow, DamageModifierMode.All),
         new BuffOnActorDamageModifier(Mod_RelicOfTheFirstRevenant, Resistance, "Relic of the First Revenant", "-33% under resistance", DamageSource.Incoming, -33.0, DamageType.Condition, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheFirstRevenant, DamageModifierMode.All)
             .WithBuilds(GW2Builds.OctoberVoERelease),
-        // TODO Verify what damage modifiers collide with this relic. Description: "This does not stack with other sources of the same effect." https://wiki.guildwars2.com/wiki/Relic_of_the_Doyen
-        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-15%", DamageSource.Incoming, -15.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.PvE),
-        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-10%", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.WvW),
-        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-7%", DamageSource.Incoming, -7.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.sPvP),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-15% (not stacking with similar damage mods)", DamageSource.Incoming, -15.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.PvE),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-10% (not stacking with similar damage mods)", DamageSource.Incoming, -10.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.WvW),
+        new BuffOnActorDamageModifier(Mod_RelicOfTheDoyen, Resolution, "Relic of the Doyen", "-7% (not stacking with similar damage mods)", DamageSource.Incoming, -7.0, DamageType.Strike, DamageType.All, Source.Gear, ByPresence, ItemImages.RelicOfTheDoyen, DamageModifierMode.sPvP),
     ];
 }

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -229,6 +229,13 @@ internal static class ProfHelper
         new MissileCastFinder(RelicOfTheForestDwellerMissileDamage, RelicOfTheForestDwellerMissileDamage)
             .UsingICD(100)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+        new MissileCastFinder(RelicOfGaldraSkill, RelicOfGaldraSkill)
+            .UsingICD(100)
+            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+        new BuffGainCastFinder(KudasCrueltyModifierBuff, KudasCrueltyModifierBuff)
+            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
+        new BuffGainCastFinder(RelicOfTheDirector, RelicOfTheDirector)
+            .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         #endregion Relics
         #region Mounts
         new BuffGainCastFinder(BondOfLifeSkill, BondOfLifeBuff),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/ProfHelper.cs
@@ -232,7 +232,7 @@ internal static class ProfHelper
         new MissileCastFinder(RelicOfGaldraSkill, RelicOfGaldraSkill)
             .UsingICD(100)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
-        new BuffGainCastFinder(KudasCrueltyModifierBuff, KudasCrueltyModifierBuff)
+        new BuffGainCastFinder(RelicOfTheCruelOverseer, KudasCrueltyModifierBuff)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),
         new BuffGainCastFinder(RelicOfTheDirector, RelicOfTheDirector)
             .UsingOrigin(InstantCastFinder.InstantCastOrigin.Gear),

--- a/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
+++ b/GW2EIEvtcParser/EIData/ProfHelpers/Ranger/RangerHelper.cs
@@ -135,6 +135,7 @@ internal static class RangerHelper
         (int)MinionID.JuvenileSpinegazer,
         (int)MinionID.JuvenileJanthiriBee,
         (int)MinionID.JuvenileRaptorSwiftwing,
+        (int)MinionID.JuvenileRiverOtter,
     }
     .Union(JuvenileFelinePetIDs)
     .Union(JuvenileBirdPetIDs)
@@ -310,6 +311,7 @@ internal static class RangerHelper
             .UsingDstBaseSpecChecker(Spec.Ranger),
         new MinionSpawnCastFinder(RangerPetSpawned, JuvenilePetIDs)
             .UsingNotAccurate(),
+        new MinionCommandCastFinder(InnocentDisplayJuvenileRiverOtter, (int)MinionID.JuvenileRiverOtter),
     ];
 
     private static bool TargetBelow600Range(DamageEvent x, ParsedEvtcLog log)

--- a/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/SotO/Bosses/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/SotO/Bosses/TempleOfFebe.cs
@@ -781,6 +781,13 @@ internal class TempleOfFebe : SecretOfTheObscureRaidEncounter
                             continue;
                         }
                     }
+
+                    // At 10%, if you phase while the side wall is active, the embodiment can show another cast later but the wall won't spawn.
+                    // Even with a cast time of 98ms the indicator is still present, so just skip the damage walls animations.
+                    if (cast.ActualDuration < indicatorDuration)
+                    {
+                        continue;
+                    }
                 }
 
                 // Frontal Damage Beam

--- a/GW2EIEvtcParser/LogLogic/Raids/RaidWings/W8/Bosses/GreerTheBlightbringer.cs
+++ b/GW2EIEvtcParser/LogLogic/Raids/RaidWings/W8/Bosses/GreerTheBlightbringer.cs
@@ -390,6 +390,9 @@ internal class GreerTheBlightbringer : MountBalrior
                 AddEnfeeblingMiasma(target, log, replay);
                 AddRainOfSpores(target, log, replay);
                 AddBlobOfBlight(target, log, replay);
+                // Rare edge case, sometimes Ereg can cast these
+                AddSweepTheMoldRakeTheRot(target, log, replay);
+                AddStompTheGrowth(target, log, replay);
                 break;
             case (int)TargetID.ProtoGreerling:
                 AddSweepTheMoldRakeTheRot(target, log, replay);

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItemOverrides.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItemOverrides.cs
@@ -579,6 +579,7 @@ public static class SkillItemOverrides
         { RelicOfShacklesDamageSkill, ItemImages.RelicOfShackles },
         { RelicOfTheForestDwellerMissileDamage, ItemImages.RelicOfTheForestDweller },
         { RelicOfGaldraSkill, ItemImages.RelicOfGaldra },
+        { RelicOfTheCruelOverseer, ItemImages.RelicOfTheCruelOverseer },
 #endregion RelicIcons
         #region ElementalistIcons
         { EarthenBlast, TraitImages.EarthenBlast },

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItemOverrides.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItemOverrides.cs
@@ -95,6 +95,8 @@ public static class SkillItemOverrides
         { RelicPrivateerSpawn, "Relic of the Privateer (Spawn Minion)" },
         { RelicOfTheSteamshrieker, "Relic of the Steamshrieker" },
         { RelicOfShacklesDamageSkill, "Relic of Shackles (Damage)" },
+        { RelicOfGaldraSkill, "Relic of Galdra" },
+        { KudasCrueltyModifierBuff, "Relic of the Cruel Overseer" },
         #endregion Relics
         #region Elementalist
         { ShatteringIceDamage, "Shattering Ice (Hit)" },
@@ -576,6 +578,7 @@ public static class SkillItemOverrides
         { RelicOfTheNauticalBeastDamageHealing, ItemImages.RelicOfTheNauticalBeast },
         { RelicOfShacklesDamageSkill, ItemImages.RelicOfShackles },
         { RelicOfTheForestDwellerMissileDamage, ItemImages.RelicOfTheForestDweller },
+        { RelicOfGaldraSkill, ItemImages.RelicOfGaldra },
 #endregion RelicIcons
         #region ElementalistIcons
         { EarthenBlast, TraitImages.EarthenBlast },
@@ -952,6 +955,10 @@ public static class SkillItemOverrides
             { LeyLineVortexAetherHunterPet, SkillImages.LeylineVortexAetherHunter },
             { LungeAetherHunterPet, SkillImages.LungeVortexAetherHunter },
             { BumbleJanthiriBee, SkillImages.BumbleJanthiriBee },
+            { InnocentDisplayJuvenileRiverOtter, SkillImages.InnocentDisplayOtter },
+            { JetJuvenileRiverOtter, SkillImages.JetOtter },
+            { ScratchJuvenileRiverOtter, SkillImages.ScratchOtter },
+            { TailWhipJuvenileRiverOtter, SkillImages.TailWhipOtter  },
             #endregion RangerIcons
             #region RevenantIcons
             { RiftSlashRiftHit, SkillImages.RiftSlash },

--- a/GW2EIEvtcParser/ParsedData/Skills/SkillItemOverrides.cs
+++ b/GW2EIEvtcParser/ParsedData/Skills/SkillItemOverrides.cs
@@ -96,7 +96,7 @@ public static class SkillItemOverrides
         { RelicOfTheSteamshrieker, "Relic of the Steamshrieker" },
         { RelicOfShacklesDamageSkill, "Relic of Shackles (Damage)" },
         { RelicOfGaldraSkill, "Relic of Galdra" },
-        { KudasCrueltyModifierBuff, "Relic of the Cruel Overseer" },
+        { RelicOfTheCruelOverseer, "Relic of the Cruel Overseer" },
         #endregion Relics
         #region Elementalist
         { ShatteringIceDamage, "Shattering Ice (Hit)" },
@@ -955,7 +955,6 @@ public static class SkillItemOverrides
             { LeyLineVortexAetherHunterPet, SkillImages.LeylineVortexAetherHunter },
             { LungeAetherHunterPet, SkillImages.LungeVortexAetherHunter },
             { BumbleJanthiriBee, SkillImages.BumbleJanthiriBee },
-            { InnocentDisplayJuvenileRiverOtter, SkillImages.InnocentDisplayOtter },
             { JetJuvenileRiverOtter, SkillImages.JetOtter },
             { ScratchJuvenileRiverOtter, SkillImages.ScratchOtter },
             { TailWhipJuvenileRiverOtter, SkillImages.TailWhipOtter  },

--- a/GW2EIEvtcParser/ParserHelpers/GW2Builds.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GW2Builds.cs
@@ -253,5 +253,8 @@ public static class GW2Builds
     // https://wiki.guildwars2.com/wiki/Game_updates/2026-04-14
     public const ulong April2026Balancepocalypse = 198816;
 
+    // https://wiki.guildwars2.com/wiki/Game_updates/2026-05-12
+    public const long May2026NewRelicsAndOtter = 200514;
+
     public const ulong EndOfLife = ulong.MaxValue;
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/DamageModifierIDs.cs
@@ -432,4 +432,6 @@ public static class DamageModifierIDs
     public const int Mod_CompoundingPowerStrike = 419;
     public const int Mod_CompoundingPowerCondition = 420;
     public const int Mod_Chronophantasma = 421;
+    public const int Mod_RelicOfTheDirector = 422;
+    public const int Mod_RelicOfTheDoyen = 423;
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -5590,6 +5590,22 @@ public static class SkillIDs
     public const long DefenderMoralBoost = 79544;
     public const long AchievementEligibilitySurefooted = 79546;
     public const long SuperSharpeningPolygon = 79575;
+    public const long RelicOfTheDirector = 79640;
+    public const long JetJuvenileRiverOtter = 79654;
+    public const long InnocentDisplayJuvenileRiverOtter = 79766;
+    public const long POV_RelicOfWatch = 79784;
+    public const long POV_RelicOfTheDoyen = 79919;
+    public const long KudasCrueltyModifierBuff = 79938;
+    public const long POV_RelicOfTheCruelOverseer = 79950;
+    public const long POV_RelicOfTheDirector = 79989;
+    public const long POV_RelicOfGaldra = 79996;
+    public const long TailWhipSoulbeastOtter = 80001;
+    public const long JetSoulbeastOtter = 80035;
+    public const long RelicOfGaldraSkill = 80072;
+    public const long POV_RelicOfTheSacredGrounds = 80125;
+    public const long KudasCrueltyStacksBuff = 80152;
+    public const long TailWhipJuvenileRiverOtter = 80164;
+    public const long ScratchJuvenileRiverOtter= 80186;
     #endregion
 
 }

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -75,6 +75,7 @@ public static class SkillIDs
     public const long SymbolOfResolutionOrLesser = -56;
     public const long SymbolOfResolutionOrLesserOrLuminousStaff= -57;
     public const long DhuumEtherealSealInteract = -58;
+    public const long RelicOfTheCruelOverseer = -59;
     #endregion
     #region ArcDPS Hardcoded
     internal const long ArcDPSDodge = 65001;

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SpeciesIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SpeciesIDs.cs
@@ -949,6 +949,7 @@ public static class SpeciesIDs
         JuvenileWarclaw = 26628,
         JuvenileJanthiriBee = 26851,
         JuvenileRaptorSwiftwing = 27259,
+        JuvenileRiverOtter = 27687,
         // Guardian Weapon Summons
         BowOfTruth = 6383,
         HammerOfWisdom = 5791,

--- a/GW2EIEvtcParser/ParserHelpers/Images/ItemImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/ItemImages.cs
@@ -151,6 +151,10 @@ internal static class ItemImages
     public const string RelicOfTheForestDweller = "https://render.guildwars2.com/file/DC19DA3EC27F49593B93F9042264F5DD36FED4ED/3745067.png";
     public const string RelicOfTheNauticalBeast = "https://render.guildwars2.com/file/0EE97FA7FB5DC098447AAF6401DF5A09C47B33AD/3745068.png";
     public const string RelicOfShackles = "https://render.guildwars2.com/file/7946A50DBDC2E45E004AAA801904015C50CC22B3/3745069.png";
+    public const string RelicOfTheDirector = "https://render.guildwars2.com/file/6FD76BA11105EC67451D9E7E1DE938C91DB3AD68/3770711.png";
+    public const string RelicOfTheCruelOverseer = "https://render.guildwars2.com/file/AECE9B16DE04F756C501743BA863B00A377CE70B/3770710.png";
+    public const string RelicOfGaldra = "https://render.guildwars2.com/file/CE07976D4420779EC0082AFE06B73F3AA6AE2348/3770713.png";
+    public const string RelicOfTheDoyen = "https://render.guildwars2.com/file/EF797D16D0D211064031129135C864311856CDB1/3770712.png";
     #endregion Relic
     #region Food
     public const string NourishmentEffect = "https://render.guildwars2.com/file/779D3F0ABE5B46C09CFC57374DA8CC3A495F291C/436367.png";

--- a/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
@@ -581,6 +581,7 @@ internal static class ParserIcons
     private const string MinionJuvenileWarclaw = "https://i.imgur.com/dYuiG3W.png";
     private const string MinionJuvenileJanthiriBee = "https://i.imgur.com/WymxKGX.png";
     private const string MinionJuvenileRaptorSwiftwing = "https://i.imgur.com/F33rSgz.png";
+    private const string MinionJuvenileRiverOtter = "https://i.imgur.com/3la7Fjc.png";
     private const string MinionBloodFiend = "https://i.imgur.com/PrOpULe.png";
     private const string MinionBoneFiend = "https://i.imgur.com/BEntBIt.png";
     private const string MinionFleshGolem = "https://i.imgur.com/JkYUNug.png";
@@ -1546,6 +1547,7 @@ internal static class ParserIcons
         { MinionID.JuvenileWarclaw, MinionJuvenileWarclaw },
         { MinionID.JuvenileJanthiriBee, MinionJuvenileJanthiriBee },
         { MinionID.JuvenileRaptorSwiftwing, MinionJuvenileRaptorSwiftwing },
+        { MinionID.JuvenileRiverOtter, MinionJuvenileRiverOtter},
         { MinionID.BloodFiend, MinionBloodFiend },
         { MinionID.BoneFiend, MinionBoneFiend },
         { MinionID.FleshGolem, MinionFleshGolem },

--- a/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/SkillImages.cs
@@ -566,6 +566,10 @@ internal static class SkillImages
     public const string LeylineVortexAetherHunter = "https://render.guildwars2.com/file/030E7AB1CB18A4B348FD17B54B2B68FDABDB1DBC/3124961.png";
     public const string LungeVortexAetherHunter = "https://render.guildwars2.com/file/B65ECEBB72F4F10C4144510777E899E477DEE5B2/3124960.png";
     public const string BumbleJanthiriBee = "https://render.guildwars2.com/file/DCA96000060D21F6E4A9600DB3D8A90CE8AB574B/3594073.png";
+    public const string InnocentDisplayOtter = "https://render.guildwars2.com/file/6548D0084D2F2D639EF62F60CBAA1712ABAA0127/3772574.png";
+    public const string JetOtter = "https://render.guildwars2.com/file/E839D32DEC66ACF974A59478370BA810C54CCC5D/3772575.png";
+    public const string TailWhipOtter = "https://render.guildwars2.com/file/A7179EB9654498EC366C0012246DCE91AD3D68B5/3772577.png";
+    public const string ScratchOtter = "https://assets.gw2dat.com/3772576.png";
     // Galeshot
     public const string Mistral = "https://render.guildwars2.com/file/10E31F10E7D84CABF0963FEA12B77EE0BD950E42/3680194.png";
     #endregion Ranger


### PR DESCRIPTION
- Added the new relics
- - Relic of the Director buff and damage modifier
- - Kuda's Cruelty stacking buff and modifier buff (no modifier tracker, it's healing output)
- - Relic of the Doyen damage modifier (no unique buff, TODO collisions with other damage modifiers)
- - Relic of the Director instant cast finder
- - Relic of Galdra instant cast finder
- - Relic of the Cruel Overseer instant cast finder (damage modifier only)
- Added Juvenile River Otter pet
- - Added icons to the pet skills
- - Added F2 cast detection
- - Added combat replay image
- Fixed Envy's damage wall displaying incorrectly in a certain edge case at 10%.
- Fixed Ereg not displaying Sweep the Mold, Rake the Rot, Stomp the Growth in the replay in a rare case where he can cast them.