### PR TITLE
Updated Distributed Magic for Vale Guardian

### DIFF
--- a/GW2EIEvtcParser/LogLogic/Raids/RaidWings/W1/Bosses/ValeGuardian.cs
+++ b/GW2EIEvtcParser/LogLogic/Raids/RaidWings/W1/Bosses/ValeGuardian.cs
@@ -154,18 +154,56 @@ internal class ValeGuardian : SpiritVale
             base.ComputeEnvironmentCombatReplayDecorations(log, environmentDecorations);
         }
 
+        // Distributed Magic - Green circle
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ValeGuardianDistributedMagic, out var distributedMagicEvents))
         {
             foreach (EffectEvent distributedMagic in distributedMagicEvents)
             {
-                // Effect duration is 6000, added 700 for the damage.
-                (long start, long end) lifespan = distributedMagic.ComputeLifespan(log, 6000);
-                lifespan.end = Math.Min(lifespan.end + 700, distributedMagic.Src.LastAware);
+                long duration = 6000;
+                long extendedDuration = 700;
+                // Effect duration is 6000, added 700 for the trigger.
+                (long start, long end) lifespan = (distributedMagic.Time, distributedMagic.Time + duration + extendedDuration);
+                long growing = lifespan.end;
+                // Blue Guardian LastAware is delayed, we use the death event to cancel the green.
+                if (distributedMagic.Src.IsSpecies(TargetID.BlueGuardian))
+                {
+                    var deathEvent = log.CombatData.GetDeadEvents(distributedMagic.Src).FirstOrDefault();
+                    if (deathEvent != null)
+                    {
+                        lifespan.end = Math.Min(lifespan.end, deathEvent.Time);
+                    }
+                }
                 var circle = new CircleDecoration(180, lifespan, Colors.DarkGreen, 0.2, new PositionConnector(distributedMagic.Position));
-                environmentDecorations.AddWithGrowing(circle, lifespan.end);
+                environmentDecorations.AddWithGrowing(circle, growing, true);
             }
         }
 
+        // Distributed Magic - Green circle successful
+        if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ValeGuardianDistributedMagicSuccess, out var successes))
+        {
+            foreach (EffectEvent effect in successes)
+            {
+                (long, long) lifespan = effect.ComputeLifespan(log, 1000);
+                var circle = new CircleDecoration(180, lifespan, Colors.Green, 0.2, new PositionConnector(effect.Position));
+                environmentDecorations.Add(circle);
+            }
+        }
+
+        // Distributed Magic - Green circle failed
+        if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ValeGuardianDistributedMagicFailure, out var failures))
+        {
+            foreach (EffectEvent effect in failures)
+            {
+                (long, long) lifespan = effect.ComputeLifespan(log, 1000);
+                var position = new PositionConnector(effect.Position);
+                var circle = new CircleDecoration(180, lifespan, Colors.DarkRed, 0.2, position);
+                environmentDecorations.Add(circle);
+                // Add a shockwave effect matching the in-game visual
+                environmentDecorations.AddShockwave(position, lifespan, Colors.LightGrey, 0.5, 1200);
+            }
+        }
+
+        // Unstable Magic Spike - Blue circle
         if (log.CombatData.TryGetEffectEventsByGUID(EffectGUIDs.ValeGuardianMagicSpike, out var magicSpikeEvents))
         {
             foreach (EffectEvent magicSpike in magicSpikeEvents)

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -659,6 +659,8 @@ public static class EffectGUIDs
     #region Raids
     // Vale Guardian
     public static readonly GUID ValeGuardianDistributedMagic = new("43FD739499BB6040BBF9EEF37781B2CE"); // 6000 duration
+    public static readonly GUID ValeGuardianDistributedMagicFailure = new("6CBE4306EBF349448184EC27FCD0B622"); // 1000 duration
+    public static readonly GUID ValeGuardianDistributedMagicSuccess = new("3611DE578F70B1439704D731663CDDF2"); // 1000 duration
     public static readonly GUID ValeGuardianMagicSpike = new("55364633145D264A934935C3F026B19F"); // 2000 duration
     // Gorseval
     public static readonly GUID GorsevalGhastlyPrison = new("16BBFDBEC55958419CC5564CB1FEED04"); // 2000 duration


### PR DESCRIPTION
- Fixed greens spawned by Blue Guardian not despawning when killed. The LastAware is delayed compared to the death event.
- Fixed greens growing in the wrong direction compared to the in-game visual
- Added successful green effects
- Added failed green effects

Logs containing greens failed and successful in both split phases and main phases
[vg logs.zip](https://github.com/user-attachments/files/28837523/vg.logs.zip)