### PR TITLE
Fix Envious Gaze once and for all

### DIFF
--- a/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/SotO/Bosses/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/SotO/Bosses/TempleOfFebe.cs
@@ -729,7 +729,10 @@ internal class TempleOfFebe : SecretOfTheObscureRaidEncounter
 
         var isCerus = target.IsSpecies(TargetID.Cerus);
         var isKillableEmbodiment = target.IsSpecies(TargetID.EmbodimentOfEnvy);
-        
+        if (!log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.TempleOfFebeEnviousGazeWall1, out var wallsDamage))
+        {
+            wallsDamage = []; 
+        }
         if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.TempleOfFebeEnviousGazeIndicator, out var wallsIndicators))
         {
             foreach (EffectEvent indicator in wallsIndicators)
@@ -764,7 +767,7 @@ internal class TempleOfFebe : SecretOfTheObscureRaidEncounter
                         replay.Decorations.AddWithGrowing(oppositeRectangle, growing);
                     }
 
-                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.TempleOfFebeEnviousGaze1, out var wallsDamage))
+                    if (wallsDamage.Count > 0)
                     {
                         var wall = wallsDamage.FirstOrDefault(x => x.Time >= indicator.Time && x.Time <= indicator.Time + wallDuration);
                         if (wall != null)
@@ -779,10 +782,6 @@ internal class TempleOfFebe : SecretOfTheObscureRaidEncounter
                             var rotation2 = new SpinningConnector(facing.Value, (float)degreesRotated);
                             var rectangle2 = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanDamageCancelled, Colors.Red, 0.2, agentConnector).UsingRotationConnector(rotation2);
                             replay.Decorations.Add(rectangle2);
-
-                            // AoE underneath - Looks like the radius is Cerus' hitbox radius, the Embodiment has smaller hitbox but same model.
-                            var circle = new CircleDecoration(140, lifespanDamage, Colors.Red, 0.2, new AgentConnector(target)).UsingFilled(false);
-                            replay.Decorations.Add(circle);
 
                             if (isEmpowered)
                             {
@@ -818,6 +817,28 @@ internal class TempleOfFebe : SecretOfTheObscureRaidEncounter
                         }
                     }
                 }
+            }
+        }
+        // AoE underneath - Looks like the radius is Cerus' hitbox radius event for the Embodiment which has a smaller hitbox but same model.
+        uint radius = 140;
+        (long start, long end) lifespan;
+        if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.TempleOfFebeEnviousGazePuddleEffect, out var aoes))
+        {
+            foreach (EffectEvent effect in aoes)
+            {
+                lifespan = effect.ComputeDynamicLifespan(log, 12500);
+                var circle = new CircleDecoration(radius, lifespan, Colors.Red, 0.1, new PositionConnector(effect.Position));
+                replay.Decorations.Add(circle);
+            }
+        }
+        // The red ring lingers when transitioning off a split phase, we don't know if it deals damage but we render it anyway.
+        if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.TempleOfFebeEnviousGazePuddleRedRing, out var rings))
+        {
+            foreach (EffectEvent effect in rings)
+            {
+                lifespan = effect.ComputeDynamicLifespan(log, 12500);
+                var circle = new CircleDecoration(radius, lifespan, Colors.Red, 0.1, new PositionConnector(effect.Position)).UsingFilled(false);
+                replay.Decorations.Add(circle);
             }
         }
     }

