### PR TITLE
Compile fix

### DIFF
--- a/GW2EIParser.tst/GW2EIParser.tst.csproj
+++ b/GW2EIParser.tst/GW2EIParser.tst.csproj
@@ -57,6 +57,7 @@
         <ProjectReference Include="..\GW2EIDPSReport\GW2EIDPSReport.csproj" />
         <ProjectReference Include="..\GW2EIEvtcParser\GW2EIEvtcParser.csproj" />
         <ProjectReference Include="..\GW2EIGW2API\GW2EIGW2API.csproj" />
+        <ProjectReference Include="..\GW2EIJSON\GW2EIJSON.csproj" />
         <ProjectReference Include="..\GW2EIParserCommons\GW2EIParserCommons.csproj" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
The tst project wasn't compiling because of missing reference to GW2EIJSON