### PR TITLE
Fix several statistics bugs and a per-combat phase bound

### DIFF
--- a/GW2EIEvtcParser/EIData/Buffs/BuffSimulators/BuffSimulatorNoID/BuffSimulator.cs
+++ b/GW2EIEvtcParser/EIData/Buffs/BuffSimulators/BuffSimulatorNoID/BuffSimulator.cs
@@ -11,7 +11,6 @@ internal abstract class BuffSimulator : AbstractBuffSimulator
     private readonly int _capacity;
 
     private static readonly QueueLogic _queueLogic = new();
-    private static readonly HealingLogic _healingLogic = new();
     private static readonly ForceOverrideLogic _forceOverrideLogic = new();
     private static readonly OverrideLogic _overrideLogic = new();
     //private static readonly CappedDurationLogic _cappedDurationLogic = new CappedDurationLogic();
@@ -27,7 +26,10 @@ internal abstract class BuffSimulator : AbstractBuffSimulator
                 _logic = _queueLogic;
                 break;
             case BuffStackType.Regeneration:
-                _logic = _healingLogic;
+                // Not shared: HealingLogic is stateful (it stops sorting once a stack-active event
+                // has been seen), so a shared instance would leak that state across every actor,
+                // log and thread that simulates Regeneration.
+                _logic = new HealingLogic();
                 break;
             case BuffStackType.Force:
                 _logic = _forceOverrideLogic;

--- a/GW2EIEvtcParser/EIData/Statistics/BuffVolumeByActorStatistics.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/BuffVolumeByActorStatistics.cs
@@ -29,10 +29,6 @@ public class BuffVolumeByActorStatistics
             if (abae is BuffExtensionEvent bee)
             {
                 incomingByExtension += bee.ExtendedDuration;
-                if (activePhaseDuration > 0)
-                {
-                    incomingByExtension += bee.ExtendedDuration;
-                }
             }
 
         }

--- a/GW2EIEvtcParser/EIData/Statistics/DefenseAllStatistics.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/DefenseAllStatistics.cs
@@ -42,7 +42,7 @@ public class DefenseAllStatistics : DefensePerTargetStatistics
         DeadDuration = (long)dead.Sum(x => x.IntersectingArea(start, end));
         DcDuration = (long)dc.Sum(x => x.IntersectingArea(start, end));
 
-        foreach (StunBreakEvent sbe in log.CombatData.GetStunBreakReceivedData(actor.AgentItem))
+        foreach (StunBreakEvent sbe in log.CombatData.GetStunBreakReceivedData(actor.AgentItem).Where(x => x.Time >= start && x.Time <= end))
         {
             StunBreakCount++;
             RemovedStunDuration += sbe.RemainingDuration;

--- a/GW2EIEvtcParser/EIData/Statistics/DefensePerTargetStatistics.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/DefensePerTargetStatistics.cs
@@ -60,7 +60,7 @@ public class DefensePerTargetStatistics
                 {
                     continue;
                 }
-                currentBoonStripTime = Math.Max(currentBoonStripTime + brae.RemovedDuration, log.LogData.LogDuration);
+                currentBoonStripTime = Math.Min(currentBoonStripTime + brae.RemovedDuration, log.LogData.LogDuration);
                 strip++;
             }
             stripTime += currentBoonStripTime;
@@ -90,7 +90,7 @@ public class DefensePerTargetStatistics
                         if (ndhd.IsLifeLeech)
                         {
                             LifeLeechDamageTaken += damageEvent.HealthDamage;
-                            LifeLeechDamageTaken++;
+                            LifeLeechDamageTakenCount++;
                         }
                     }
                     else

--- a/GW2EIEvtcParser/EIData/Statistics/SupportAllStatistics.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/SupportAllStatistics.cs
@@ -33,7 +33,7 @@ public class SupportAllStatistics : SupportPerAllyStatistics
         var (Count, Duration) = GetReses(log, actor, start, end);
         ResurrectCount = Count;
         ResurrectTime = Math.Round((double)Duration / 1000, ParserHelper.TimeDigit);
-        foreach (StunBreakEvent sbe in log.CombatData.GetStunBreakData(actor.AgentItem))
+        foreach (StunBreakEvent sbe in log.CombatData.GetStunBreakData(actor.AgentItem).Where(x => x.Time >= start && x.Time <= end))
         {
             StunBreakCount++;
             RemovedStunDuration += sbe.RemainingDuration;

--- a/GW2EIEvtcParser/EIData/Statistics/SupportPerAllyStatistics.cs
+++ b/GW2EIEvtcParser/EIData/Statistics/SupportPerAllyStatistics.cs
@@ -30,22 +30,22 @@ public class SupportPerAllyStatistics
                 if (brae.ToFriendly)
                 {
                     friendlyCount++;
-                    friendlyTime = Math.Max(friendlyTime + brae.RemovedDuration, log.LogData.LogDuration);
+                    friendlyTime = Math.Min(friendlyTime + brae.RemovedDuration, log.LogData.LogDuration);
                 }
                 else if (brae.ToFoe)
                 {
                     foeCount++;
-                    foeTime = Math.Max(foeTime + brae.RemovedDuration, log.LogData.LogDuration);
+                    foeTime = Math.Min(foeTime + brae.RemovedDuration, log.LogData.LogDuration);
                     if (brae.To.IsDownedBeforeNext90(log, brae.Time))
                     {
                         foeDownContributionCount++;
-                        foeDownContributionTime = Math.Max(foeTime + brae.RemovedDuration, log.LogData.LogDuration);
+                        foeDownContributionTime = Math.Min(foeDownContributionTime + brae.RemovedDuration, log.LogData.LogDuration);
                     }
                 }
                 else
                 {
                     unknownCount++;
-                    unknownTime = Math.Max(unknownTime + brae.RemovedDuration, log.LogData.LogDuration);
+                    unknownTime = Math.Min(unknownTime + brae.RemovedDuration, log.LogData.LogDuration);
                 }
             }
             if (foeCount > 0)

