### PR TITLE
Adjusted Sulfuric Eruption radius

### DIFF
--- a/GW2EIEvtcParser/LogLogic/Raids/RaidWings/W8/Bosses/UraTheSteamshrieker.cs
+++ b/GW2EIEvtcParser/LogLogic/Raids/RaidWings/W8/Bosses/UraTheSteamshrieker.cs
@@ -532,9 +532,8 @@ internal class UraTheSteamshrieker : MountBalrior
                 {
                     foreach (var effect in shockwaves)
                     {
-                        // Looks like in game it loses velocity as it gets further away from the starting point, can't display it as velocity is unknown.
                         lifespan = effect.ComputeLifespan(log, 8000);
-                        replay.Decorations.AddShockwave(new PositionConnector(effect.Position), lifespan, Colors.LightGrey, 0.5, 5000);
+                        replay.Decorations.AddShockwave(new PositionConnector(effect.Position), lifespan, Colors.LightGrey, 0.5, 3400);
                     }
                 }
                 break;


### PR DESCRIPTION
I've played around with the radius and it looks like 3400 matches with the Sulfuric Eruption Hit mechanic event, the decoration wave is roughly in the center of the players hitbox whenever it is selected in the table.