### PR TITLE
Content GUID tab changes

### DIFF
--- a/GW2EI.Executables/GW2EI.Applications/GW2EIParserAvalonia/Inspector/ViewModels/InspectorViewModel.cs
+++ b/GW2EI.Executables/GW2EI.Applications/GW2EIParserAvalonia/Inspector/ViewModels/InspectorViewModel.cs
@@ -17,12 +17,20 @@ public partial class InspectorViewModel : ObservableObject
     private AgentDataModel? selectedAgent;
     [ObservableProperty]
     private SkillDataModel? selectedSkill;
+
+    // Events tab filters
     [ObservableProperty]
     private string? skillIdFilter;
     [ObservableProperty]
     private string? skillNameFilter;
     [ObservableProperty]
     private string? guidFilter;
+
+    // Content GUID tab filters
+    [ObservableProperty]
+    private string? contentIdFilter;
+    [ObservableProperty]
+    private string? contentGuidFilter;
 
     private readonly IReadOnlyList<TimeCombatEvent> _allTimeEvents;
     private readonly IReadOnlyList<NonTimeCombatEvent> _allNonTimeEvents;
@@ -47,6 +55,14 @@ public partial class InspectorViewModel : ObservableObject
     public IReadOnlyList<ContentGUIDModel> Emotes { get; }
     public IReadOnlyList<ContentGUIDModel> Transformations { get; }
 
+    public BulkObservableCollection<ContentGUIDModel> VisibleSkills { get; } = [];
+    public BulkObservableCollection<ContentGUIDModel> VisibleEffects { get; } = [];
+    public BulkObservableCollection<ContentGUIDModel> VisibleMarkers { get; } = [];
+    public BulkObservableCollection<ContentGUIDModel> VisibleSpecies { get; } = [];
+    public BulkObservableCollection<ContentGUIDModel> VisibleTeams { get; } = [];
+    public BulkObservableCollection<ContentGUIDModel> VisibleEmotes { get; } = [];
+    public BulkObservableCollection<ContentGUIDModel> VisibleTransformations { get; } = [];
+
     public int CombatItemCount => CombatItems.Count;
     public int AgentCount => AgentsData.Count;
     public int SkillCount => SkillsData.Count;
@@ -61,13 +77,13 @@ public partial class InspectorViewModel : ObservableObject
         _allNonTimeEvents = log.CombatData.GetAllNonTimeCombatEvents();
 
         var contentGUIDEvents = _allNonTimeEvents.OfType<IDToGUIDEvent>().Where(x => x.IsValid).ToList();
-        Skills = contentGUIDEvents.OfType<SkillGUIDEvent>().Select(x => new ContentGUIDModel(x)).ToList();
-        Effects = contentGUIDEvents.OfType<EffectGUIDEvent>().Select(x => new ContentGUIDModel(x)).ToList();
-        Markers = contentGUIDEvents.OfType<MarkerGUIDEvent>().Select(x => new ContentGUIDModel(x)).ToList();
-        Species = contentGUIDEvents.OfType<SpeciesGUIDEvent>().Select(x => new ContentGUIDModel(x)).ToList();
-        Teams = contentGUIDEvents.OfType<TeamGUIDEvent>().Select(x => new ContentGUIDModel(x)).ToList();
-        Emotes = contentGUIDEvents.OfType<EmoteGUIDEvent>().Select(x => new ContentGUIDModel(x)).ToList();
-        Transformations = contentGUIDEvents.OfType<TransformationGUIDEvent>().Select(x => new ContentGUIDModel(x)).ToList();
+        Skills = contentGUIDEvents.OfType<SkillGUIDEvent>().Select(x => new ContentGUIDModel(x)).OrderBy(skill => skill.ContentID).ToList();
+        Effects = contentGUIDEvents.OfType<EffectGUIDEvent>().Select(x => new ContentGUIDModel(x)).OrderBy(effect => effect.ContentID).ToList();
+        Markers = contentGUIDEvents.OfType<MarkerGUIDEvent>().Select(x => new ContentGUIDModel(x)).OrderBy(marker => marker.ContentID).ToList();
+        Species = contentGUIDEvents.OfType<SpeciesGUIDEvent>().Select(x => new ContentGUIDModel(x)).OrderBy(species => species.ContentID).ToList();
+        Teams = contentGUIDEvents.OfType<TeamGUIDEvent>().Select(x => new ContentGUIDModel(x)).OrderBy(team => team.ContentID).ToList();
+        Emotes = contentGUIDEvents.OfType<EmoteGUIDEvent>().Select(x => new ContentGUIDModel(x)).OrderBy(emote => emote.ContentID).ToList();
+        Transformations = contentGUIDEvents.OfType<TransformationGUIDEvent>().Select(x => new ContentGUIDModel(x)).OrderBy(transformation => transformation.ContentID).ToList();
 
         Events = _allTimeEvents.OrderBy(x => x.Time).Cast<object>().Concat(_allNonTimeEvents).Select(x => new EventModel(x)).ToList();
         EventTypeFilterRoots = EventTypeFilterNodeModel.Build(_allTimeEvents, _allNonTimeEvents);
