### PR TITLE
Application traces fix

### DIFF
--- a/GW2EIParserAvalonia/Services/ApplicationTrace.cs
+++ b/GW2EIParserAvalonia/Services/ApplicationTrace.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.Threading.Tasks;
 using GW2EIParserCommons;
 using GW2EIParserCommons.Properties;
 
@@ -8,24 +10,28 @@ namespace GW2EIParserAvalonia.Services;
 public sealed class ApplicationTrace : IApplicationTrace
 {
     private readonly string _traceFileName;
+    private readonly BlockingCollection<string> _messages = [];
 
     public ApplicationTrace()
     {
         _traceFileName = $"{ProgramHelper.EILogPath}EILogs-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.txt";
+        _ = Task.Run(WriteToFile);
     }
 
     public void Add(string message)
     {
-        if (!Settings.Default.ApplicationTraces)
+        if (Settings.Default.ApplicationTraces)
         {
-            return;
+            _messages.Add($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {message}");
         }
+    }
 
-        if (!Directory.Exists(ProgramHelper.EILogPath))
+    private void WriteToFile()
+    {
+        foreach (string message in _messages.GetConsumingEnumerable())
         {
             Directory.CreateDirectory(ProgramHelper.EILogPath);
+            File.AppendAllText(_traceFileName, message + Environment.NewLine);
         }
-
-        File.AppendAllText(_traceFileName, message + Environment.NewLine);
     }
 }


### PR DESCRIPTION
When parsing multiple logs I was getting an I/O Exception because the threads were attempting to write to the same file at the same time.
I've also added a timestamp to each message so we can see the timings of operations.

How the log looks like:

<img width="727" height="930" alt="11552" src="https://github.com/user-attachments/assets/47e42450-916b-43f6-971e-2da7c70aecb6" />