--- a/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/SotO/Bosses/TempleOfFebe.cs
+++ b/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/SotO/Bosses/TempleOfFebe.cs
@@ -722,112 +722,100 @@ internal class TempleOfFebe : SecretOfTheObscureRaidEncounter
     private static void AddEnviousGazeDecoration(NPC target, ParsedEvtcLog log, CombatReplay replay, IEnumerable<CastEvent> casts)
     {
         uint width = 2200;
+        long indicatorDuration = 1500;
+        long wallDuration = 12500;
 
         var enviousGaze = casts.Where(x => x.SkillID == EnviousGazeNM || x.SkillID == EnviousGazeEmpoweredNM || x.SkillID == EnviousGazeCM || x.SkillID == EnviousGazeEmpoweredCM);
 
         var isCerus = target.IsSpecies(TargetID.Cerus);
         var isKillableEmbodiment = target.IsSpecies(TargetID.EmbodimentOfEnvy);
-
-        foreach (CastEvent cast in enviousGaze)
+        
+        if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.TempleOfFebeEnviousGazeIndicator, out var wallsIndicators))
         {
-            bool isEmpowered = cast.SkillID == EnviousGazeEmpoweredNM || cast.SkillID == EnviousGazeEmpoweredCM;
-            long indicatorDuration = 1500;
-            (long start, long end) lifespanIndicator = (cast.Time, cast.Time + indicatorDuration);
-            long growing = lifespanIndicator.end;
-            if (target.TryGetCurrentFacingDirection(log, lifespanIndicator.end, out var facing))
+            foreach (EffectEvent indicator in wallsIndicators)
             {
-                // Indicator
-                // Check if quickness is still applied from a previous steal
-                double computedDuration = ComputeCastTimeWithQuickness(log, target, cast.Time, indicatorDuration);
-                if (computedDuration > 0)
+                (long start, long end) lifespanIndicator = (indicator.Time, indicator.Time + indicatorDuration);
+                long growing = lifespanIndicator.end;
+                var cast = enviousGaze.FirstOrDefault(x => x.Time <= indicator.Time && indicator.Time <= x.Time + indicatorDuration);
+                if (target.TryGetCurrentFacingDirection(log, lifespanIndicator.end, out var facing) && cast != null)
                 {
-                    lifespanIndicator.end = cast.Time + Math.Min(indicatorDuration, (long)Math.Ceiling(computedDuration));
-                }
-                // Check if the indicator is cancelled
-                lifespanIndicator = ComputeMechanicLifespanWithCancellationTime(target.AgentItem, log, lifespanIndicator);
+                    bool isEmpowered = cast.SkillID == EnviousGazeEmpoweredNM || cast.SkillID == EnviousGazeEmpoweredCM;
 
-                // Frontal indicator
-                var rotation = new AngleConnector(facing.Value);
-                var agentConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(width / 2, 0, 0), true);
-                var rectangle = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanIndicator, Colors.LightOrange, 0.2, agentConnector).UsingRotationConnector(rotation);
-                replay.Decorations.AddWithGrowing(rectangle, growing);
-                if (isEmpowered)
-                {
-                    // Opposite Indicator
-                    var oppositeAgentConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(-(width / 2), 0, 0), true);
-                    var oppositeRectangle = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanIndicator, Colors.LightOrange, 0.2, oppositeAgentConnector).UsingRotationConnector(rotation);
-                    replay.Decorations.AddWithGrowing(oppositeRectangle, growing);
-                }
-
-                // Check if Petrify is casted between the end of the indicator and the start of the damage beam
-                (long start, long end) = ComputeMechanicLifespanWithCancellationTime(target.AgentItem, log, (lifespanIndicator.end, lifespanIndicator.end + 950));
-                if (end < lifespanIndicator.end + 950)
-                {
-                    continue;
-                }
-
-                // At 10%, if the embodiment is casting the indicator but the wall hasn't spawend yet and Cerus' bar is broken, the wall is interrupted and doesn't spawn.
-                if (!isCerus)
-                {
-                    IReadOnlyList<HealthUpdateEvent> health = log.CombatData.GetHealthUpdateEvents(GetCerusItem(log.AgentData));
-                    HealthUpdateEvent? hp11 = health.FirstOrDefault(x => x.HealthPercent < 11);
-                    var petrify = log.CombatData.GetAnimatedCastData(PetrifySkill);
-                    if (hp11 != null)
+                    // Indicator
+                    // Check if quickness is still applied from a previous steal
+                    double computedDuration = ComputeCastTimeWithQuickness(log, target, cast.Time, indicatorDuration);
+                    if (computedDuration > 0)
                     {
-                        AnimatedCastEvent? pet = petrify.FirstOrDefault(x => x.Time > hp11.Time);
-                        // If petrify at 10% finishes casting before the end of the envy indicator, we don't show the rotating beams.
-                        if (pet != null && Math.Abs(lifespanIndicator.start - pet.Time) < 5000 && pet.EndTime < lifespanIndicator.end + 950)
-                        {
-                            continue;
-                        }
+                        lifespanIndicator.end = cast.Time + Math.Min(indicatorDuration, (long)Math.Ceiling(computedDuration));
                     }
+                    // Check if the indicator is cancelled
+                    lifespanIndicator = ComputeMechanicLifespanWithCancellationTime(target.AgentItem, log, lifespanIndicator);
 
-                    // At 10%, if you phase while the side wall is active, the embodiment can show another cast later but the wall won't spawn.
-                    // Even with a cast time of 98ms the indicator is still present, so just skip the damage walls animations.
-                    if (cast.ActualDuration < indicatorDuration)
+                    // Frontal indicator
+                    var rotation = new AngleConnector(facing.Value);
+                    var agentConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(width / 2, 0, 0), true);
+                    var rectangle = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanIndicator, Colors.LightOrange, 0.2, agentConnector).UsingRotationConnector(rotation);
+                    replay.Decorations.AddWithGrowing(rectangle, growing);
+                    if (isEmpowered)
                     {
-                        continue;
-                    }
-                }
-
-                // Frontal Damage Beam
-                (long start, long end) lifespanDamage = (lifespanIndicator.end + 950, lifespanIndicator.end + 10750);
-                (long start, long end) lifespanDamageCancelled = lifespanDamage;
-                lifespanDamageCancelled = ComputeMechanicLifespanWithCancellationTime(target.AgentItem, log, lifespanDamage);
-                double millisecondsPerDegree = (double)(lifespanDamage.end - lifespanDamage.start) / 360;
-                double degreesRotated = (lifespanDamageCancelled.end - lifespanDamageCancelled.start) / millisecondsPerDegree;
-                var rotation2 = new SpinningConnector(facing.Value, (float)degreesRotated);
-                var rectangle2 = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanDamageCancelled, Colors.Red, 0.2, agentConnector).UsingRotationConnector(rotation2);
-                replay.Decorations.Add(rectangle2);
-                if (isEmpowered)
-                {
-                    // Opposite Damage Beam
-                    (long start, long end) lifespanDamageOpposite = (lifespanIndicator.end + 950, lifespanIndicator.end + 5850);
-                    (long start, long end) lifespanDamageOppositeCancelled = lifespanDamageOpposite;
-                    // In game bug, when ending the 80% and 50% split phases and transitioning back to Cerus, the back wall of the empowered envy does not despawn.
-                    // If this gets fixed in game, add a game build versioning check.
-                    if (!isKillableEmbodiment)
-                    {
-                        lifespanDamageOppositeCancelled = ComputeMechanicLifespanWithCancellationTime(target.AgentItem, log, lifespanDamageOpposite);
-                    }
-                    double millisecondsPerDegreeOpposite = (double)(lifespanDamageOpposite.end - lifespanDamageOpposite.start) / 360;
-                    double degreedRotatedOpposite = (lifespanDamageOppositeCancelled.end - lifespanDamageOppositeCancelled.start) / millisecondsPerDegreeOpposite;
-                    var rotation3 = new SpinningConnector(facing.Value, (float)degreedRotatedOpposite);
-                    
-                    // The bug makes the beam continue while the embodiment has despawned, so we use the agent position for a PositionConnector instead of AgentConnector.
-                    ParametricPoint3D? position = target.GetCombatReplayActivePolledPositions(log).FirstOrDefault(x => x!= null && x.Value.Time > lifespanDamage.start && x.Value.Time <= lifespanDamage.end);
-                    if (position != null)
-                    {
-                        var connector = new PositionConnector(position.Value.XYZ).WithOffset(new(-(width / 2), 0, 0), true);
-                        var rectangle3 = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanDamageOppositeCancelled, Colors.Red, 0.2, connector).UsingRotationConnector(rotation3);
-                        replay.Decorations.Add(rectangle3);
-                    }
-                    else
-                    {
-                        // Fallback for security
+                        // Opposite Indicator
                         var oppositeAgentConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(-(width / 2), 0, 0), true);