@@ -78,6 +94,7 @@ public partial class InspectorViewModel : ObservableObject
         }
 
         RefreshVisibleEvents();
+        RefreshVisibleContentGUIDs();
     }
 
     private void OnFilterChanged(object? sender, EventArgs e) => RefreshVisibleEvents();
@@ -164,5 +181,41 @@ public partial class InspectorViewModel : ObservableObject
     private bool IsEventTypeVisible(Type eventType)
     {
         return EventTypeFilterRoots.Any(root => root.IsEventVisible(eventType));
+    }
+
+    partial void OnContentIdFilterChanged(string? value) => RefreshVisibleContentGUIDs();
+
+    partial void OnContentGuidFilterChanged(string? value) => RefreshVisibleContentGUIDs();
+
+    private void RefreshVisibleContentGUIDs()
+    {
+        bool hasContentIdFilter = !string.IsNullOrWhiteSpace(ContentIdFilter);
+        bool hasGuidFilter = !string.IsNullOrWhiteSpace(ContentGuidFilter);
+
+        VisibleSkills.ReplaceRange(FilterContentGUIDs(Skills, hasContentIdFilter, hasGuidFilter));
+        VisibleEffects.ReplaceRange(FilterContentGUIDs(Effects, hasContentIdFilter, hasGuidFilter));
+        VisibleMarkers.ReplaceRange(FilterContentGUIDs(Markers, hasContentIdFilter, hasGuidFilter));
+        VisibleSpecies.ReplaceRange(FilterContentGUIDs(Species, hasContentIdFilter, hasGuidFilter));
+        VisibleTeams.ReplaceRange(FilterContentGUIDs(Teams, hasContentIdFilter, hasGuidFilter));
+        VisibleEmotes.ReplaceRange(FilterContentGUIDs(Emotes, hasContentIdFilter, hasGuidFilter));
+        VisibleTransformations.ReplaceRange(FilterContentGUIDs(Transformations, hasContentIdFilter, hasGuidFilter));
+    }
+
+    private IEnumerable<ContentGUIDModel> FilterContentGUIDs(IEnumerable<ContentGUIDModel> source, bool hasContentIdFilter, bool hasGuidFilter)
+    {
+        return source.Where(model =>
+        {
+            if (hasContentIdFilter && !model.ContentID.ToString().Contains(ContentIdFilter!, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (hasGuidFilter && !model.GUID.ToString().Contains(ContentGuidFilter!, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return true;
+        });
     }
 }

--- a/GW2EI.Executables/GW2EI.Applications/GW2EIParserAvalonia/Inspector/Views/InspectorWindow.axaml
+++ b/GW2EI.Executables/GW2EI.Applications/GW2EIParserAvalonia/Inspector/Views/InspectorWindow.axaml
@@ -428,374 +428,427 @@
             </TabItem>
 
             <TabItem Header="Content GUID">
-                <TabControl>
+                <Grid RowDefinitions="Auto,*">
 
-                    <TabItem Header="Skills">
-                        <DataGrid ItemsSource="{Binding Skills}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserResizeColumns="True"
-                                  CanUserReorderColumns="True"
-                                  CanUserSortColumns="True"
-                                  GridLinesVisibility="All"
-                                  HeadersVisibility="Column"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  SelectionMode="Extended"
-                                  RowHeight="28">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="ContentID"
-                                                    Binding="{Binding ContentID}"
-                                                    Width="150">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy Content ID"
-                                                              Click="CopyContentId_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
+                    <Border Grid.Row="0"
+                            Padding="8"
+                            BorderBrush="#444"
+                            BorderThickness="0,0,0,1">
 
-                                <DataGridTextColumn Header="GUID"
-                                                    Binding="{Binding GUID}"
-                                                    Width="350">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy GUID"
-                                                              Click="CopyGuid_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
+                        <Grid ColumnDefinitions="Auto,*,Auto,*">
 
-                    <TabItem Header="Effects">
-                        <DataGrid ItemsSource="{Binding Effects}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserResizeColumns="True"
-                                  CanUserReorderColumns="True"
-                                  CanUserSortColumns="True"
-                                  GridLinesVisibility="All"
-                                  HeadersVisibility="Column"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  SelectionMode="Extended"
-                                  RowHeight="28">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="ContentID"
-                                                    Binding="{Binding ContentID}"
-                                                    Width="150">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy Content ID"
-                                                              Click="CopyContentId_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
+                            <TextBlock Grid.Column="0"
+                                       Text="Content ID"
+                                       VerticalAlignment="Center"
+                                       Margin="0,0,8,0"/>
 
-                                <DataGridTextColumn Header="DefaultDuration"
-                                                    Binding="{Binding DefaultDuration}"
-                                                    Width="180"/>
+                            <TextBox Grid.Column="1"
+                                     Text="{Binding ContentIdFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     PlaceholderText="Content ID"/>
 
-                                <DataGridTextColumn Header="GUID"
-                                                    Binding="{Binding GUID}"
-                                                    Width="350">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy GUID"
-                                                              Click="CopyGuid_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
+                            <TextBlock Grid.Column="2"
+                                       Text="GUID"
+                                       VerticalAlignment="Center"
+                                       Margin="16,0,8,0"/>
 
-                    <TabItem Header="Markers">
-                        <DataGrid ItemsSource="{Binding Markers}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserResizeColumns="True"
-                                  CanUserReorderColumns="True"
-                                  CanUserSortColumns="True"
-                                  GridLinesVisibility="All"
-                                  HeadersVisibility="Column"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  SelectionMode="Extended"
-                                  RowHeight="28">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="ContentID"
-                                                    Binding="{Binding ContentID}"
-                                                    Width="150">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy Content ID"
-                                                              Click="CopyContentId_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
+                            <TextBox Grid.Column="3"
+                                     Text="{Binding ContentGuidFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                     PlaceholderText="GUID"/>
 
-                                <DataGridCheckBoxColumn Header="Commander Tag"
-                                                        Binding="{Binding IsCommanderTag}"
-                                                        Width="150"/>
+                        </Grid>
 
-                                <DataGridTextColumn Header="GUID"
-                                                    Binding="{Binding GUID}"
-                                                    Width="350">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy GUID"
-                                                              Click="CopyGuid_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
+                    </Border>
 
-                    <TabItem Header="Species">
-                        <DataGrid ItemsSource="{Binding Species}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserResizeColumns="True"
-                                  CanUserReorderColumns="True"
-                                  CanUserSortColumns="True"
-                                  GridLinesVisibility="All"
-                                  HeadersVisibility="Column"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  SelectionMode="Extended"
-                                  RowHeight="28">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="ContentID"
-                                                    Binding="{Binding ContentID}"
-                                                    Width="150">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy Content ID"
-                                                              Click="CopyContentId_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
+                    <TabControl Grid.Row="1">
 
-                                <DataGridTextColumn Header="GUID"
-                                                    Binding="{Binding GUID}"
-                                                    Width="350">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy GUID"
-                                                              Click="CopyGuid_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
+                        <TabItem Header="Effects">
+                            <DataGrid ItemsSource="{Binding VisibleEffects}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="All"
+                                      HeadersVisibility="Column"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      SelectionMode="Extended"
+                                      RowHeight="28">
 
-                    <TabItem Header="Teams">
-                        <DataGrid ItemsSource="{Binding Teams}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserResizeColumns="True"
-                                  CanUserReorderColumns="True"
-                                  CanUserSortColumns="True"
-                                  GridLinesVisibility="All"
-                                  HeadersVisibility="Column"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  SelectionMode="Extended"
-                                  RowHeight="28">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="ContentID"
-                                                    Binding="{Binding ContentID}"
-                                                    Width="150">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy Content ID"
-                                                              Click="CopyContentId_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
+                                <DataGrid.Columns>
 
-                                <DataGridTextColumn Header="GUID"
-                                                    Binding="{Binding GUID}"
-                                                    Width="350">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy GUID"
-                                                              Click="CopyGuid_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
+                                    <DataGridTextColumn Header="ContentID"
+                                                        Binding="{Binding ContentID}"
+                                                        Width="150">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy Content ID"
+                                                                  Click="CopyContentId_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
 
-                    <TabItem Header="Emotes">
-                        <DataGrid ItemsSource="{Binding Emotes}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserResizeColumns="True"
-                                  CanUserReorderColumns="True"
-                                  CanUserSortColumns="True"
-                                  GridLinesVisibility="All"
-                                  HeadersVisibility="Column"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  SelectionMode="Extended"
-                                  RowHeight="28">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="ContentID"
-                                                    Binding="{Binding ContentID}"
-                                                    Width="150">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy Content ID"
-                                                              Click="CopyContentId_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
+                                    <DataGridTextColumn Header="DefaultDuration"
+                                                        Binding="{Binding DefaultDuration}"
+                                                        Width="180"/>
 
-                                <DataGridTextColumn Header="GUID"
-                                                    Binding="{Binding GUID}"
-                                                    Width="350">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy GUID"
-                                                              Click="CopyGuid_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
+                                    <DataGridTextColumn Header="GUID"
+                                                        Binding="{Binding GUID}"
+                                                        Width="350">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy GUID"
+                                                                  Click="CopyGuid_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
 
-                    <TabItem Header="Transformations">
-                        <DataGrid ItemsSource="{Binding Transformations}"
-                                  AutoGenerateColumns="False"
-                                  IsReadOnly="True"
-                                  CanUserResizeColumns="True"
-                                  CanUserReorderColumns="True"
-                                  CanUserSortColumns="True"
-                                  GridLinesVisibility="All"
-                                  HeadersVisibility="Column"
-                                  HorizontalScrollBarVisibility="Auto"
-                                  VerticalScrollBarVisibility="Auto"
-                                  SelectionMode="Extended"
-                                  RowHeight="28">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="ContentID"
-                                                    Binding="{Binding ContentID}"
-                                                    Width="150">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy Content ID"
-                                                              Click="CopyContentId_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
 
-                                <DataGridTextColumn Header="GUID"
-                                                    Binding="{Binding GUID}"
-                                                    Width="350">
-                                    <DataGridTextColumn.CellTheme>
-                                        <ControlTheme TargetType="DataGridCell"
-                                                      BasedOn="{StaticResource {x:Type DataGridCell}}">
-                                            <Setter Property="ContextMenu">
-                                                <ContextMenu>
-                                                    <MenuItem Header="Copy GUID"
-                                                              Click="CopyGuid_Click"
-                                                              CommandParameter="{Binding}" />
-                                                </ContextMenu>
-                                            </Setter>
-                                        </ControlTheme>
-                                    </DataGridTextColumn.CellTheme>
-                                </DataGridTextColumn>
-                            </DataGrid.Columns>
-                        </DataGrid>
-                    </TabItem>
+                        <TabItem Header="Markers">
+                            <DataGrid ItemsSource="{Binding VisibleMarkers}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="All"
+                                      HeadersVisibility="Column"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      SelectionMode="Extended"
+                                      RowHeight="28">
 
-                </TabControl>
+                                <DataGrid.Columns>
+
+                                    <DataGridTextColumn Header="ContentID"
+                                                        Binding="{Binding ContentID}"
+                                                        Width="150">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy Content ID"
+                                                                  Click="CopyContentId_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                    <DataGridCheckBoxColumn Header="Commander Tag"
+                                                            Binding="{Binding IsCommanderTag}"
+                                                            Width="150"/>
+
+                                    <DataGridTextColumn Header="GUID"
+                                                        Binding="{Binding GUID}"
+                                                        Width="350">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy GUID"
+                                                                  Click="CopyGuid_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
+
+                        <TabItem Header="Emotes">
+                            <DataGrid ItemsSource="{Binding VisibleEmotes}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="All"
+                                      HeadersVisibility="Column"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      SelectionMode="Extended"
+                                      RowHeight="28">
+
+                                <DataGrid.Columns>
+
+                                    <DataGridTextColumn Header="ContentID"
+                                                        Binding="{Binding ContentID}"
+                                                        Width="150">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy Content ID"
+                                                                  Click="CopyContentId_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                    <DataGridTextColumn Header="GUID"
+                                                        Binding="{Binding GUID}"
+                                                        Width="350">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy GUID"
+                                                                  Click="CopyGuid_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
+
+                        <TabItem Header="Skills">
+                            <DataGrid ItemsSource="{Binding VisibleSkills}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="All"
+                                      HeadersVisibility="Column"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      SelectionMode="Extended"
+                                      RowHeight="28">
+
+                                <DataGrid.Columns>
+
+                                    <DataGridTextColumn Header="ContentID"
+                                                        Binding="{Binding ContentID}"
+                                                        Width="150">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy Content ID"
+                                                                  Click="CopyContentId_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                    <DataGridTextColumn Header="GUID"
+                                                        Binding="{Binding GUID}"
+                                                        Width="350">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy GUID"
+                                                                  Click="CopyGuid_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
+
+                        <TabItem Header="Species">
+                            <DataGrid ItemsSource="{Binding VisibleSpecies}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="All"
+                                      HeadersVisibility="Column"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      SelectionMode="Extended"
+                                      RowHeight="28">
+
+                                <DataGrid.Columns>
+
+                                    <DataGridTextColumn Header="ContentID"
+                                                        Binding="{Binding ContentID}"
+                                                        Width="150">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy Content ID"
+                                                                  Click="CopyContentId_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                    <DataGridTextColumn Header="GUID"
+                                                        Binding="{Binding GUID}"
+                                                        Width="350">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy GUID"
+                                                                  Click="CopyGuid_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
+
+                        <TabItem Header="Teams">
+                            <DataGrid ItemsSource="{Binding VisibleTeams}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="All"
+                                      HeadersVisibility="Column"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      SelectionMode="Extended"
+                                      RowHeight="28">
+
+                                <DataGrid.Columns>
+
+                                    <DataGridTextColumn Header="ContentID"
+                                                        Binding="{Binding ContentID}"
+                                                        Width="150">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy Content ID"
+                                                                  Click="CopyContentId_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                    <DataGridTextColumn Header="GUID"
+                                                        Binding="{Binding GUID}"
+                                                        Width="350">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy GUID"
+                                                                  Click="CopyGuid_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
+
+                        <TabItem Header="Transformations">
+                            <DataGrid ItemsSource="{Binding VisibleTransformations}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True"
+                                      CanUserResizeColumns="True"
+                                      CanUserReorderColumns="True"
+                                      CanUserSortColumns="True"
+                                      GridLinesVisibility="All"
+                                      HeadersVisibility="Column"
+                                      HorizontalScrollBarVisibility="Auto"
+                                      VerticalScrollBarVisibility="Auto"
+                                      SelectionMode="Extended"
+                                      RowHeight="28">
+
+                                <DataGrid.Columns>
+
+                                    <DataGridTextColumn Header="ContentID"
+                                                        Binding="{Binding ContentID}"
+                                                        Width="150">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy Content ID"
+                                                                  Click="CopyContentId_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                    <DataGridTextColumn Header="GUID"
+                                                        Binding="{Binding GUID}"
+                                                        Width="350">
+                                        <DataGridTextColumn.CellTheme>
+                                            <ControlTheme TargetType="DataGridCell"
+                                                          BasedOn="{StaticResource {x:Type DataGridCell}}">
+                                                <Setter Property="ContextMenu">
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy GUID"
+                                                                  Click="CopyGuid_Click"
+                                                                  CommandParameter="{Binding}" />
+                                                    </ContextMenu>
+                                                </Setter>
+                                            </ControlTheme>
+                                        </DataGridTextColumn.CellTheme>
+                                    </DataGridTextColumn>
+
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </TabItem>
+
+                    </TabControl>
+                </Grid>
             </TabItem>
 
             <TabItem Header="Combat Items">
@@ -900,7 +953,7 @@
                             <DataGridTextColumn Header="Result"
                                                 Binding="{Binding Result}"
                                                 Width="85"/>
-                            
+
                             <DataGridTextColumn Header="Result Enum"
                                                 Binding="{Binding ResultEnum}"
                                                 Width="85"/>

--- a/GW2EI.Library/GW2EI.Services/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/IcebroodSaga/Bjora/Bosses/WhisperOfJormag.cs
+++ b/GW2EI.Library/GW2EI.Services/GW2EIEvtcParser/LogLogic/Raids/RaidEncounters/IcebroodSaga/Bjora/Bosses/WhisperOfJormag.cs
@@ -46,7 +46,7 @@ internal class WhisperOfJormag : Bjora
                 new PlayerDstBuffRemoveMechanic(WhisperTeleportBack, Mech_WhisperTPBack, new (Symbols.Circle, Colors.LightBlue), new ("TP In", "Teleported back to the arena", "Teleport Back"), Sev2, 500),
                 new PlayerDstBuffRemoveMechanic(WhisperTeleportOut, Mech_WhisperTPOut, new (Symbols.CircleOpen, Colors.LightBlue), new ("TP Out", "Teleported outside of the arena", "Teleport Out"), Sev2, 500),
             ]),
-            new PlayerDstHealthDamageHitMechanic([FallingIce1, FallingIce2, FallingIce3], Mech_FallingIce, new (Symbols.Circle, Colors.LightBlue), new ("FallIce", "Hit by Falling Ice", "Falling Ice"), Sev0),
+            new PlayerDstHealthDamageHitMechanic([FallingIce1, FallingIce2, FallingIce3], Mech_FallingIce, new (Symbols.CircleOpenDot, Colors.LightBlue), new ("FallIce", "Hit by Falling Ice", "Falling Ice"), Sev0),
             new EnemyCastStartMechanic([ViciousSlam1, ViciousSlam2], Mech_ViciousSlam, new (Symbols.TriangleUp, Colors.White),  new ("Vicious Slam", "Cast Vicious Slam (Launch)", "Vicious Slam (Launch)"), Sev1, 150),
         ])
         );


### PR DESCRIPTION
- All GUIDs are now sorted by ContentID
- Reordered the tabs so that the most used are on the first ones (effects, markers)
- Added filtering by ContentID and ContentGUID shared across all tabs

(most of the rows changes are indentation and reordering)