### PR TITLE
Arkk improvements

### DIFF
--- a/GW2EIEvtcParser/LogLogic/Fractals/ShatteredObservatory/Bosses/Arkk.cs
+++ b/GW2EIEvtcParser/LogLogic/Fractals/ShatteredObservatory/Bosses/Arkk.cs
@@ -2,7 +2,6 @@
 using GW2EIEvtcParser.Exceptions;
 using GW2EIEvtcParser.ParsedData;
 using GW2EIEvtcParser.ParserHelpers;
-using static GW2EIEvtcParser.EIData.Mechanic;
 using static GW2EIEvtcParser.LogLogic.LogLogicPhaseUtils;
 using static GW2EIEvtcParser.LogLogic.LogLogicTimeUtils;
 using static GW2EIEvtcParser.LogLogic.LogLogicUtils;
@@ -10,7 +9,7 @@ using static GW2EIEvtcParser.ParserHelper;
 using static GW2EIEvtcParser.ParserHelpers.LogImages;
 using static GW2EIEvtcParser.SkillIDs;
 using static GW2EIEvtcParser.SpeciesIDs;
-using static GW2EIEvtcParser.EIData.Mechanic.MechanicSeverity; 
+using static GW2EIEvtcParser.EIData.Mechanic.MechanicSeverity;
 using static GW2EIEvtcParser.MechanicIDs;
 
 namespace GW2EIEvtcParser.LogLogic;
@@ -87,7 +86,7 @@ internal class Arkk : ShatteredObservatory
 
     internal override IReadOnlyList<TargetID> GetTrashMobsIDs()
     {
-        var trashIDs = new List<TargetID>(9 + base.GetTrashMobsIDs().Count);
+        var trashIDs = new List<TargetID>(10 + base.GetTrashMobsIDs().Count);
         trashIDs.AddRange(base.GetTrashMobsIDs());
         trashIDs.Add(TargetID.FanaticDagger2);
         trashIDs.Add(TargetID.FanaticDagger1);
@@ -98,6 +97,7 @@ internal class Arkk : ShatteredObservatory
         trashIDs.Add(TargetID.DOC);
         trashIDs.Add(TargetID.CHOP);
         trashIDs.Add(TargetID.ProjectionArkk);
+        trashIDs.Add(TargetID.ReactorArkk);
         return trashIDs;
     }
 
@@ -106,7 +106,7 @@ internal class Arkk : ShatteredObservatory
         return LogData.Mode.CMNoName;
     }
 
-    internal override IReadOnlyList<TargetID>  GetTargetsIDs()
+    internal override IReadOnlyList<TargetID> GetTargetsIDs()
     {
         return
         [
@@ -351,22 +351,29 @@ internal class Arkk : ShatteredObservatory
                     }
                 }
                 break;
-                // case (int)TargetID.TemporalAnomalyArkk:
-                //     if (!log.CombatData.HasEffectData)
-                //     {
-                //         foreach (ExitCombatEvent exitCombat in log.CombatData.GetExitCombatEvents(target.AgentItem))
-                //         {
-                //             int start = (int)exitCombat.Time;
-                //             BuffRemoveAllEvent skullRemove = log.CombatData.GetBuffRemoveAllData(CorporealReassignmentBuff).FirstOrDefault(x => x.Time >= exitCombat.Time + ServerDelayConstant);
-                //             int end = Math.Min((int?)skullRemove?.Time ?? int.MaxValue, start + 11000); // cap at 11s spawn to explosion
-                //             ParametricPoint3D anomalyPos = replay.PolledPositions.LastOrDefault(x => x.Time <= exitCombat.Time + ServerDelayConstant);
-                //             if (anomalyPos != null)
-                //             {
-                //                 replay.Decorations.Add(new CircleDecoration(false, 0, 220, (start, end), Colors.LightBlue, 0.4, new PositionConnector(anomalyPos)));
-                //             }
-                //         }
-                //     }
-                //     break;
+            // case (int)TargetID.TemporalAnomalyArkk:
+            //     if (!log.CombatData.HasEffectData)
+            //     {
+            //         foreach (ExitCombatEvent exitCombat in log.CombatData.GetExitCombatEvents(target.AgentItem))
+            //         {
+            //             int start = (int)exitCombat.Time;
+            //             BuffRemoveAllEvent skullRemove = log.CombatData.GetBuffRemoveAllData(CorporealReassignmentBuff).FirstOrDefault(x => x.Time >= exitCombat.Time + ServerDelayConstant);
+            //             int end = Math.Min((int?)skullRemove?.Time ?? int.MaxValue, start + 11000); // cap at 11s spawn to explosion
+            //             ParametricPoint3D anomalyPos = replay.PolledPositions.LastOrDefault(x => x.Time <= exitCombat.Time + ServerDelayConstant);
+            //             if (anomalyPos != null)
+            //             {
+            //                 replay.Decorations.Add(new CircleDecoration(false, 0, 220, (start, end), Colors.LightBlue, 0.4, new PositionConnector(anomalyPos)));
+            //             }
+            //         }
+            //     }
+            //     break;
+            case (int)TargetID.ReactorArkk:
+                {
+                    // reactor beams
+                    var beamEvents = GetBuffApplyRemoveSequence(log.CombatData, ReactorBeamArkk, target, true, true);
+                    replay.Decorations.AddTethers(beamEvents, Colors.SkyBlue, 0.5);
+                    break;
+                }
         }
     }
 

