### PR TITLE
Added mechanic ticks to timeline

### DIFF
--- a/GW2EIBuilders/Resources/JS/CR-JS/animator.js
+++ b/GW2EIBuilders/Resources/JS/CR-JS/animator.js
@@ -97,6 +97,12 @@ const reactiveAnimationData = {
         max: 1e12
     },
     selectedExtraDecorations: false,
+    selectedMechanic: {
+        actorId: null,
+        actorName: null,
+        name: null,
+        times: [],
+    }
 };
 
 var sliderDelimiter = {

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayAnimationControl.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayAnimationControl.html
@@ -202,7 +202,7 @@
                     </div>
                     <div v-if="!isTouchDevice && isMechanicSelected"
                          id="mechReset"
-                         @click="resetMechanic(selectedPhase);" class="btn btn-small"
+                         @click="resetMechanic();" class="btn btn-small"
                          :class="{'btn-dark': !light, 'btn-light': light}"
                          data-original-title="Remove mechanic ticks from timeline">
                         Reset Mechanic
@@ -530,7 +530,7 @@
                 }
                 return res;
             },
-            resetMechanic: function (phase) {
+            resetMechanic: function () {
                 $('#mechReset').tooltip('hide');
 
                 this.animationData.selectedMechanic = {
@@ -539,7 +539,6 @@
                     name: null,
                     times: [],
                 };
-                this.getFormattedPhaseText(phase);
             },
             updatePhaseTime: function (phase) {
                 this.selectedPhase = phase;

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayAnimationControl.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayAnimationControl.html
@@ -133,6 +133,18 @@
                                 </text>
                             </g>
 
+                            <!-- Mechanics ticks -->
+                            <g v-for="tick in playerMechanicTicks">
+                                <line :x1="tick.x" y1="15" :x2="tick.x" y2="25"
+                                      :stroke="timelineColors.mechanic" />
+                                <!-- Top -->
+                                <line :x1="tick.x - 1" y1="15" :x2="tick.x + 1" y2="15"
+                                      :stroke="timelineColors.mechanic" />
+                                <!-- Bottom -->
+                                <line :x1="tick.x - 1" y1="25" :x2="tick.x + 1" y2="25"
+                                      :stroke="timelineColors.mechanic" />
+                            </g>
+
                             <!-- Moving time -->
                             <g v-if="isHoveringTimeline">
                                 <rect :x="timeToX(hoverTime) - 18"
@@ -169,17 +181,32 @@
                     <img class="icon mr-2" :src="UIIcons.QuestionMark"
                          data-original-title="You can click on the canvas to select agents" />
                     <div @click="toggleAnimate();" class="btn btn-small"
-                         :class="{'btn-dark': !light, 'btn-light': light}" style="width: 50px;">
+                         :class="{'btn-dark': !light, 'btn-light': light}" style="width: 50px;"
+                         data-original-title="Play / pause animation">
                         {{ animated ? "Pause" : "Play "}}
                     </div>
                     <div @click="restartAnimate();" class="btn btn-small"
-                         :class="{'btn-dark': !light, 'btn-light': light}">
+                         :class="{'btn-dark': !light, 'btn-light': light}"
+                         data-original-title="Reset back to start">
                         Restart
                     </div>
                     <div @click="toggleBackwards();" class="btn btn-small"
-                         :class="{'active': backwards, 'btn-dark': !light, 'btn-light': light}">Backwards</div>
+                         :class="{'active': backwards, 'btn-dark': !light, 'btn-light': light}"
+                         data-original-title="Play animation backwards">
+                        Backwards
+                    </div>
                     <div @click="resetViewpoint();" class="btn btn-small"
-                         :class="{'btn-dark': !light, 'btn-light': light}">Reset Viewpoint</div>
+                         :class="{'btn-dark': !light, 'btn-light': light}"
+                         data-original-title="Reset canvas position">
+                        Reset Viewpoint
+                    </div>
+                    <div v-if="!isTouchDevice && isMechanicSelected"
+                         id="mechReset"
+                         @click="resetMechanic(selectedPhase);" class="btn btn-small"
+                         :class="{'btn-dark': !light, 'btn-light': light}"
+                         data-original-title="Remove mechanic ticks from timeline">
+                        Reset Mechanic
+                    </div>
                     <input v-if="!isTouchDevice" style="width: 100px; text-align: right;" class="ml-3 mr-1" type="number" step="0.001"
                            :id="htmlElementIDs.timeRangeDisplayID" value="0"
                            @input="updateInputTime($event.target.value);">
@@ -257,6 +284,7 @@
                 blockDragCursor: false,
                 phaseDoubleClickTimeout: null, 
                 dragThroughPhaseBlockTimeout: null,
+                animationData: reactiveAnimationData,
             };
         },
         watch: {
@@ -424,6 +452,7 @@
                         cursor: "#ff6b6b",
                         background: "#f8f9fa",
                         backgroundBorder: "#dee2e6",
+                        mechanic: "#ff8a9d",
                     };
                 } else {
                     return {
@@ -432,9 +461,21 @@
                         cursor: "#ff6b6b",
                         background: "#2C3035",
                         backgroundBorder: "#3e444c",
+                        mechanic: "#ff8a9d",
                     };
                 }
             },