-                        var rectangle3 = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanDamageOppositeCancelled, Colors.Red, 0.2, oppositeAgentConnector).UsingRotationConnector(rotation3);
-                        replay.Decorations.Add(rectangle3);
+                        var oppositeRectangle = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanIndicator, Colors.LightOrange, 0.2, oppositeAgentConnector).UsingRotationConnector(rotation);
+                        replay.Decorations.AddWithGrowing(oppositeRectangle, growing);
+                    }
+
+                    if (log.CombatData.TryGetEffectEventsBySrcWithGUID(target.AgentItem, EffectGUIDs.TempleOfFebeEnviousGaze1, out var wallsDamage))
+                    {
+                        var wall = wallsDamage.FirstOrDefault(x => x.Time >= indicator.Time && x.Time <= indicator.Time + wallDuration);
+                        if (wall != null)
+                        {
+                            // Frontal Damage Beam
+                            (long start, long end) lifespanDamage = (lifespanIndicator.end + 950, lifespanIndicator.end + 10750);
+                            (long start, long end) lifespanDamageCancelled = lifespanDamage;
+                            lifespanDamageCancelled = ComputeMechanicLifespanWithCancellationTime(target.AgentItem, log, lifespanDamage);
+                            double millisecondsPerDegree = (double)(lifespanDamage.end - lifespanDamage.start) / 360;
+                            double degreesRotated = (lifespanDamageCancelled.end - lifespanDamageCancelled.start) / millisecondsPerDegree;
+
+                            var rotation2 = new SpinningConnector(facing.Value, (float)degreesRotated);
+                            var rectangle2 = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanDamageCancelled, Colors.Red, 0.2, agentConnector).UsingRotationConnector(rotation2);
+                            replay.Decorations.Add(rectangle2);
+
+                            // AoE underneath - Looks like the radius is Cerus' hitbox radius, the Embodiment has smaller hitbox but same model.
+                            var circle = new CircleDecoration(140, lifespanDamage, Colors.Red, 0.2, new AgentConnector(target)).UsingFilled(false);
+                            replay.Decorations.Add(circle);
+
+                            if (isEmpowered)
+                            {
+                                // Opposite Damage Beam
+                                (long start, long end) lifespanDamageOpposite = (lifespanIndicator.end + 950, lifespanIndicator.end + 5850);
+                                (long start, long end) lifespanDamageOppositeCancelled = lifespanDamageOpposite;
+                                // In game bug, when ending the 80% and 50% split phases and transitioning back to Cerus, the back wall of the empowered envy does not despawn.
+                                // If this gets fixed in game, add a game build versioning check.
+                                if (!isKillableEmbodiment)
+                                {
+                                    lifespanDamageOppositeCancelled = ComputeMechanicLifespanWithCancellationTime(target.AgentItem, log, lifespanDamageOpposite);
+                                }
+                                double millisecondsPerDegreeOpposite = (double)(lifespanDamageOpposite.end - lifespanDamageOpposite.start) / 360;
+                                double degreedRotatedOpposite = (lifespanDamageOppositeCancelled.end - lifespanDamageOppositeCancelled.start) / millisecondsPerDegreeOpposite;
+                                var rotation3 = new SpinningConnector(facing.Value, (float)degreedRotatedOpposite);
+
+                                // The bug makes the beam continue while the embodiment has despawned, so we use the agent position for a PositionConnector instead of AgentConnector.
+                                ParametricPoint3D? position = target.GetCombatReplayActivePolledPositions(log).FirstOrDefault(x => x != null && x.Value.Time > lifespanDamage.start && x.Value.Time <= lifespanDamage.end);
+                                if (position != null)
+                                {
+                                    var connector = new PositionConnector(position.Value.XYZ).WithOffset(new(-(width / 2), 0, 0), true);
+                                    var rectangle3 = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanDamageOppositeCancelled, Colors.Red, 0.2, connector).UsingRotationConnector(rotation3);
+                                    replay.Decorations.Add(rectangle3);
+                                }
+                                else
+                                {
+                                    // Fallback for security
+                                    var oppositeAgentConnector = (AgentConnector)new AgentConnector(target).WithOffset(new(-(width / 2), 0, 0), true);
+                                    var rectangle3 = (RectangleDecoration)new RectangleDecoration(width, 100, lifespanDamageOppositeCancelled, Colors.Red, 0.2, oppositeAgentConnector).UsingRotationConnector(rotation3);
+                                    replay.Decorations.Add(rectangle3);
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -1086,10 +1086,10 @@ public static class EffectGUIDs
     public static readonly GUID TempleOfFebePoolOfDespair2 = new("4F982CD060507C44A25844BF0ADFCB54"); // No Owner Target Player Duration 0
     public static readonly GUID TempleOfFebePoolOfDespairEmpowered = new("24E40E1F15BE2142B61F3568D23AE799"); // Owner Cerus/Embodiment Duration 999000
     public static readonly GUID TempleOfFebeEnviousGazeIndicator = new("62B3766CDF54BD4EA964DAA462954A4A"); // Duration 1500 - Around Agent
-    public static readonly GUID TempleOfFebeEnviousGaze1 = new("246ECEBC28173B498B9A6886D7937D59"); // Duration 12500 - Around Agent
-    public static readonly GUID TempleOfFebeEnviousGaze2 = new("DA42718917F2304FBA10AF6898217788"); // Duration 12500 - Ground Effect
-    public static readonly GUID TempleOfFebeEnviousGaze3 = new("B77A06C842511949889877EDC1448D49"); // Duration 11000 - Ground Effect
-    public static readonly GUID TempleOfFebeEnviousGaze4 = new("0D2192849D53B4469F56B1C74542DBE9"); // Duration 11000 - Red circle AoE underneath Cerus - Conflics with other encounters
+    public static readonly GUID TempleOfFebeEnviousGazeWall1 = new("246ECEBC28173B498B9A6886D7937D59"); // Duration 12500 - Around Agent - Wall moving
+    public static readonly GUID TempleOfFebeEnviousGazeWall2 = new("DA42718917F2304FBA10AF6898217788"); // Duration 12500 - Ground Effect - Wall red rectangle
+    public static readonly GUID TempleOfFebeEnviousGazePuddleEffect = new("B77A06C842511949889877EDC1448D49"); // Duration 11000 - Ground Effect - Puddle AoE underneath Cerus
+    public static readonly GUID TempleOfFebeEnviousGazePuddleRedRing = new("0D2192849D53B4469F56B1C74542DBE9"); // Duration 11000 - Red ring AoE underneath Cerus - Conflics with other encounters
     public static readonly GUID TempleOfFebeMaliciousIntentTether = new("518369328A12B74EAC49702A785FBA19"); // Duration 0
     // Guardian's Glade
     public static readonly GUID GuardiansGaleClawSlamIndicator = new("051F8F1650EE0A44960AD1B865DB4BC5"); // owned by kela, duration 3000 - damage happens at around 2520

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -1085,10 +1085,10 @@ public static class EffectGUIDs
     public static readonly GUID TempleOfFebePoolOfDespair = new("3CF93AB93143B64A879D1D63FBA9282A"); // Owner Cerus/Embodiment Duration 60000
     public static readonly GUID TempleOfFebePoolOfDespair2 = new("4F982CD060507C44A25844BF0ADFCB54"); // No Owner Target Player Duration 0
     public static readonly GUID TempleOfFebePoolOfDespairEmpowered = new("24E40E1F15BE2142B61F3568D23AE799"); // Owner Cerus/Embodiment Duration 999000
-    public static readonly GUID TempleOfFebeEnviousGazeIndicator = new("62B3766CDF54BD4EA964DAA462954A4A"); // Duration 1500
-    public static readonly GUID TempleOfFebeEnviousGaze1 = new("246ECEBC28173B498B9A6886D7937D59"); // Duration 12500
-    public static readonly GUID TempleOfFebeEnviousGaze2 = new("DA42718917F2304FBA10AF6898217788"); // Duration 12500
-    public static readonly GUID TempleOfFebeEnviousGaze3 = new("B77A06C842511949889877EDC1448D49"); // Duration 11000
+    public static readonly GUID TempleOfFebeEnviousGazeIndicator = new("62B3766CDF54BD4EA964DAA462954A4A"); // Duration 1500 - Around Agent
+    public static readonly GUID TempleOfFebeEnviousGaze1 = new("246ECEBC28173B498B9A6886D7937D59"); // Duration 12500 - Around Agent
+    public static readonly GUID TempleOfFebeEnviousGaze2 = new("DA42718917F2304FBA10AF6898217788"); // Duration 12500 - Ground Effect
+    public static readonly GUID TempleOfFebeEnviousGaze3 = new("B77A06C842511949889877EDC1448D49"); // Duration 11000 - Ground Effect
     public static readonly GUID TempleOfFebeEnviousGaze4 = new("0D2192849D53B4469F56B1C74542DBE9"); // Duration 11000 - Red circle AoE underneath Cerus - Conflics with other encounters
     public static readonly GUID TempleOfFebeMaliciousIntentTether = new("518369328A12B74EAC49702A785FBA19"); // Duration 0
     // Guardian's Glade


### PR DESCRIPTION
I've reworked the logic to be using the effect events as a mean to know whether the wall has spawned or not. All the edge cases at 10% and the 80-50% intermissions have been working correctly from my testings.
Most of the changes are actually just indentation shifts
Also added some extra documentation for the effect GUIDs