--- a/GW2EIEvtcParser/LogLogic/Fractals/ShatteredObservatory/Bosses/Arkk.cs
+++ b/GW2EIEvtcParser/LogLogic/Fractals/ShatteredObservatory/Bosses/Arkk.cs
@@ -64,6 +64,7 @@ internal class Arkk : ShatteredObservatory
                 new PlayerDstHealthDamageHitMechanic(SpinningCut, Mech_SpinningCut, new (Symbols.StarSquareOpen,Colors.LightPurple), new("Daze", "Spinning Cut (3rd Gladiator Auto->Daze)","Gladiator Daze"), Sev1), //
             ]),
         ]);
+
     public Arkk(int triggerID) : base(triggerID)
     {
         MechanicList.Add(Mechanics);
@@ -77,9 +78,7 @@ internal class Arkk : ShatteredObservatory
     {
         var crMap = new CombatReplayMap(
                         (914, 914),
-                        (-19231, -18137, -16591, -15677)/*,
-                        (-6144, -6144, 9216, 9216),
-                        (11804, 4414, 12444, 5054)*/);
+                        (-19291, -18274, -16571, -15554));
         AddArenaDecorationsPerEncounter(log, arenaDecorations, LogID, CombatReplayArkk, crMap, parentMap);
         return crMap;
     }

--- a/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/GUIDs/EffectGUIDs.cs
@@ -576,6 +576,7 @@ public static class EffectGUIDs
     public static readonly GUID CorporealReassignmentExplosion1 = new("C93D2CA54BC7F84BBFA31B40DE056D21"); // owned by exploding player
     public static readonly GUID CorporealReassignmentExplosion2 = new("DAD653E8823274409610A732BE8FA188"); // owned by exploding player
     public static readonly GUID HorizonStrikeArkk = new("C5E4632E8131D342AA4F18222C68D8EB"); // owned by arkk
+    public static readonly GUID ArkkEye = new("291F8934D54C7840A4CE943B11499A2F"); // owned by arkk, 2.1s duration
     // Sunqua Peak Fractal
     public static readonly GUID AiArrowAttackIndicator = new("88E9C3112BF6DA4486845A0433782E9C"); // GENERIC, no owner, rotated towards direction, used for lines & dash
     public static readonly GUID AiCircleAoEIndicator = new("171A7BD24B5D0B4BA3770FF8A6A37EC0"); // GENERIC, no owner, no rotation, used for air & fire lines, pulsing circles

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -2526,6 +2526,7 @@ public static class SkillIDs
     public const long HorizonStrikeSkorvald = 39458;
     public const long TeleportLunge = 39469;
     public const long Obliterate = 39470;
+    public const long ReactorBeamArkk = 39473;
     public const long BloomExplode = 39491;
     public const long OystersWithSpicySauce = 39500;
     public const long HorizonStrikeSkorvald1 = 39507;

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SkillIDs.cs
@@ -2501,6 +2501,7 @@ public static class SkillIDs
     public const long FixatedBloom1 = 39131;
     public const long WaveOfMutilation = 39133;
     public const long HypernovaLaunchSAK = 39157;
+    public const long POV_TimePocket = 39159;
     public const long TawShot1 = 39160;
     public const long CranialCascadeSkorvald = 39220;
     public const long SupernovaSkorvaldCM = 39225;

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SpeciesIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SpeciesIDs.cs
@@ -641,6 +641,7 @@ public static class SpeciesIDs
         DOC = 16657,
         CHOP = 16552,
         ProjectionArkk = 17613,
+        ReactorArkk = 17823, // gadget
         // - Ai
         Parent_AiKeeperOfThePeak = ParentAiKeeperOfThePeak,
         AiKeeperOfThePeak = 23254,

--- a/GW2EIEvtcParser/ParserHelpers/IDs/SpeciesIDs.cs
+++ b/GW2EIEvtcParser/ParserHelpers/IDs/SpeciesIDs.cs
@@ -641,7 +641,8 @@ public static class SpeciesIDs
         DOC = 16657,
         CHOP = 16552,
         ProjectionArkk = 17613,
-        ReactorArkk = 17823, // gadget
+        TimePocketArkk = 17709, // spawns before anomaly, creates dome effect
+        ReactorArkk = 17823,
         // - Ai
         Parent_AiKeeperOfThePeak = ParentAiKeeperOfThePeak,
         AiKeeperOfThePeak = 23254,

--- a/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
+++ b/GW2EIEvtcParser/ParserHelpers/Images/ParserIcons.cs
@@ -274,6 +274,7 @@ internal static class ParserIcons
     private const string TrashTear = "https://i.imgur.com/N9seps0.png";
     private const string TrashFluxAnomaly = "https://i.imgur.com/JZUYCHt.png";
     private const string TrashSolarBloom = "https://i.imgur.com/2b09Qgn.png";
+    private const string TrashReactorArkk = "https://i.imgur.com/j5Urqb8.png";
     private const string TrashGamblerDrunkarThief = "https://i.imgur.com/vINeVU6.png";
     private const string TrashTormentedDeadMessenger = "https://i.imgur.com/1J2BTFg.png";
     private const string TrashEnforcer = "https://i.imgur.com/elHjamF.png";
@@ -1304,6 +1305,7 @@ internal static class ParserIcons
         { TargetID.FluxAnomalyCM3, TrashFluxAnomaly },
         { TargetID.FluxAnomalyCM4, TrashFluxAnomaly },
         { TargetID.SolarBloom, TrashSolarBloom },
+        { TargetID.ReactorArkk, TrashReactorArkk },
         { TargetID.Torch, TrashTorch },
         { TargetID.AberrantWisp, TrashAberrantWisp },
         { TargetID.BoundIcebroodElemental, TrashBoundIcebroodElemental },


### PR DESCRIPTION
This adds the reactor gadgets (only logged since halfway through 2024) to the combat replay and adjusts the map to be more in line with their actual positions.

The electrocuted areas might also be worth adding. So far I did not see any events related to them, their visual might simply be part of the reactor models.