+            playerMechanicTicks() {
+                return this.animationData.selectedMechanic.times.map(
+                    time => ({
+                        x: this.timeOffsetedToX(time / 1000),
+                        time: time
+                    })
+                );
+            },
+            isMechanicSelected() {
+                return this.animationData.selectedMechanic.name != null && this.animationData.selectedMechanic.actorId != null;
+            }
         },
         methods: {
             updateAnimatorTimes(phase) {
@@ -483,7 +524,22 @@
             },
             getFormattedPhaseText: function (phase) {              
                 const offset = (this.range.min / 1000);
-                return this.getPhaseName(phase) + ' (' + this.round3(phase.start - offset) + 's - ' + this.round3(phase.end - offset) + 's)';
+                var res = this.getPhaseName(phase) + ' (' + this.round3(phase.start - offset) + 's - ' + this.round3(phase.end - offset) + 's)';
+                if (this.animationData.selectedMechanic.name != null) {
+                    res += ' | ' + this.animationData.selectedMechanic.name + ' (' + this.animationData.selectedMechanic.actorName + ')';
+                }
+                return res;
+            },
+            resetMechanic: function (phase) {
+                $('#mechReset').tooltip('hide');
+
+                this.animationData.selectedMechanic = {
+                    actorId: null,
+                    actorName: null,
+                    name: null,
+                    times: [],
+                };
+                this.getFormattedPhaseText(phase);
             },
             updatePhaseTime: function (phase) {
                 this.selectedPhase = phase;

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
@@ -214,6 +214,10 @@
                 animator.stopAnimate(true);
                 animator.updateTime(mechanic.time);
 
+                if (isTouchDevice) {
+                    return;
+                }
+
                 // Deselection
                 if (reactiveAnimationData.selectedMechanic.actorId == mechanic.actor.id &&
                     reactiveAnimationData.selectedMechanic.name == mechanic.mechanic.name) {

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
@@ -1,8 +1,11 @@
 <template>
     <div class="d-flex flex-row flex-wrap justify-content-center align-items-center">
         <div class="d-flex align-items-center mb-2 scale85">
-            <input id="followTimeline" type="checkbox" v-model="followTimeline" class="mr-1"/>
+            <input id="followTimeline" type="checkbox" v-model="followTimeline" class="mr-1" />
             <label for="followTimeline" class="mb-0 ml-1">Scroll with timeline</label>
+            <div v-if="!isTouchDevice"
+                 @click="resetMechanic()" class="ml-3 btn btn-small"
+                 :class="{'btn-dark': !light, 'btn-light': light}">Reset Mechanic Selection</div>
         </div>
         <div id="combat-replay-mechanics-list" class="combat-replay-mechanics-list-container d-flex d-flex-row justify-content-center w-100 scrollable-y"
              style="max-width:450px; overflow-y:auto;">
@@ -89,7 +92,7 @@
 
 <script>
     Vue.component("combat-replay-mechanics-list-component", {
-        props: ['time', 'selectedplayerid'],
+        props: ['time', 'light', 'selectedplayerid'],
         template: `${template}`,
         data: function () {
             var mechanicEvents = [];
@@ -183,6 +186,7 @@
             });
 
             return {
+                isTouchDevice: isTouchDevice,
                 mechanicEvents: mechanicEvents,
                 actors: actors,
                 actorsList: actorsList,
@@ -209,6 +213,24 @@
                 this.followTimeline = false;
                 animator.stopAnimate(true);
                 animator.updateTime(mechanic.time);
+
+                // Deselection
+                if (reactiveAnimationData.selectedMechanic.actorId == mechanic.actor.id &&
+                    reactiveAnimationData.selectedMechanic.name == mechanic.mechanic.name) {
+                    this.resetMechanic();
+                    return;
+                }
+
+                // Selection
+                reactiveAnimationData.selectedMechanic.actorId = mechanic.actor.id;
+                reactiveAnimationData.selectedMechanic.name = mechanic.mechanic.name;
+                reactiveAnimationData.selectedMechanic.times =
+                    this.mechanicEvents
+                        .filter(event =>
+                            event.actor.id === mechanic.actor.id &&
+                            event.mechanic.name === mechanic.mechanic.name)
+                        .map(event => event.time);
+                reactiveAnimationData.selectedMechanic.actorName = mechanic.actor.name;
             },
             stopClickEvent: function (event) {
                 event.stopPropagation();
@@ -261,6 +283,14 @@
 
                 container.scrollTop = targetScroll;
             },
+            resetMechanic() {
+                reactiveAnimationData.selectedMechanic = {
+                    actorId: null,
+                    actorName: null,
+                    name: null,
+                    times: [],
+                };
+            }
         },
         computed: {
             filteredMechanicEvents: function () {

--- a/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
+++ b/GW2EIBuilders/Resources/combatReplayTemplates/tmplCombatReplayMechanicsList.html
@@ -75,7 +75,7 @@
                 </thead>
                 <tbody>
                     <tr v-for="event in filteredMechanicEvents" class="combat-replay-mechanics-list-row"
-                        :class="{active: event.actor.id === selectedplayerid}" @click="selectMechanic(event)">
+                        :class="rowHighlight(event)" @click="selectMechanic(event)">
                         <td :data-original-title="'Timestamp'">{{(event.time / 1000).toFixed(2)}}s</td>
                         <td class="text-left" :data-original-title="event.mechanic.name">{{event.mechanic.shortName}}</td>
                         <td class="text-left">
@@ -214,10 +214,6 @@
                 animator.stopAnimate(true);
                 animator.updateTime(mechanic.time);
 
-                if (isTouchDevice) {
-                    return;
-                }
-
                 // Deselection
                 if (reactiveAnimationData.selectedMechanic.actorId == mechanic.actor.id &&
                     reactiveAnimationData.selectedMechanic.name == mechanic.mechanic.name) {
@@ -294,7 +290,23 @@
                     name: null,
                     times: [],
                 };
-            }
+            },
+            rowHighlight(event) {
+                if (event.actor.id === this.selectedplayerid &&
+                    reactiveAnimationData.selectedMechanic.actorId === null) {
+                    return 'active';
+                }
+                if (this.selectedplayerid == null &&
+                    reactiveAnimationData.selectedMechanic.name === event.mechanic.name &&
+                    reactiveAnimationData.selectedMechanic.actorId === event.actor.id) {
+                    return 'mechanicSelected';
+                }
+                if (event.actor.id === this.selectedplayerid &&
+                    this.selectedplayerid === reactiveAnimationData.selectedMechanic.actorId &&
+                    reactiveAnimationData.selectedMechanic.name !== null) {
+                    return 'agentAndMechanicSelected';
+                }
+            },
         },
         computed: {
             filteredMechanicEvents: function () {

--- a/GW2EIBuilders/Resources/ei.css
+++ b/GW2EIBuilders/Resources/ei.css
@@ -759,6 +759,24 @@ th {
     background-color: rgba(50, 120, 0, 0.5);
 }
 
+.theme-yeti table tbody tr.mechanicSelected {
+    font-weight: bold;
+}
+
+.theme-slate table tbody tr.mechanicSelected {
+    font-weight: bold;
+}
+
+.theme-yeti table tbody tr.agentAndMechanicSelected {
+    font-weight: bold;
+    background-color: rgba(100, 200, 0, 0.5);
+}
+
+.theme-slate table tbody tr.agentAndMechanicSelected {
+    font-weight: bold;
+    background-color: rgba(50, 120, 0, 0.5);
+}
+
 .nav-item .nav-link {
     margin-left: -1px;
     border-radius: 0;


### PR DESCRIPTION
The ticks on the timeline represent the instances of the mechanic that happened for the selected player.
Button under the timeline that appears/disappears when a mechanic is selected/deselected.
Button above the mechanics table to deselect the mechanic.
Click the current select mechanic to deselect it.
Timeline text is updated to include MechanicName (Agent) when a mechanic is selected.