--- a/GW2EIEvtcParser/LogLogic/LogLogicPhaseUtils.cs
+++ b/GW2EIEvtcParser/LogLogic/LogLogicPhaseUtils.cs
@@ -51,7 +51,7 @@ internal static class LogLogicPhaseUtils
             }
             else
             {
-                var fightPhase = new EncounterPhaseData(startEvent.Time, phases[0].End, "Fight " + (sequence++), true, log.LogData.Logic.Icon, LogData.Mode.Normal, log.LogData.Logic.LogID);
+                var fightPhase = new EncounterPhaseData(startEvent.Time, log.LogData.LogEnd, "Fight " + (sequence++), true, log.LogData.Logic.Icon, LogData.Mode.Normal, log.LogData.Logic.LogID);
                 phases.Add(fightPhase);
                 break;
             }


### PR DESCRIPTION
# Fix several statistics bugs and a per-combat phase bound

This PR fixes seven small, independent defects found while auditing the parser's statistics and buff-simulation code against the arcDPS evtc spec. Each change is a one- or two-line correction; none changes any public API.

## Statistics

**Cleanse / strip time is floored at the log duration instead of capped** (`SupportPerAllyStatistics.cs`, `DefensePerTargetStatistics.GetStripData`)
The time accumulators do `Math.Max(time + RemovedDuration, LogDuration)`. `Max` makes every result at least the whole fight length; the obvious intent (capping runaway `RemovedDuration` values) needs `Min`. This has been there since the feature was added in b57b60d1 (Jan 2023). Counts were always correct; only `conditionCleanseTime`, `condiCleanseTimeSelf`, `boonStripsTime`, `boonStripDownContributionTime`, `conditionCleansesTime` and the per-source `*Time` dictionaries were affected.
Example from a 32.9 s WvW log: every `conditionCleansesTime` was `32.882`; after the fix they are `3.679`, `2.588`, `2.888`, ...

**`foeDownContributionTime` accumulates the wrong variable** (`SupportPerAllyStatistics.cs`)
It added `RemovedDuration` onto `foeTime` (already incremented on the previous line) instead of its own running total, so it double counted even with the cap fixed.

**Incoming-by-extension buff volume is double counted** (`BuffVolumeByActorStatistics.FillDictionnaries`)
`incomingByExtension` is added once unconditionally and once more inside `if (activePhaseDuration > 0)`, which is always true for a living actor. `BuffVolumeStatistics` (the non-per-actor variant) adds it once. Both `IncomingByExtensionBy` and `IncomingBy` (which folds it in) were inflated; in the A/B run every by-extension entry is exactly halved (e.g. `8.646` -> `4.323`).

**Life-leech damage taken increments the wrong field** (`DefensePerTargetStatistics.cs`)
`LifeLeechDamageTaken++` where `LifeLeechDamageTakenCount++` was meant, so the count was always `0` and the damage was off by one per event (`583 / 0` -> `582 / 1` in the sample).

**Stun-break stats ignore the phase window** (`DefenseAllStatistics.cs`, `SupportAllStatistics.cs`)
`GetStunBreakReceivedData` / `GetStunBreakData` were iterated without a `start`/`end` filter, unlike everything else in those constructors, so every sub-phase reported the full-log `StunBreakCount` / `RemovedStunDuration`.

## Phases

**Unterminated squad-combat phase uses the wrong end** (`LogLogicPhaseUtils.GetEncounterPhasesBySquadCombatStartEnd`)
When a `SquadCombatStart` has no matching end, the phase was given `phases[0].End`, i.e. the end of the *first* fight phase. For any start after the first fight that produces a phase that ends before it starts; if the very first start is unterminated, `phases` is still empty and indexing it throws. The phase now ends at `log.LogData.LogEnd`.

## Buff simulation

**`HealingLogic` state shared across all simulators** (`BuffSimulator.cs`)
`HealingLogic` has a `_noSort` flag that is set on the first `Activate` and never reset, but it was held in a `static readonly` field shared by every Regeneration simulator in the process. The first simulator to see a stack-active event silently changed the sorting behaviour of every later actor and every later log, and the flag was written from parallel parses without synchronization. Each simulator now gets its own instance.

## Verification

Built `GW2EIEvtcParser` and `GW2EIParserCLI` on this branch and on `master`, ran both CLIs with identical settings (`ParsePhases`, `DetailledWvW`, JSON output) over the same two WvW logs, and diffed the JSON. The only fields that differ are the ones listed above; every damage, healing, boon, defense and fight-outcome figure is byte-identical. (Note for anyone repeating this: `PlayerNonSquad` numbers anonymous players from a process-wide static counter, so parse each log in its own process or the "Non Squad Player N" names will shift.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dHUXhVtugFcZugyPBwZTs
